### PR TITLE
Fix abort sync breaking conversation chain when queue-operation entries exist

### DIFF
--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -624,13 +624,17 @@ class ClaudeCodeProvider implements AIProviderInterface
         $file->seek(PHP_INT_MAX);
         $lastLine = $file->key();
 
-        // Read backwards to find last non-empty line (including the last line)
+        // Read backwards to find last entry with a uuid field
+        // (skip queue-operation and other metadata entries that don't have uuid)
         for ($i = $lastLine; $i >= 0; $i--) {
             $file->seek($i);
             $line = trim($file->current());
             if (!empty($line)) {
                 $data = json_decode($line, true);
-                return $data['uuid'] ?? null;
+                if (isset($data['uuid'])) {
+                    return $data['uuid'];
+                }
+                // Continue searching if this entry has no uuid (e.g., queue-operation)
             }
         }
 


### PR DESCRIPTION
## Summary
- `getLastUuidFromFile()` was returning `null` when the last line was a `queue-operation` entry (no uuid field)
- This caused synced aborted messages to have `parentUuid:null`, breaking the chain
- Claude Code interpreted `parentUuid:null` as a new conversation start, losing all prior context

## Fix
Skip entries without a uuid field and continue searching backwards until finding a proper message entry.

## Test plan
- [ ] Interrupt a conversation while Claude is mid-response
- [ ] Continue the conversation
- [ ] Verify Claude remembers the prior context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system stability by improving UUID identification logic to properly handle and skip entries without identifiers, ensuring the system continues searching for valid references when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->