### PR TITLE
Improve header and sidebar consistency across chat and settings

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -145,6 +145,31 @@
         {{-- Main Content Area --}}
         <div class="flex-1 flex flex-col">
 
+            {{-- Desktop Header (hidden on mobile) --}}
+            <div class="hidden md:flex bg-gray-800 border-b border-gray-700 p-2 items-center justify-between">
+                <div class="flex items-center gap-3 pl-2">
+                    <h2 class="text-base font-semibold">PocketDev</h2>
+                    <button @click="showAgentSelector = true"
+                            class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200"
+                            aria-label="Select AI agent">
+                        <span class="w-1.5 h-1.5 rounded-full shrink-0"
+                              :class="{
+                                  'bg-orange-500': currentAgent?.provider === 'anthropic',
+                                  'bg-green-500': currentAgent?.provider === 'openai',
+                                  'bg-purple-500': currentAgent?.provider === 'claude_code',
+                                  'bg-gray-500': !currentAgent
+                              }"></span>
+                        <span x-text="currentAgent?.name || 'Select Agent'" class="underline decoration-gray-600 hover:decoration-gray-400"></span>
+                    </button>
+                </div>
+                <a href="{{ route('config.index') }}" class="text-gray-300 hover:text-white p-2" title="Settings">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                </a>
+            </div>
+
             {{-- Messages Container --}}
             {{-- Mobile: fixed position between header and input, contained scroll --}}
             {{-- Desktop: flex container scroll with overflow-y-auto --}}

--- a/www/resources/views/layouts/config.blade.php
+++ b/www/resources/views/layouts/config.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>@yield('title', 'Configuration') - PocketDev</title>
+    <title>@yield('title', 'Settings') - PocketDev</title>
 
     @if (file_exists(public_path('build/manifest.json')))
         @vite(['resources/css/app.css', 'resources/js/app.js'])
@@ -116,26 +116,21 @@
 </head>
 <body class="bg-gray-900 text-white" x-data="{ showMobileDrawer: false }">
     <!-- Desktop Layout -->
-    <div class="desktop-layout flex flex-col" style="height: 100dvh;">
+    @php
+        $lastConversationUuid = session('last_conversation_uuid');
+        $backToChatUrl = $lastConversationUuid ? '/chat/' . $lastConversationUuid : '/';
+    @endphp
+    <div class="desktop-layout flex" style="height: 100dvh;">
 
-        <!-- Header -->
-        @php
-            $lastConversationUuid = session('last_conversation_uuid');
-            $backToChatUrl = $lastConversationUuid ? '/chat/' . $lastConversationUuid : '/';
-        @endphp
-        <div class="bg-gray-800 border-b border-gray-700 p-4 flex justify-between items-center">
-            <h1 class="text-2xl font-bold">⚙️ Configuration</h1>
-            <a href="{{ $backToChatUrl }}" class="text-blue-400 hover:text-blue-300 text-sm"
-               onclick="localStorage.setItem('pocketdev_returning_from_settings', 'true')">
-                ← Back to Chat
-            </a>
-        </div>
-
-        <!-- Main Content: Sidebar + Content Area -->
-        <div class="flex-1 flex overflow-hidden">
-
-            <!-- Sidebar (Categories) -->
-            <div class="w-64 bg-gray-800 border-r border-gray-700 overflow-y-auto">
+        <!-- Sidebar (Categories) -->
+        <div class="w-64 bg-gray-800 border-r border-gray-700 flex flex-col">
+            <!-- Sidebar Header -->
+            <div class="p-4 border-b border-gray-700">
+                <h2 class="text-lg font-semibold">Menu</h2>
+            </div>
+            {{-- TODO: Extract navigation to <x-config.navigation> component to reduce duplication with mobile drawer --}}
+            <!-- Sidebar Navigation -->
+            <div class="flex-1 overflow-y-auto">
 
                 <!-- System Prompt (Primary Setting) -->
                 <div class="border-b border-gray-700">
@@ -243,35 +238,52 @@
                 </div>
 
             </div>
+        </div>
 
