### PR TITLE
Fix deploy postgres image to use custom image with PostGIS

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -66,8 +66,9 @@ services:
       start_period: 20s
 
   pocket-dev-postgres:
-    # pgvector/pgvector:pg17 includes pgvector extension for semantic search
-    image: pgvector/pgvector:pg17
+    # Custom postgres image with pgvector, PostGIS, and pg_trgm extensions
+    image: ghcr.io/tetrixdev/pocket-dev-postgres:${IMAGE_TAG:-latest}
+    pull_policy: always
     container_name: pocket-dev-postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary

- Fix `deploy/compose.yml` to use the custom postgres image instead of base `pgvector/pgvector:pg17`

## Problem

The migration `2025_12_26_000001_create_memory_schema_and_extensions.php` requires PostGIS:
```php
DB::statement('CREATE EXTENSION IF NOT EXISTS postgis');
```

But `deploy/compose.yml` was using `pgvector/pgvector:pg17` which only has pgvector, not PostGIS.

This caused the error:
```
SQLSTATE[0A000]: Feature not supported: 7 ERROR: extension "postgis" is not available
```

## Fix

Changed from:
```yaml
image: pgvector/pgvector:pg17
```

To:
```yaml
image: ghcr.io/tetrixdev/pocket-dev-postgres:${IMAGE_TAG:-latest}
pull_policy: always
```

The custom image is built from `docker-postgres/Dockerfile` and includes:
- pgvector (vector similarity search)
- PostGIS (spatial queries)  
- pg_trgm (fuzzy text search)

## Test plan
- [ ] Fresh deploy using `deploy/` files should complete migrations successfully
- [ ] PostGIS extension should be available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment to use a custom PostgreSQL image. The image is now automatically pulled on each startup to ensure the latest version is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->