### PR TITLE
Fix Docker production build vite dependency issue

### DIFF
--- a/docker-laravel/production/php/Dockerfile
+++ b/docker-laravel/production/php/Dockerfile
@@ -43,8 +43,8 @@ COPY www/ /var/www/
 # Install Composer dependencies (production optimized)
 RUN composer install --no-dev --optimize-autoloader --no-interaction --verbose
 
-# Install npm dependencies and build assets
-RUN npm ci --only=production \
+# Install npm dependencies (including dev deps for build), build assets, then clean up
+RUN npm ci \
     && npm run build \
     && rm -rf node_modules
 


### PR DESCRIPTION
## Summary
Fix Docker production build failure caused by missing vite dependency during frontend asset compilation.

## Problem
The build was failing with:
```
sh: 1: vite: not found
ERROR: process "npm ci --only=production && npm run build && rm -rf node_modules" did not complete successfully: exit code: 127
```

## Root Cause
- `npm ci --only=production` only installs production dependencies
- `vite` is typically a dev dependency, not a production dependency  
- `npm run build` requires `vite` to compile frontend assets
- Result: vite not available when trying to build

## Solution
- Change `npm ci --only=production` to `npm ci` (installs all dependencies)
- Keep the build and cleanup steps: `npm run build && rm -rf node_modules`
- This ensures vite is available for building while keeping final image size minimal

## Benefits
- ✅ Build succeeds with all required dependencies
- ✅ Frontend assets compile correctly with vite
- ✅ Final image remains minimal (node_modules removed after build)
- ✅ Production-optimized approach (dev deps used only for build, then removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)