-            <!-- Content Area -->
+        <!-- Content Area -->
+        <div class="flex-1 flex flex-col">
+
+            <!-- Desktop Header -->
+            <div class="bg-gray-800 border-b border-gray-700 p-2 flex items-center justify-between">
+                <div class="flex items-center gap-3 pl-2">
+                    <h2 class="text-base font-semibold">Settings</h2>
+                </div>
+                <a href="{{ $backToChatUrl }}" class="text-gray-300 hover:text-white p-2" title="Back to Chat"
+                   onclick="localStorage.setItem('pocketdev_returning_from_settings', 'true')">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+                    </svg>
+                </a>
+            </div>
+
+            <!-- Content -->
             <div class="flex-1 overflow-y-auto p-6">
 
-                <!-- Notifications -->
-                @if(session('success'))
-                    <div class="notification success">
-                        {{ session('success') }}
-                    </div>
-                @endif
+            <!-- Notifications -->
+            @if(session('success'))
+                <div class="notification success">
+                    {{ session('success') }}
+                </div>
+            @endif
 
-                @if(session('error'))
-                    <div class="notification error">
-                        {{ session('error') }}
-                    </div>
-                @endif
+            @if(session('error'))
+                <div class="notification error">
+                    {{ session('error') }}
+                </div>
+            @endif
 
-                @if($errors->any())
-                    <div class="notification error">
-                        <ul class="list-disc list-inside">
-                            @foreach($errors->all() as $error)
-                                <li>{{ $error }}</li>
-                            @endforeach
-                        </ul>
-                    </div>
-                @endif
+            @if($errors->any())
+                <div class="notification error">
+                    <ul class="list-disc list-inside">
+                        @foreach($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
 
-                <!-- Page Content -->
-                @yield('content')
+            <!-- Page Content -->
+            @yield('content')
             </div>
         </div>
     </div>
@@ -279,14 +291,14 @@
     <!-- Mobile Layout -->
     <div class="mobile-layout min-h-screen flex flex-col">
         <!-- Mobile Header (Sticky) -->
-        <div class="sticky top-0 z-10 bg-gray-800 border-b border-gray-700 p-4 flex items-center justify-between">
-            <button @click="showMobileDrawer = true" class="text-gray-300 hover:text-white">
+        <div class="sticky top-0 z-10 bg-gray-800 border-b border-gray-700 p-2 flex items-center justify-between">
+            <button @click="showMobileDrawer = true" class="text-gray-300 hover:text-white p-2">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
                 </svg>
             </button>
-            <h2 class="text-lg font-semibold">⚙️ Configuration</h2>
-            <a href="{{ $backToChatUrl }}" class="text-gray-300 hover:text-white"
+            <h2 class="text-lg font-semibold">Settings</h2>
+            <a href="{{ $backToChatUrl }}" class="text-gray-300 hover:text-white p-2"
                onclick="localStorage.setItem('pocketdev_returning_from_settings', 'true')">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />

--- a/www/resources/views/partials/chat/mobile-layout.blade.php
+++ b/www/resources/views/partials/chat/mobile-layout.blade.php
@@ -92,25 +92,7 @@
     <div class="p-4 border-t border-gray-700 text-xs text-gray-400">
         <div class="mb-2">Cost: <span class="text-green-400 font-mono" x-text="'$' + sessionCost.toFixed(4)">$0.00</span></div>
         <div class="mb-2"><span x-text="totalTokens.toLocaleString() + ' tokens'">0 tokens</span></div>
-        <div class="mb-2">
-            <button @click="showAgentSelector = true; showMobileDrawer = false" class="text-left w-full">
-                <div class="text-gray-300 font-medium flex items-center gap-1.5">
-                    <span class="w-2 h-2 rounded-full shrink-0"
-                          :class="{
-                              'bg-orange-500': currentAgent?.provider === 'anthropic',
-                              'bg-green-500': currentAgent?.provider === 'openai',
-                              'bg-purple-500': currentAgent?.provider === 'claude_code',
-                              'bg-gray-500': !currentAgent
-                          }"></span>
-                    <span x-text="currentAgent?.name || 'Select Agent'"></span>
-                </div>
-                <div class="text-gray-500 text-xs mt-0.5" x-text="currentAgent?.model || 'No agent'"></div>
-            </button>
-        </div>
         <div class="flex flex-wrap gap-3">
