### PR TITLE
Fix Docker buildx cache import errors

### DIFF
--- a/.github/workflows/docker-laravel.yml
+++ b/.github/workflows/docker-laravel.yml
@@ -41,7 +41,6 @@ jobs:
             --file docker-laravel/production/php/Dockerfile \
             --progress plain \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-php:cache,ignore-error=true \
             --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-php:cache,mode=max \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-php:${{ github.event.release.tag_name }} \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-php:latest \
@@ -55,7 +54,6 @@ jobs:
             --file docker-laravel/production/nginx/Dockerfile \
             --progress plain \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-nginx:cache,ignore-error=true \
             --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-nginx:cache,mode=max \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-nginx:${{ github.event.release.tag_name }} \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-nginx:latest \
@@ -69,7 +67,6 @@ jobs:
             --file docker-ttyd/shared/Dockerfile \
             --progress plain \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-ttyd:cache,ignore-error=true \
             --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-ttyd:cache,mode=max \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-ttyd:${{ github.event.release.tag_name }} \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-ttyd:latest \
@@ -83,7 +80,6 @@ jobs:
             --file docker-proxy/shared/Dockerfile \
             --progress plain \
             --build-arg BUILDKIT_INLINE_CACHE=1 \
-            --cache-from=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-proxy:cache,ignore-error=true \
             --cache-to=type=registry,ref=ghcr.io/${{ github.repository_owner }}/pocket-dev-proxy:cache,mode=max \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-proxy:${{ github.event.release.tag_name }} \
             --tag ghcr.io/${{ github.repository_owner }}/pocket-dev-proxy:latest \


### PR DESCRIPTION
## Summary
Fix Docker buildx cache import errors that prevent successful builds when cache images don't exist yet.

## Problem
The builds were failing with cache import errors:
```
ERROR: failed to configure registry cache importer: ghcr.io/tetrixdev/pocket-dev-php:cache: not found
```

## Solution
- Remove problematic `--cache-from` directives that cause failures on first builds
- Keep `--cache-to` directives to populate cache for subsequent builds
- This ensures first releases build successfully while still providing cache benefits for future builds

## Changes
- Remove `--cache-from=type=registry,ref=...` lines from all four image builds
- Maintain `--cache-to=type=registry,ref=...` for cache population

Once this release succeeds and creates cache images, we can add back the cache-from directives in a future update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)