### PR TITLE
fix: Handle null config values and hide unavailable providers

### DIFF
--- a/www/app/Services/Providers/AnthropicProvider.php
+++ b/www/app/Services/Providers/AnthropicProvider.php
@@ -22,9 +22,11 @@ class AnthropicProvider implements AIProviderInterface
 
     public function __construct(ModelRepository $models)
     {
-        $this->apiKey = config('ai.providers.anthropic.api_key', '');
-        $this->baseUrl = config('ai.providers.anthropic.base_url', 'https://api.anthropic.com');
-        $this->apiVersion = config('ai.providers.anthropic.api_version', '2023-06-01');
+        // Use ?? instead of config default - config() returns null when env var is not set,
+        // not the default value, because the key exists in config with null value
+        $this->apiKey = config('ai.providers.anthropic.api_key') ?? '';
+        $this->baseUrl = config('ai.providers.anthropic.base_url') ?? 'https://api.anthropic.com';
+        $this->apiVersion = config('ai.providers.anthropic.api_version') ?? '2023-06-01';
         $this->models = $models;
     }
 

--- a/www/app/Services/Providers/OpenAIProvider.php
+++ b/www/app/Services/Providers/OpenAIProvider.php
@@ -21,8 +21,10 @@ class OpenAIProvider implements AIProviderInterface
 
     public function __construct(ModelRepository $models)
     {
-        $this->apiKey = config('ai.providers.openai.api_key', '');
-        $this->baseUrl = config('ai.providers.openai.base_url', 'https://api.openai.com');
+        // Use ?? instead of config default - config() returns null when env var is not set,
+        // not the default value, because the key exists in config with null value
+        $this->apiKey = config('ai.providers.openai.api_key') ?? '';
+        $this->baseUrl = config('ai.providers.openai.base_url') ?? 'https://api.openai.com';
         $this->models = $models;
     }
 

--- a/www/resources/views/partials/chat/modals/quick-settings.blade.php
+++ b/www/resources/views/partials/chat/modals/quick-settings.blade.php
@@ -1,25 +1,22 @@
 {{-- Quick Settings Modal --}}
 <x-modal show="showQuickSettings" title="Quick Settings">
     <div class="space-y-4">
-        {{-- Provider Selection --}}
+        {{-- Provider Selection (only shows configured providers) --}}
         <div>
             <label class="block text-sm font-medium text-gray-300 mb-2">Provider</label>
             <div class="space-y-2">
                 <template x-for="(p, key) in providers" :key="key">
-                    <div class="flex items-center text-gray-300" :class="{'opacity-50': !p.available}">
+                    <div x-show="p.available" class="flex items-center text-gray-300">
                         <label class="flex items-center cursor-pointer flex-1">
-                            <input type="radio" x-model="provider" :value="key" @change="updateModels(); saveDefaultSettings()" :disabled="!p.available" class="mr-2">
+                            <input type="radio" x-model="provider" :value="key" @change="updateModels(); saveDefaultSettings()" class="mr-2">
                             <span x-text="key.replace('_', ' ')" class="capitalize"></span>
-                            <span x-show="!p.available && key !== 'claude_code'" class="ml-2 text-xs text-red-400">(not configured)</span>
                         </label>
-                        <button
-                            x-show="key === 'claude_code' && !p.available"
-                            @click="showQuickSettings = false; showClaudeCodeAuthModal = true"
-                            class="text-xs text-blue-400 hover:underline"
-                        >Setup</button>
                     </div>
                 </template>
             </div>
+            <p x-show="Object.values(providers).filter(p => p.available).length === 0" class="text-sm text-gray-500 italic">
+                No providers configured. Visit <a href="/config/credentials" class="text-blue-400 hover:underline">Settings</a> to add one.
+            </p>
         </div>
 
         {{-- Model Selection --}}


### PR DESCRIPTION
## Summary

- Fix TypeError when providers are instantiated without API keys configured
- Update quick settings modal to only show available (configured) providers
- Select first available provider if configured default isn't available

## Problem

When deploying PocketDev via the README method (without `.env` API keys configured), the `/api/providers` endpoint would crash with a `TypeError` because:

1. Config files set `'api_key' => env('ANTHROPIC_API_KEY')` which returns `null` when not set
2. Provider constructors used `config('...api_key', '')` expecting the default `''` to be used
3. But `config()` returns `null` (not the default) when the key exists with a null value
4. The `private string $apiKey` property can't accept null → TypeError

## Solution

1. **Backend**: Use `config('...') ?? ''` instead of `config('...', '')` to properly handle null
2. **Frontend**: Only show providers where `available: true` in the quick settings modal
3. **Frontend**: Auto-select first available provider if the default isn't configured

## Test plan

- [ ] Deploy fresh instance without any API keys in `.env`
- [ ] Verify the page loads without "Failed to load providers" error
- [ ] Verify only configured providers appear in quick settings
- [ ] Configure a provider via settings and verify it becomes selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced provider selection to intelligently default to available AI providers in the chat interface.
  * Improved settings UI by hiding unavailable providers and displaying a message when no providers are configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->