### PR TITLE
Improve chat message styling on mobile

### DIFF
--- a/www/resources/views/components/chat/assistant-message.blade.php
+++ b/www/resources/views/components/chat/assistant-message.blade.php
@@ -1,6 +1,6 @@
 {{-- Assistant message - responsive design using Tailwind breakpoints --}}
 <template x-if="msg.role === 'assistant'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="px-4 py-3 rounded-lg bg-gray-800">
             <div class="text-sm markdown-content" x-html="renderMarkdown(msg.content)"></div>
             <div class="text-xs mt-2 text-gray-400 flex items-center gap-2">

--- a/www/resources/views/components/chat/empty-response.blade.php
+++ b/www/resources/views/components/chat/empty-response.blade.php
@@ -1,6 +1,6 @@
 {{-- Empty response block - responsive design using Tailwind breakpoints --}}
 <template x-if="msg.role === 'empty-response'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="px-3 md:px-4 py-2 rounded-lg bg-gray-800/50 border border-gray-700/50">
             <div class="text-xs text-gray-500 flex items-center justify-between gap-2">
                 <span class="italic">No response content</span>

--- a/www/resources/views/components/chat/error-block.blade.php
+++ b/www/resources/views/components/chat/error-block.blade.php
@@ -1,6 +1,6 @@
 {{-- Error block - expandable, shows when job failed unexpectedly --}}
 <template x-if="msg.role === 'error'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="border border-red-500/30 rounded-lg bg-red-900/30 overflow-hidden">
             {{-- Header --}}
             <div class="flex items-center flex-wrap md:flex-nowrap gap-2 px-3 md:px-4 py-2 bg-red-900/30 md:border-b md:border-red-500/20 cursor-pointer"

--- a/www/resources/views/components/chat/interrupted-block.blade.php
+++ b/www/resources/views/components/chat/interrupted-block.blade.php
@@ -1,13 +1,11 @@
-{{-- Interrupted block - simple red bar indicating response was stopped --}}
+{{-- Interrupted block - styled like error header (no icon, not expandable) --}}
 <template x-if="msg.role === 'interrupted'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
-        <div class="flex items-center gap-2 px-3 md:px-4 py-2 rounded-lg border border-red-500/30 bg-red-900/30">
-            <svg class="w-4 h-4 text-red-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 10a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
-            </svg>
-            <span class="text-xs md:text-sm text-red-300">Response interrupted</span>
-            <span class="text-xs text-gray-500" x-text="formatTimestamp(msg.timestamp)"></span>
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
+        <div class="border border-red-500/30 rounded-lg bg-red-900/30 overflow-hidden">
+            <div class="flex items-center gap-2 px-3 md:px-4 py-2">
+                <span class="text-xs md:text-sm font-semibold text-red-300">Response interrupted</span>
+                <span class="text-xs text-gray-500" x-text="formatTimestamp(msg.timestamp)"></span>
+            </div>
         </div>
     </div>
 </template>

--- a/www/resources/views/components/chat/system-block.blade.php
+++ b/www/resources/views/components/chat/system-block.blade.php
@@ -1,6 +1,6 @@
 {{-- System info block - for /context, /usage, etc. --}}
 <template x-if="msg.role === 'system'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="border border-gray-600/30 rounded-lg bg-gray-800/50 overflow-hidden">
             {{-- Header --}}
             <div class="flex items-center gap-2 px-3 md:px-4 py-2 bg-gray-700/30 border-b border-gray-600/20">

--- a/www/resources/views/components/chat/thinking-block.blade.php
+++ b/www/resources/views/components/chat/thinking-block.blade.php
@@ -1,6 +1,6 @@
 {{-- Thinking block - responsive design using Tailwind breakpoints --}}
 <template x-if="msg.role === 'thinking'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="border border-purple-500/30 rounded-lg bg-purple-900/20 overflow-hidden">
             {{-- Header --}}
             <div class="flex items-center flex-wrap md:flex-nowrap gap-2 px-3 md:px-4 py-2 bg-purple-900/30 md:border-b md:border-purple-500/20 cursor-pointer"

--- a/www/resources/views/components/chat/tool-block.blade.php
+++ b/www/resources/views/components/chat/tool-block.blade.php
@@ -1,6 +1,6 @@
 {{-- Tool block - responsive design using Tailwind breakpoints --}}
 <template x-if="msg.role === 'tool'">
-    <div class="max-w-[85%] md:max-w-3xl w-full">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl w-full">
         <div class="border border-blue-500/30 rounded-lg bg-blue-900/20 overflow-hidden">
             {{-- Header --}}
             <div class="flex items-center flex-wrap md:flex-nowrap gap-2 px-3 md:px-4 py-2 bg-blue-900/30 md:border-b md:border-blue-500/20 cursor-pointer"

--- a/www/resources/views/components/chat/user-message.blade.php
+++ b/www/resources/views/components/chat/user-message.blade.php
@@ -1,6 +1,6 @@
 {{-- User message - responsive design using Tailwind breakpoints --}}
 <template x-if="msg.role === 'user'">
-    <div class="max-w-[85%] md:max-w-3xl">
+    <div class="max-w-[calc(100%-1rem)] md:max-w-3xl">
         <div class="px-4 py-3 rounded-lg bg-blue-600">
             <div class="text-sm whitespace-pre-wrap" x-text="msg.content"></div>
             <div class="text-xs mt-2 text-gray-300 text-right" x-text="formatTimestamp(msg.timestamp)"></div>


### PR DESCRIPTION
## Summary
- Change message max-width from 85% to calc(100%-1rem) for tighter spacing on mobile (leaves 16px gap on opposite side instead of 15%)
- Simplify interrupted block to match error header style (removed icon, non-expandable, font-semibold text)

## Test plan
- [ ] Test on mobile device/viewport to verify message width changes
- [ ] Verify interrupted messages display correctly without icon
- [ ] Check that all message types (user, assistant, tool, thinking, error, system, empty-response) have consistent spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined chat message container widths for improved responsive layout across all screen sizes
  * Updated interrupted message styling for enhanced visual consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->