### PR TITLE
Separate CLI and API examples in tool instructions

### DIFF
--- a/www/app/Services/ToolSelector.php
+++ b/www/app/Services/ToolSelector.php
@@ -203,7 +203,7 @@ class ToolSelector
                 foreach ($systemTools as $tool) {
                     $artisanCommand = $tool->getArtisanCommand();
                     $sections[] = "### {$artisanCommand}\n";
-                    $sections[] = $tool->instructions ?? $tool->description;
+                    $sections[] = $this->getToolInstructions($tool, true);
                     $sections[] = $this->formatToolParameters($tool);
                     $sections[] = "";
                 }
@@ -216,7 +216,7 @@ class ToolSelector
                 foreach ($customTools as $tool) {
                     $artisanCommand = $tool->getArtisanCommand();
                     $sections[] = "### {$artisanCommand}\n";
-                    $sections[] = $tool->instructions ?? $tool->description;
+                    $sections[] = $this->getToolInstructions($tool, true);
                     $sections[] = $this->formatToolParameters($tool);
                     $sections[] = "";
                 }
@@ -231,7 +231,7 @@ class ToolSelector
 
                 foreach ($categoryTools as $tool) {
                     $sections[] = "### {$tool->name}\n";
-                    $sections[] = $tool->instructions ?? $tool->description;
+                    $sections[] = $this->getToolInstructions($tool, false);
                     $sections[] = $this->formatToolParameters($tool);
                     $sections[] = "";
                 }
@@ -351,6 +351,25 @@ MD;
             PocketTool::CATEGORY_CUSTOM => 'Custom Tools',
             default => ucfirst(str_replace('_', ' ', $category)),
         };
