### PR TITLE
fix: Increase transcription timeout and file size limits for longer recordings

### DIFF
--- a/www/app/Http/Controllers/Api/TranscriptionController.php
+++ b/www/app/Http/Controllers/Api/TranscriptionController.php
@@ -28,7 +28,7 @@ class TranscriptionController extends Controller
     {
         try {
             $request->validate([
-                'audio' => 'required|file|mimes:webm,wav,mp3,m4a,ogg|max:10240', // 10MB max
+                'audio' => 'required|file|mimes:webm,wav,mp3,m4a,ogg|max:25600', // 25MB max (OpenAI Whisper limit)
             ]);
 
             // Check if API key is configured

--- a/www/app/Services/TranscriptionService.php
+++ b/www/app/Services/TranscriptionService.php
@@ -28,7 +28,7 @@ class TranscriptionService
             $response = Http::withHeaders([
                 'Authorization' => 'Bearer ' . $this->apiKey,
             ])
-            ->timeout(30) // 30 second timeout for audio processing
+            ->timeout(1800) // 30 minute timeout for longer audio recordings
             ->attach('file', file_get_contents($audioFile->getRealPath()), $audioFile->getClientOriginalName())
             ->post($this->baseUrl . '/audio/transcriptions', [
                 'model' => 'gpt-4o-transcribe',

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1485,8 +1485,8 @@
                             return;
                         }
 
-                        if (audioBlob.size > 10 * 1024 * 1024) {
-                            this.showError('Recording too large. Please keep it under 10MB.');
+                        if (audioBlob.size > 25 * 1024 * 1024) {
+                            this.showError('Recording too large. Please keep it under 25MB.');
                             return;
                         }
 


### PR DESCRIPTION
## Summary
- Increase HTTP timeout from 30s to 30 minutes for OpenAI Whisper API calls
- Increase file size limit from 10MB to 25MB (matching OpenAI's actual limit)
- Update both frontend (chat.blade.php) and backend (TranscriptionController.php) validation

## Problem
Voice recordings longer than ~2 minutes were failing because:
1. The 30-second HTTP timeout was too short for OpenAI to process longer audio
2. The 10MB file limit was unnecessarily restrictive (OpenAI accepts up to 25MB)

## Test plan
- [ ] Record a 2+ minute voice message and verify transcription completes
- [ ] Verify error message shows "25MB" limit in frontend validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Audio file upload limit increased from 10MB to 25MB
  * Transcription processing timeout extended to support longer audio files
  * Updated validation messages to reflect new size limits

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->