### PR TITLE
Fix credential file checks to verify readability

### DIFF
--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -36,13 +36,13 @@ class ClaudeCodeProvider implements AIProviderInterface
     }
 
     /**
-     * Check if OAuth credentials exist (from `claude login`).
+     * Check if OAuth credentials exist and are readable (from `claude login`).
      */
     public function hasOAuthCredentials(): bool
     {
         $home = getenv('HOME') ?: '/home/appuser';
         $credentialsFile = $home . '/.claude/.credentials.json';
-        return file_exists($credentialsFile);
+        return is_readable($credentialsFile);
     }
 
     /**

--- a/www/app/Services/Providers/CodexProvider.php
+++ b/www/app/Services/Providers/CodexProvider.php
@@ -45,13 +45,13 @@ class CodexProvider implements AIProviderInterface
     }
 
     /**
-     * Check if Codex auth.json exists (contains either OAuth or API key).
+     * Check if Codex auth.json exists and is readable (contains either OAuth or API key).
      */
     public function hasCredentials(): bool
     {
         $home = getenv('HOME') ?: '/home/appuser';
         $authFile = $home . '/.codex/auth.json';
-        return file_exists($authFile);
+        return is_readable($authFile);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Changed `file_exists()` to `is_readable()` in both ClaudeCodeProvider and CodexProvider
- Prevents false positives where credential files exist but are not readable due to permission issues
- Fixes issue where users see "Permission denied (os error 13)" when using Codex with unreadable auth.json

## Context
During production testing, credential files created by a previous user (UID 1001) with mode 0600 were not readable by www-data (UID 33). The `file_exists()` check passed, but the CLI then failed with permission errors.

Using `is_readable()` checks both existence AND readability, providing a more accurate authentication status.

## Test plan
- [ ] Verify `is_readable()` returns false when file doesn't exist
- [ ] Verify `is_readable()` returns false when file exists but is not readable
- [ ] Verify auth status correctly shows "not authenticated" in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication credential validation to confirm files are readable and properly accessible, preventing potential authentication failures when credential files exist but lack appropriate read permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->