+    }
+
+    /**
+     * Get tool instructions with CLI or API examples appended.
+     *
+     * @param Tool $tool The tool
+     * @param bool $isCli Whether to use CLI examples (true) or API examples (false)
+     * @return string The combined instructions
+     */
+    private function getToolInstructions(Tool $tool, bool $isCli): string
+    {
+        $base = $tool->instructions ?? $tool->description;
+        $examples = $isCli ? $tool->cliExamples : $tool->apiExamples;
+
+        if ($examples) {
+            return $base . "\n\n" . $examples;
+        }
+
+        return $base;
     }
 
     /**

--- a/www/app/Tools/MemoryDeleteTool.php
+++ b/www/app/Tools/MemoryDeleteTool.php
@@ -39,12 +39,6 @@ class MemoryDeleteTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use MemoryDelete to remove rows from memory tables. Associated embeddings are automatically deleted.
 
-## CLI Example
-
-```bash
-php artisan memory:delete --table=characters --where="id = '123e4567-e89b-12d3-a456-426614174000'"
-```
-
 ## WHERE Clause
 
 The WHERE clause is **required** to prevent accidental deletion of all rows:
@@ -91,6 +85,25 @@ Deleting from schema_registry has special validation to prevent metadata corrupt
 - The table must NOT exist (only orphaned entries can be deleted)
 - Use this to clean up registry entries after dropping a table
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:delete --table=characters --where="id = '123e4567-e89b-12d3-a456-426614174000'"
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "table": "characters",
+  "where": "name = 'Thorin Ironforge'"
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/MemoryInsertTool.php
+++ b/www/app/Tools/MemoryInsertTool.php
@@ -38,12 +38,6 @@ class MemoryInsertTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use MemoryInsert to add rows to memory tables. Embeddings are automatically generated based on the table's configured embed_fields.
 
-## CLI Example
-
-```bash
-php artisan memory:insert --table=characters --data='{"name":"Thorin Ironforge","class":"fighter","backstory":"A dwarf warrior seeking revenge for his fallen clan."}'
-```
-
 ## Auto-Embedding
 
 When you insert data, fields configured in the table's `embed_fields` are automatically embedded:
@@ -77,6 +71,29 @@ If the table has `backstory` and `relationships` as embed_fields, both will be e
 - created_at/updated_at are auto-generated if columns exist
 - Returns the new row's UUID
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:insert --table=characters --data='{"name":"Thorin Ironforge","class":"fighter","backstory":"A dwarf warrior seeking revenge for his fallen clan."}'
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "table": "characters",
+  "data": {
+    "name": "Gandalf the Grey",
+    "class": "wizard",
+    "backstory": "A Maia spirit sent to Middle-earth..."
+  }
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/MemoryQueryTool.php
+++ b/www/app/Tools/MemoryQueryTool.php
@@ -46,13 +46,6 @@ class MemoryQueryTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use MemoryQuery to search and retrieve data from memory tables. This is your primary read tool for the memory system.
 
-## CLI Example
-
-```bash
-php artisan memory:query --sql="SELECT * FROM memory.characters LIMIT 10"
-php artisan memory:query --sql="SELECT * FROM memory.schema_registry"
-```
-
 ## System Tables
 
 - **memory.schema_registry**: Table metadata (table_name, description, embeddable_fields)
@@ -118,6 +111,34 @@ ORDER BY distance_m
 - Use :search_embedding placeholder with search_text parameter for vector searches
 - Tables are in memory schema (memory.tablename)
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:query --sql="SELECT * FROM memory.characters LIMIT 10"
+php artisan memory:query --sql="SELECT * FROM memory.schema_registry"
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+Basic query:
+```json
+{
+  "sql": "SELECT * FROM memory.characters LIMIT 10"
+}
+```
+
+Semantic search:
+```json
+{
+  "sql": "SELECT e.source_table, e.content, 1 - (e.embedding <=> :search_embedding) as similarity FROM memory.embeddings e WHERE 1 - (e.embedding <=> :search_embedding) > 0.6 ORDER BY similarity DESC LIMIT 5",
+  "search_text": "dwarf warrior revenge"
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/MemorySchemaExecuteTool.php
+++ b/www/app/Tools/MemorySchemaExecuteTool.php
@@ -41,32 +41,13 @@ Use MemorySchemaExecute for DDL operations other than CREATE TABLE:
 - UPDATE memory.embeddings (for table renames)
 - Other memory schema operations
 
-## CLI Example
-
-```bash
-php artisan memory:schema:execute --sql="CREATE INDEX idx_characters_name ON memory.characters(name)"
-php artisan memory:schema:execute --sql="DROP TABLE IF EXISTS memory.old_table"
-```
-
 ## ALTER TABLE
 
 ALTER TABLE is supported for modifying existing tables:
-
-```bash
-# Add a column
-php artisan memory:schema:execute --sql="ALTER TABLE memory.session_logs ADD COLUMN in_game_date_start TEXT"
-
-# Drop a column
-php artisan memory:schema:execute --sql="ALTER TABLE memory.characters DROP COLUMN old_field"
-
-# Rename a column
-php artisan memory:schema:execute --sql="ALTER TABLE memory.characters RENAME COLUMN old_name TO new_name"
-
-# Rename a table (also update embeddings and schema_registry)
-php artisan memory:schema:execute --sql="ALTER TABLE memory.old_name RENAME TO new_name"
-php artisan memory:schema:execute --sql="UPDATE memory.embeddings SET source_table = 'new_name' WHERE source_table = 'old_name'"
-php artisan memory:update --table=schema_registry --data='{"table_name":"new_name"}' --where="table_name = 'old_name'"
-```
+- Add a column: `ALTER TABLE memory.X ADD COLUMN new_col TEXT`
+- Drop a column: `ALTER TABLE memory.X DROP COLUMN old_col`
+- Rename a column: `ALTER TABLE memory.X RENAME COLUMN old TO new`
+- Rename a table: Also update embeddings and schema_registry (see examples)
 
 ## Protected Tables
 
@@ -74,7 +55,7 @@ Cannot DROP, TRUNCATE, or ALTER:
 - memory.embeddings
 - memory.schema_registry
 
-## Index Examples
+## Index Types
 
 ```sql
 -- Standard B-tree index
@@ -90,6 +71,25 @@ CREATE INDEX idx_tablename_geo ON memory.tablename USING GIST (coordinates);
 CREATE INDEX idx_tablename_data ON memory.tablename USING GIN (data);
 ```
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:schema:execute --sql="CREATE INDEX idx_characters_name ON memory.characters(name)"
+php artisan memory:schema:execute --sql="DROP TABLE IF EXISTS memory.old_table"
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "sql": "CREATE INDEX idx_characters_name ON memory.characters(name)"
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/MemorySchemaListTablesTool.php
+++ b/www/app/Tools/MemorySchemaListTablesTool.php
@@ -38,14 +38,6 @@ class MemorySchemaListTablesTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use MemorySchemaListTables to see what tables exist in the memory schema.
 
-## CLI Example
-
-```bash
-php artisan memory:schema:list-tables
-php artisan memory:schema:list-tables --table=characters
-php artisan memory:schema:list-tables --show-columns=false
-```
-
 ## Output Includes
 
 For each table:
@@ -59,6 +51,32 @@ For each table:
 - **memory.embeddings**: Central storage for semantic search vectors
 - **memory.schema_registry**: Tracks table metadata and embeddable fields
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:schema:list-tables
+php artisan memory:schema:list-tables --table=characters
+php artisan memory:schema:list-tables --show-columns=false
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+List all tables:
+```json
+{}
+```
+
+Show specific table:
+```json
+{
+  "table": "characters"
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/MemoryUpdateTool.php
+++ b/www/app/Tools/MemoryUpdateTool.php
@@ -70,12 +70,6 @@ php artisan memory:update --table=characters --data='{"backstory":"New content o
 
 **Note:** For relationship tracking, prefer using the append-only `relationship_events` table instead of updating `entity_relationships`. See dm_system_prompt.md for the pattern.
 
-## CLI Example
-
-```bash
-php artisan memory:update --table=characters --data='{"backstory":"Updated backstory with new details..."}' --where="id = '123e4567-e89b-12d3-a456-426614174000'"
-```
-
 ## WHERE Clause
 
 The WHERE clause is **required** to prevent accidental updates of all rows:
@@ -99,7 +93,24 @@ When you update embeddable fields:
 3. Regenerates embeddings only for changed embeddable fields
 4. Updates the hash to track the new content
 
-## Example: Update character backstory
+## Notes
+
+- WHERE clause is required (no bulk updates without filter)
+- Only specified columns are updated (others remain unchanged)
+- Returns count of affected rows
+- Embeddings only regenerated for fields that actually changed
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan memory:update --table=characters --data='{"backstory":"Updated backstory with new details..."}' --where="id = '123e4567-e89b-12d3-a456-426614174000'"
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
 
 ```json
 {
@@ -112,14 +123,7 @@ When you update embeddable fields:
 ```
 
 The backstory embedding will be regenerated automatically if `backstory` is an embed field.
-
-## Notes
-
-- WHERE clause is required (no bulk updates without filter)
-- Only specified columns are updated (others remain unchanged)
-- Returns count of affected rows
-- Embeddings only regenerated for fields that actually changed
-INSTRUCTIONS;
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/Tool.php
+++ b/www/app/Tools/Tool.php
@@ -22,8 +22,14 @@ abstract class Tool
     /** JSON Schema for input parameters */
     public array $inputSchema = [];
 
