### PR TITLE
Add infinite scroll and provider info to conversation list

### DIFF
--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -132,6 +132,7 @@ class ConversationController extends Controller
     public function index(Request $request): JsonResponse
     {
         $query = Conversation::query()
+            ->with(['agent:id,name'])
             ->when($request->input('status'), fn($q, $s) => $q->where('status', $s))
             ->when($request->input('provider_type'), fn($q, $t) => $q->where('provider_type', $t))
             ->when($request->input('working_directory'), fn($q, $d) => $q->where('working_directory', $d))

--- a/www/resources/views/partials/chat/mobile-layout.blade.php
+++ b/www/resources/views/partials/chat/mobile-layout.blade.php
@@ -52,7 +52,7 @@
     </div>
 
     {{-- Conversations List --}}
-    <div class="flex-1 overflow-y-auto p-2">
+    <div class="flex-1 overflow-y-auto p-2" @scroll="handleConversationsScroll($event)">
         <template x-if="conversations.length === 0">
             <div class="text-center text-gray-500 text-xs mt-4">No conversations yet</div>
         </template>
@@ -61,9 +61,17 @@
                  :class="{'bg-gray-700': currentConversationUuid === conv.uuid}"
                  class="p-2 mb-1 rounded hover:bg-gray-700 cursor-pointer transition-colors">
                 <div class="text-xs text-gray-300 truncate" x-text="conv.title || 'New Conversation'"></div>
-                <div class="text-xs text-gray-500 mt-1" x-text="formatDate(conv.last_activity_at || conv.created_at)"></div>
+                <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                    <span x-text="formatDate(conv.last_activity_at || conv.created_at)"></span>
+                    <span class="w-1 h-1 rounded-full shrink-0" :class="getProviderColorClass(conv.provider_type)"></span>
+                    <span class="truncate" x-text="conv.agent?.name || getProviderDisplayName(conv.provider_type)"></span>
+                </div>
             </div>
         </template>
+        {{-- Loading indicator --}}
+        <div x-show="loadingMoreConversations" class="text-center py-2">
+            <span class="text-xs text-gray-500">Loading...</span>
+        </div>
     </div>
 
     {{-- Footer --}}

--- a/www/resources/views/partials/chat/sidebar.blade.php
+++ b/www/resources/views/partials/chat/sidebar.blade.php
@@ -6,7 +6,7 @@
     </div>
 
     {{-- Conversations List --}}
-    <div class="flex-1 overflow-y-auto p-2" id="conversations-list">
+    <div class="flex-1 overflow-y-auto p-2" id="conversations-list" @scroll="handleConversationsScroll($event)">
         <template x-if="conversations.length === 0">
             <div class="text-center text-gray-500 text-xs mt-4">No conversations yet</div>
         </template>
@@ -15,9 +15,17 @@
                  :class="{'bg-gray-700': currentConversationUuid === conv.uuid}"
                  class="p-2 mb-1 rounded hover:bg-gray-700 cursor-pointer transition-colors">
                 <div class="text-xs text-gray-300 truncate" x-text="conv.title || 'New Conversation'"></div>
-                <div class="text-xs text-gray-500 mt-1" x-text="formatDate(conv.last_activity_at || conv.created_at)"></div>
+                <div class="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+                    <span x-text="formatDate(conv.last_activity_at || conv.created_at)"></span>
+                    <span class="w-1 h-1 rounded-full shrink-0" :class="getProviderColorClass(conv.provider_type)"></span>
+                    <span class="truncate" x-text="conv.agent?.name || getProviderDisplayName(conv.provider_type)"></span>
+                </div>
             </div>
         </template>
+        {{-- Loading indicator --}}
+        <div x-show="loadingMoreConversations" class="text-center py-2">
+            <span class="text-xs text-gray-500">Loading...</span>
+        </div>
     </div>
 
     {{-- Footer Info --}}


### PR DESCRIPTION
## Summary
- Add infinite scroll pagination for conversations in the sidebar (loads more when scrolling to bottom)
- Show provider color dot and agent name on each conversation item
- Compact layout: `date • [colored dot] • agent name` on second line

## Changes
- **chat.blade.php**: Added pagination state, `fetchMoreConversations()`, `handleConversationsScroll()`, and `getProviderColorClass()` helper
- **ConversationController.php**: Include agent relationship (id, name) in conversation list API
- **sidebar.blade.php** & **mobile-layout.blade.php**: Updated conversation item layout with provider dot and agent name, added scroll listener and loading indicator

## Test plan
- [ ] Scroll to bottom of conversations list - should load more
- [ ] Verify colored dot matches provider (orange=Anthropic, green=OpenAI, purple=Claude Code, etc.)
- [ ] Verify agent name shows next to dot (falls back to provider name if no agent)
- [ ] Test on mobile drawer as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented infinite scroll for conversations list—automatically load additional conversations as you scroll toward the bottom
  * Enhanced conversation items with color-coded provider indicators and agent/provider names for better visual distinction
  * Added loading state indicator during conversation pagination for improved user feedback

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->