### PR TITLE
Fix CLI credential storage path mismatch in production

### DIFF
--- a/docker-laravel/local/php/Dockerfile
+++ b/docker-laravel/local/php/Dockerfile
@@ -83,6 +83,11 @@ RUN mkdir -p /home/appuser/.claude /home/appuser/.codex \
     && chown -R 1000:1000 /home/appuser \
     && chmod 775 /home/appuser /home/appuser/.claude /home/appuser/.codex
 
+# Change www-data's home directory to /home/appuser
+# This ensures all CLI tools (claude, codex, git, gh, etc.) use consistent paths
+# regardless of whether called from PHP-FPM, entrypoint, or docker exec
+RUN usermod -d /home/appuser www-data
+
 # Set working directory
 WORKDIR /var/www
 

--- a/docker-laravel/production/php/Dockerfile
+++ b/docker-laravel/production/php/Dockerfile
@@ -83,6 +83,11 @@ RUN mkdir -p /home/appuser/.claude /home/appuser/.codex \
     && chown -R 1000:1000 /home/appuser \
     && chmod 775 /home/appuser /home/appuser/.claude /home/appuser/.codex
 
+# Change www-data's home directory to /home/appuser
+# This ensures all CLI tools (claude, codex, git, gh, etc.) use consistent paths
+# regardless of whether called from PHP-FPM, entrypoint, or docker exec
+RUN usermod -d /home/appuser www-data
+
 # Set working directory
 WORKDIR /var/www
 


### PR DESCRIPTION
## Summary

- Fix www-data HOME directory to ensure CLI tools store credentials in the correct location
- Resolves issue where `docker exec pocket-dev-php claude setup-token` would store credentials in `/var/www/.claude/` while PHP expected them in `/home/appuser/.claude/`

## Problem

In production deployments, users following the authentication instructions would:
1. Run `docker exec -it pocket-dev-php claude setup-token`
2. Complete the OAuth flow successfully
3. Find that the app still showed "Not authenticated"

This was because:
- `docker exec` runs as www-data with HOME=/var/www (from /etc/passwd)
- PHP-FPM also uses www-data's HOME from /etc/passwd
- But the code had a fallback to `/home/appuser` which created confusion

## Solution

Change www-data's home directory in the Dockerfile:
```dockerfile
RUN usermod -d /home/appuser www-data
```

This ensures consistent HOME=/home/appuser across:
- PHP-FPM worker processes
- docker exec commands  
- All CLI tools (claude, codex, git, gh, etc.)

## Test plan

- [ ] Rebuild images locally
- [ ] Run `docker exec pocket-dev-php bash -c 'echo $HOME'` → should return `/home/appuser`
- [ ] Run `docker exec pocket-dev-php php -r "echo getenv('HOME');"` → should return `/home/appuser`
- [ ] Run `docker exec -it pocket-dev-php claude setup-token` and verify credentials are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configurations in both development and production environments to ensure consistent behavior of CLI tools across different execution contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->