### PR TITLE
feat: Add URL-based conversation persistence to chat-v2

### DIFF
--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -17,7 +17,9 @@ Route::view("/session/{sessionId}", "chat")->name("claude.session");
 Route::view("/", "chat")->name("claude.index");
 
 // V2 Chat - Multi-provider direct API
-Route::view("/chat-v2/{conversationUuid?}", "chat-v2")->name("chat.v2");
+Route::view("/chat-v2/{conversationUuid?}", "chat-v2")
+    ->whereUuid("conversationUuid")
+    ->name("chat.v2");
 
 Route::get("/terminal", [TerminalController::class, "index"])->name("terminal.index");
 Route::post("/transcribe", [TerminalController::class, "transcribe"])->name("terminal.transcribe");


### PR DESCRIPTION
## Summary
- Adds conversation tracking via URL for chat-v2, matching the original chat interface behavior
- Refreshing the page now maintains the current conversation context
- Browser back/forward buttons work correctly for conversation navigation

## Changes
- **Route updated**: `/chat-v2/{conversationUuid?}` - accepts optional UUID parameter
- **URL tracking**: Updates URL when loading, creating, or clearing conversations
- **Browser navigation**: Handles `popstate` event for back/forward buttons
- **Error handling**: Clears URL if conversation fails to load (e.g., was deleted)

## Implementation Details
- `getConversationUuidFromUrl()` - extracts UUID from URL path
- `updateUrl(uuid)` - updates browser URL via `history.pushState()`
- On init, checks URL and loads conversation if UUID present
- `popstate` listener handles browser navigation

## Test plan
- [ ] Start new conversation → URL should remain `/chat-v2`
- [ ] Send first message → URL should update to `/chat-v2/{uuid}`
- [ ] Refresh page → same conversation should load
- [ ] Click conversation in sidebar → URL should update
- [ ] Click "New Conversation" → URL should clear to `/chat-v2`
- [ ] Use browser back button → should navigate to previous conversation
- [ ] Visit `/chat-v2/{invalid-uuid}` → should show error and clear URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations are now addressable by direct URLs: bookmarkable and shareable links restore specific conversations.
  * Browser navigation (back/forward) restores conversation state and the URL stays synchronized when creating or loading conversations.
* **Bug Fixes**
  * Improved URL reset behavior to prevent navigation loops and ensure the address bar reflects the current UI state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->