### PR TITLE
fix: OpenAI API key save fails due to chicken-and-egg problem

### DIFF
--- a/www/app/Services/TranscriptionService.php
+++ b/www/app/Services/TranscriptionService.php
@@ -21,14 +21,16 @@ class TranscriptionService
         if (str_ends_with($this->baseUrl, '/v1')) {
             $this->baseUrl = substr($this->baseUrl, 0, -3);
         }
-
-        if (empty($this->apiKey)) {
-            throw new \Exception('OpenAI API key is not configured. Set it in Config → Credentials.');
-        }
+        // Note: API key validation moved to transcribeAudio() to avoid chicken-and-egg
+        // problem where the controller can't be instantiated to save the key
     }
 
     public function transcribeAudio(UploadedFile $audioFile): string
     {
+        if (empty($this->apiKey)) {
+            throw new \Exception('OpenAI API key is not configured. Set it in Config → Credentials.');
+        }
+
         try {
             $response = Http::withHeaders([
                 'Authorization' => 'Bearer ' . $this->apiKey,


### PR DESCRIPTION
## Summary

- Fixes bug where saving OpenAI API key via the record button popup would fail with "Failed to save API key"
- Root cause: Commit 1475613 moved `TranscriptionService` to constructor injection, but the service throws in its constructor if no API key is configured
- This created a chicken-and-egg problem: can't save the key because the controller that saves it requires the service that requires the key

## Changes

- Move API key validation from `TranscriptionService::__construct()` to `TranscriptionService::transcribeAudio()`
- Controller can now be instantiated without a configured API key
- Validation still occurs before any transcription attempt

## Test plan

- [ ] Click Record button without OpenAI key configured
- [ ] Enter an invalid key → should show "invalid" error
- [ ] Enter a valid key → should save successfully and start recording
- [ ] Test voice transcription works after key is saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements have been made to enhance maintainability. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->