### PR TITLE
Fix GitHub Container Registry permissions for package publishing

### DIFF
--- a/.github/workflows/docker-laravel.yml
+++ b/.github/workflows/docker-laravel.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Fix GitHub Actions workflow permissions to enable pushing Docker images to GitHub Container Registry.

## Problem
Builds were failing at the final push step with:
```
ERROR: failed to push ghcr.io/tetrixdev/pocket-dev-php:0.2.2: denied: installation not allowed to Create organization package
```

## Root Cause
- By default, GITHUB_TOKEN only has `read` access to packages
- GitHub Actions workflows need explicit `packages: write` permission to push to GHCR
- This is a security improvement GitHub made to reduce default permissions

## Solution
Add explicit permissions to the workflow job:
```yaml
permissions:
  contents: read    # for repository access (explicit, though default)
  packages: write   # for pushing to GitHub Container Registry
```

## What This Enables
- ✅ Docker images can be pushed to `ghcr.io/tetrixdev/pocket-dev-*`
- ✅ Successful completion of the build pipeline
- ✅ Automated container registry publishing on releases

## Testing
This should resolve the final blocking issue for releases 0.2.0, 0.2.1, and 0.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)