### PR TITLE
Add agent selector to mobile header

### DIFF
--- a/www/resources/views/partials/chat/mobile-layout.blade.php
+++ b/www/resources/views/partials/chat/mobile-layout.blade.php
@@ -8,7 +8,8 @@
     <div class="flex flex-col items-center">
         <h2 class="text-base font-semibold leading-tight">PocketDev</h2>
         <button @click="showAgentSelector = true"
-                class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200 underline decoration-gray-600 hover:decoration-gray-400">
+                class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200 underline decoration-gray-600 hover:decoration-gray-400"
+                aria-label="Select AI agent">
             <span class="w-1.5 h-1.5 rounded-full shrink-0"
                   :class="{
                       'bg-orange-500': currentAgent?.provider === 'anthropic',


### PR DESCRIPTION
## Summary
- Display current agent name with colored provider indicator dot in mobile header
- Tapping the agent name opens the agent selector modal for quick switching
- Reduced header padding for more compact appearance

## Test plan
- [ ] Open PocketDev on mobile or narrow viewport
- [ ] Verify agent name shows in header with colored dot (orange=Anthropic, green=OpenAI, purple=Claude Code)
- [ ] Tap agent name and confirm selector modal opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an agent selector in the mobile header with a color-coded status dot and agent name/fallback label.

* **Style**
  * Reduced mobile header padding and tightened spacing for a more compact layout.
  * Reorganized header elements for clearer grouping while preserving the config/menu access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->