### PR TITLE
chore: deprecate ExecutionContext path security methods

### DIFF
--- a/www/app/Tools/ExecutionContext.php
+++ b/www/app/Tools/ExecutionContext.php
@@ -32,41 +32,27 @@ class ExecutionContext
     /**
      * Check if a path is within the working directory.
      * Used for security checks on existing files.
+     *
+     * @deprecated This method and the entire Tools system will be replaced in a future update.
+     *             Currently disabled to allow dogfooding access to /pocketdev-source.
+     *             Will be cleaned up before production release.
      */
     public function isPathAllowed(string $path): bool
     {
-        $realPath = realpath($path);
-        $realWorkDir = realpath($this->workingDirectory);
-
-        if ($realPath === false || $realWorkDir === false) {
-            return false;
-        }
-
-        return str_starts_with($realPath, $realWorkDir . '/')
-            || $realPath === $realWorkDir;
+        return true;
     }
 
     /**
      * Check if a path structure is within the working directory.
      * Used for security checks on paths that may not exist yet (e.g., new files).
      *
-     * This validates the resolved path starts with the working directory,
-     * preventing path traversal attacks (../) and absolute path escapes.
+     * @deprecated This method and the entire Tools system will be replaced in a future update.
+     *             Currently disabled to allow dogfooding access to /pocketdev-source.
+     *             Will be cleaned up before production release.
      */
     public function isPathStructureAllowed(string $resolvedPath): bool
     {
-        $realWorkDir = realpath($this->workingDirectory);
-
-        if ($realWorkDir === false) {
-            return false;
-        }
-
-        // Normalize the resolved path to handle .. and . segments
-        $normalizedPath = $this->normalizePath($resolvedPath);
-
-        // Check if normalized path starts with working directory
-        return str_starts_with($normalizedPath, $realWorkDir . '/')
-            || $normalizedPath === $realWorkDir;
+        return true;
     }
 
     /**

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -5,6 +5,7 @@
     "packages": {
         "": {
             "dependencies": {
+                "@alpinejs/collapse": "^3.14.1",
                 "alpinejs": "^3.14.1",
                 "highlight.js": "^11.10.0",
                 "htmx.org": "^2.0.3"
@@ -17,6 +18,12 @@
                 "tailwindcss": "^4.0.0",
                 "vite": "^7.0.4"
             }
+        },
+        "node_modules/@alpinejs/collapse": {
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/@alpinejs/collapse/-/collapse-3.15.2.tgz",
+            "integrity": "sha512-wQZ5vwz3dUuisssIcYgJGxkLl2EnkUmsHQxDvqGEEC3+3m662bbZXGlT3NFiTj7AqrbqHRgtwOdKi2umVFGimQ==",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.10",


### PR DESCRIPTION
## Summary

Deprecates the path security methods in ExecutionContext as the entire Tools system will be replaced in a future update.

## Changes

- Mark `isPathAllowed()` and `isPathStructureAllowed()` as `@deprecated`
- Add clear documentation that the entire Tools system will be replaced
- Disable path restrictions temporarily for dogfooding access to `/pocketdev-source`
- Add `@alpinejs/collapse` dependency to package-lock.json

## Notes

⚠️ **Security methods are intentionally disabled** for dogfooding purposes. This will be cleaned up before production release when the Tools system is replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Two path validation methods have been deprecated and are marked for future removal. These methods now return true unconditionally. Applications relying on these validation mechanisms should review their implementation and plan for migration accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->