### PR TITLE
fix: Add Claude Code verification to setup wizard

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -2,6 +2,7 @@ services:
   # Nginx reverse proxy
   pocket-dev-proxy:
     image: ghcr.io/tetrixdev/pocket-dev-proxy:${IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: pocket-dev-proxy
     restart: unless-stopped
     ports:
@@ -24,12 +25,13 @@ services:
 
   pocket-dev-php:
     image: ghcr.io/tetrixdev/pocket-dev-php:${IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: pocket-dev-php
     restart: unless-stopped
     working_dir: /var/www
     volumes:
       - .env:/var/www/.env
-      - user-data:/home/www-data
+      - user-data:/home/appuser
       - workspace-data:/workspace
       - proxy-config-data:/etc/nginx-proxy-config
     networks:
@@ -48,6 +50,7 @@ services:
 
   pocket-dev-nginx:
     image: ghcr.io/tetrixdev/pocket-dev-nginx:${IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: pocket-dev-nginx
     restart: unless-stopped
     networks:
@@ -99,13 +102,14 @@ services:
 
   pocket-dev-queue:
     image: ghcr.io/tetrixdev/pocket-dev-php:${IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: pocket-dev-queue
     restart: unless-stopped
     working_dir: /var/www
     command: ["php", "artisan", "queue:work", "redis", "--sleep=1", "--tries=1", "--timeout=600"]
     volumes:
       - .env:/var/www/.env
-      - user-data:/home/www-data
+      - user-data:/home/appuser
       - workspace-data:/workspace
     networks:
       - pocket-dev

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -41,8 +41,6 @@
                             <p class="text-sm text-gray-400 mt-1">Uses your Claude Pro/Team subscription. No API key needed.</p>
                             @if($hasClaudeCode)
                                 <p class="text-sm text-green-400 mt-1">Already authenticated</p>
-                            @else
-                                <p class="text-sm text-yellow-400 mt-1">Requires CLI authentication after setup</p>
                             @endif
                         </div>
                     </label>
@@ -74,6 +72,25 @@
                     </label>
                 </div>
             </div>
+
+            {{-- Claude Code Setup (conditional) --}}
+            @if(!$hasClaudeCode)
+            <div x-show="provider === 'claude_code'" x-cloak class="bg-gray-800 rounded-lg p-6">
+                <h3 class="text-lg font-semibold mb-3">Claude Code Setup</h3>
+                <p class="text-sm text-gray-400 mb-4">
+                    Run this command in your terminal to authenticate with your Claude Pro/Team subscription:
+                </p>
+                <div class="bg-gray-900 rounded p-3 font-mono text-sm text-green-400 select-all mb-3">
+                    docker exec -it pocket-dev-queue claude
+                </div>
+                <p class="text-sm text-gray-400 mb-2">
+                    This opens an interactive login. Complete the OAuth flow in your browser, then return here and click <strong class="text-white">Verify & Continue</strong>.
+                </p>
+                <p class="text-xs text-gray-500">
+                    If you prefer to use an API key instead, select "Anthropic API" above.
+                </p>
+            </div>
+            @endif
 
             {{-- API Key Input (conditional) --}}
             <div x-show="provider === 'anthropic'" x-cloak class="bg-gray-800 rounded-lg p-6">
@@ -157,18 +174,13 @@
                     class="w-full px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors"
                     :disabled="!provider"
                     :class="{ 'opacity-50 cursor-not-allowed': !provider }"
+                    x-text="provider === 'claude_code' && !{{ $hasClaudeCode ? 'true' : 'false' }} ? 'Verify & Continue' : 'Continue'"
                 >
                     Continue
                 </button>
             </div>
         </form>
 
-        <form method="POST" action="{{ route('setup.skip') }}" class="mt-4 text-center">
-            @csrf
-            <button type="submit" class="text-gray-500 hover:text-gray-400 text-sm">
-                Skip for now
-            </button>
-        </form>
     </div>
 
     <script>

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\Route;
 // Setup wizard (first-run)
 Route::get("/setup", [CredentialsController::class, "showSetup"])->name("setup");
 Route::post("/setup", [CredentialsController::class, "processSetup"])->name("setup.process");
-Route::post("/setup/skip", [CredentialsController::class, "skipSetup"])->name("setup.skip");
 
 // Claude authentication routes - MUST be before wildcard routes
 Route::get("/claude/auth", [ClaudeAuthController::class, "index"])->name("claude.auth");


### PR DESCRIPTION
## Summary
- Add Claude Code setup instructions showing the `docker exec -it pocket-dev-queue claude` command
- Verify Claude Code authentication before completing setup (redirects with error if not authenticated)
- Change button text to "Verify & Continue" when Claude Code is selected but not authenticated
- Remove "Skip for now" option - provider selection is now required
- Add `pull_policy: always` to all custom images in deploy/compose.yml
- Fix volume mount path from `/home/www-data` to `/home/appuser` to match production entrypoint HOME setting

## Test plan
- [ ] Reset wizard (`AppSetting::where('key', 'setup_complete')->delete()`)
- [ ] Select Claude Code without authenticating - verify error message appears
- [ ] Run `docker exec -it pocket-dev-queue claude` and complete OAuth
- [ ] Click "Verify & Continue" - verify setup completes successfully
- [ ] Verify "Skip for now" button no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Claude Code authentication into the setup wizard
  * Added on-screen instructions for Claude Code OAuth configuration during initial setup

* **Chores**
  * Updated Docker service configurations and volume mappings for enhanced consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->