-            <x-button @click="showShortcutsModal = true; showMobileDrawer = false" variant="ghost" size="sm">
-                Shortcuts
-            </x-button>
             <x-button @click="copyConversationToClipboard(); showMobileDrawer = false"
                       variant="ghost"
                       size="sm"

--- a/www/resources/views/partials/chat/sidebar.blade.php
+++ b/www/resources/views/partials/chat/sidebar.blade.php
@@ -1,7 +1,7 @@
 {{-- Desktop Sidebar --}}
 <div class="w-64 h-full bg-gray-800 border-r border-gray-700 flex flex-col">
     <div class="p-4 border-b border-gray-700">
-        <h2 class="text-lg font-semibold">PocketDev</h2>
+        <h2 class="text-lg font-semibold">Conversations</h2>
         <button @click="newConversation()" class="mt-2 w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm">New Conversation</button>
     </div>
 
@@ -47,29 +47,9 @@
                 <span x-text="totalTokens.toLocaleString() + ' tokens'">0 tokens</span>
             </div>
         </div>
-        {{-- Current Agent Display --}}
-        {{-- TODO: Refactor to use <x-button variant="ghost"> for consistency with coding guidelines --}}
-        <div class="mb-2">
-            <button @click="showAgentSelector = true" class="text-left w-full group">
-                <div class="text-gray-300 font-medium flex items-center gap-1.5">
-                    <span class="w-2 h-2 rounded-full shrink-0"
-                          :class="{
-                              'bg-orange-500': currentAgent?.provider === 'anthropic',
-                              'bg-green-500': currentAgent?.provider === 'openai',
-                              'bg-purple-500': currentAgent?.provider === 'claude_code',
-                              'bg-gray-500': !currentAgent
-                          }"></span>
-                    <span x-text="currentAgent?.name || 'Select Agent'" class="truncate"></span>
-                    <svg class="w-3 h-3 text-gray-500 group-hover:text-gray-300 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-                    </svg>
-                </div>
-                <div class="text-gray-500 text-xs mt-0.5 truncate" x-text="currentAgent?.model || 'No agent selected'"></div>
-            </button>
-        </div>
         <div>Working Dir: /var/www</div>
         <div class="flex flex-wrap gap-2 mt-2">
-            <a href="/config" class="text-blue-400 hover:text-blue-300">Config</a>
+            <a href="{{ route('config.index') }}" class="text-blue-400 hover:text-blue-300">Settings</a>
             <button @click="showShortcutsModal = true" class="text-blue-400 hover:text-blue-300">Shortcuts</button>
             <button @click="copyConversationToClipboard()"
                     :disabled="messages.length === 0"


### PR DESCRIPTION
## Summary
- Add desktop header to both chat and settings pages with consistent styling
- Chat header shows "PocketDev" + agent selector + settings icon
- Settings header shows "Settings" + back-to-chat arrow
- Align sidebar structure: "Conversations" for chat, "Menu" for settings
- Remove redundant agent selector from sidebar/drawer footers (now in headers)
- Remove model name display, shortcuts link from mobile, and cog emoji
- Rename "Configuration" to "Settings" throughout

## Test plan
- [ ] Desktop chat: Verify header shows PocketDev, agent selector, and settings icon
- [ ] Desktop settings: Verify header shows Settings and back arrow, sidebar shows Menu
- [ ] Mobile chat: Verify header shows agent name, drawer no longer has agent selector
- [ ] Mobile settings: Verify header height matches chat header
- [ ] Both: Clicking agent selector opens modal, clicking settings/back navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop header in chat with an agent selector button and a Settings link.

* **Refactor**
  * Settings page redesigned with a persistent left sidebar and categorized menu (System Prompt, Files, Agents, Commands, Hooks, Tools, Memory, Credentials).
  * Chat sidebar header renamed to "Conversations".
  * Mobile chat footer simplified: agent selector and shortcuts removed; other controls preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->