### PR TITLE
Fix TTYD Dockerfile to reference moved entrypoint.sh path

### DIFF
--- a/docker-ttyd/shared/Dockerfile
+++ b/docker-ttyd/shared/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /workspace
 USER devuser
 
 # Copy and set up entrypoint
-COPY docker-ttyd/entrypoint.sh /entrypoint.sh
+COPY docker-ttyd/shared/entrypoint.sh /entrypoint.sh
 USER root
 RUN chmod +x /entrypoint.sh
 USER devuser


### PR DESCRIPTION
## Summary
Fix TTYD Dockerfile to reference the correct path for entrypoint.sh after file structure consolidation.

## Problem
Build was failing on the TTYD image with:
```
COPY docker-ttyd/entrypoint.sh /entrypoint.sh
ERROR: "/docker-ttyd/entrypoint.sh": not found
```

## Root Cause
During the TODO consolidation in 0.2.0, we moved files from:
- `docker-ttyd/entrypoint.sh` → `docker-ttyd/shared/entrypoint.sh`
- `docker-ttyd/Dockerfile` → `docker-ttyd/shared/Dockerfile`

However, the **Dockerfile content** still referenced the old path `docker-ttyd/entrypoint.sh` instead of the new `docker-ttyd/shared/entrypoint.sh`.

## Solution
Update the COPY instruction in the Dockerfile:
```dockerfile
# Before
COPY docker-ttyd/entrypoint.sh /entrypoint.sh

# After  
COPY docker-ttyd/shared/entrypoint.sh /entrypoint.sh
```

## Progress Update
This should complete the TTYD image build. Current status:
- ✅ pocket-dev-php: Built and pushed successfully  
- ✅ pocket-dev-nginx: Built and pushed successfully
- 🔄 pocket-dev-ttyd: Should work with this fix
- ⏳ pocket-dev-proxy: Next in line

🤖 Generated with [Claude Code](https://claude.com/claude-code)