-    /** Detailed instructions for system prompt (what Claude sees) */
+    /** Detailed instructions for system prompt (what Claude sees) - shared content */
     public ?string $instructions = null;
+
+    /** CLI-specific examples (appended for CLI providers like Claude Code) */
+    public ?string $cliExamples = null;
+
+    /** API/JSON-specific examples (appended for API providers) */
+    public ?string $apiExamples = null;
 
     /** Tool category for grouping: memory, tools, file_ops, custom */
     public string $category = 'custom';
@@ -77,6 +83,8 @@ abstract class Tool
             'description' => $this->description,
             'category' => $this->category,
             'instructions' => $this->instructions,
+            'cli_examples' => $this->cliExamples,
+            'api_examples' => $this->apiExamples,
             'input_schema' => $this->inputSchema,
         ];
     }

--- a/www/app/Tools/ToolDeleteTool.php
+++ b/www/app/Tools/ToolDeleteTool.php
@@ -29,17 +29,29 @@ class ToolDeleteTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use ToolDelete to permanently remove a user-created tool.
 
-## CLI Example
-
-```bash
-php artisan tool:delete --slug=my-tool
-```
-
 ## Important
 - Only user-created tools can be deleted
 - PocketDev built-in tools cannot be deleted
 - This action cannot be undone
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan tool:delete --slug=my-tool
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "slug": "my-tool"
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/ToolListTool.php
+++ b/www/app/Tools/ToolListTool.php
@@ -45,6 +45,13 @@ class ToolListTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use ToolList to see all available tools.
 
+## Filters
+- enabled/disabled: Filter by status
+- pocketdev/user: Filter by source
+- category: Filter by category
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
 ## CLI Example
 
 ```bash
@@ -52,13 +59,10 @@ php artisan tool:list
 php artisan tool:list --enabled --user
 php artisan tool:list --category=memory
 ```
+CLI;
 
-## Filters
-- enabled/disabled: Filter by status
-- pocketdev/user: Filter by source
-- category: Filter by category
-
-## Example
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
 
 List all tools:
 ```json
@@ -79,7 +83,7 @@ List memory tools:
   "category": "memory"
 }
 ```
-INSTRUCTIONS;
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/ToolRunTool.php
+++ b/www/app/Tools/ToolRunTool.php
@@ -34,17 +34,9 @@ class ToolRunTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use ToolRun to execute a user-created tool.
 
-## CLI Example
-
-```bash
-php artisan tool:run greet -- --name=World
-```
-
-**Important:** The `--` separator is REQUIRED for `tool:run` only, before any `--arguments`.
-
 ## How Arguments Work
 
-Arguments passed via CLI become environment variables in the script:
+Arguments passed become environment variables in the script:
 - `--name=John` → `$TOOL_NAME` in script
 - `--my-param=value` → `$TOOL_MY_PARAM` in script
 
@@ -54,6 +46,29 @@ Arguments passed via CLI become environment variables in the script:
 - Scripts have a 5-minute timeout
 - Use `tool:list` to see available tools and their slugs
 INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+php artisan tool:run greet -- --name=World
+```
+
+**Important:** The `--` separator is REQUIRED for `tool:run` only, before any `--arguments`.
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "slug": "greet",
+  "arguments": {
+    "name": "World"
+  }
+}
+```
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/ToolShowTool.php
+++ b/www/app/Tools/ToolShowTool.php
@@ -32,15 +32,19 @@ class ToolShowTool extends Tool
 
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use ToolShow to get detailed information about a tool.
+INSTRUCTIONS;
 
+    public ?string $cliExamples = <<<'CLI'
 ## CLI Example
 
 ```bash
 php artisan tool:show --slug=my-tool
 php artisan tool:show --slug=my-tool --include_script
 ```
+CLI;
 
-## Example
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
 
 Show basic info:
 ```json
@@ -56,7 +60,7 @@ Show info including script:
   "include_script": true
 }
 ```
-INSTRUCTIONS;
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {

--- a/www/app/Tools/ToolUpdateTool.php
+++ b/www/app/Tools/ToolUpdateTool.php
@@ -53,17 +53,27 @@ class ToolUpdateTool extends Tool
     public ?string $instructions = <<<'INSTRUCTIONS'
 Use ToolUpdate to modify an existing user-created tool.
 
+## Important
+- Only user-created tools can be modified
+- PocketDev built-in tools cannot be changed
+
+## Valid Categories
+- memory: Memory-related tools
+- tools: Tool management
+- file_ops: File operations
+- custom: Custom tools (default)
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
 ## CLI Example
 
 ```bash
 php artisan tool:update --slug=my-tool --name="Updated Name" --description="New description"
 ```
+CLI;
 
-## Important
-- Only user-created tools can be modified
-- PocketDev built-in tools cannot be changed
-
-## Example
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
 
 Update a tool's script:
 ```json
@@ -81,13 +91,7 @@ Update name and description:
   "description": "An updated description"
 }
 ```
-
-## Valid Categories
-- memory: Memory-related tools
-- tools: Tool management
-- file_ops: File operations
-- custom: Custom tools (default)
-INSTRUCTIONS;
+API;
 
     public function execute(array $input, ExecutionContext $context): ToolResult
     {


### PR DESCRIPTION
## Summary
- Add `$cliExamples` and `$apiExamples` properties to Tool base class
- ToolSelector now appends appropriate examples based on provider type (CLI vs API)
- All tool files updated to split instructions into shared content + provider-specific examples
- MemorySchemaCreateTableTool includes guidance on writing AI-consumable documentation

## Test plan
- [ ] Verify CLI providers (Claude Code) see bash command examples
- [ ] Verify API providers see JSON input examples
- [ ] Check system prompt generation includes correct examples per provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool instructions now display CLI and API examples separately and contextually—showing relevant examples based on whether you're using the CLI or API interface.
  * Enhanced tool documentation with clearer separation between instructions and usage examples for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->