### PR TITLE
Add -u www-data flag to docker exec commands in UI

### DIFF
--- a/www/config/backup.php
+++ b/www/config/backup.php
@@ -4,8 +4,8 @@ return [
     // Docker user/group for file permissions and exec commands
     // Local: must be set in .env (run `id -u` and `id -g` to get your values)
     // Production: falls back to www-data if not set
-    'user_id' => env('USER_ID') ?: (env('APP_ENV') === 'local' ? null : 'www-data'),
-    'group_id' => env('GROUP_ID') ?: (env('APP_ENV') === 'local' ? null : 'www-data'),
+    'user_id' => env('USER_ID', env('APP_ENV') === 'local' ? null : 'www-data'),
+    'group_id' => env('GROUP_ID', env('APP_ENV') === 'local' ? null : 'www-data'),
 
     'host_project_path' => env('HOST_PROJECT_PATH'),
 ];

--- a/www/resources/views/claude-auth.blade.php
+++ b/www/resources/views/claude-auth.blade.php
@@ -106,7 +106,7 @@
                 <!-- Docker Exec Tab -->
                 <div id="content-docker" class="tab-content hidden">
                     <p class="text-gray-300 mb-4">Run this command on your host machine to authenticate:</p>
-                    @if(config('backup.user_id'))
+                    @if(config('backup.user_id') !== null)
                         <div class="bg-gray-900 rounded p-4 mb-4">
                             <code class="text-sm text-green-400">docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude</code>
                         </div>

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -75,7 +75,7 @@
                 <!-- Docker Exec Tab (Subscription) -->
                 <div id="content-docker" class="tab-content">
                     <p class="text-gray-300 mb-4">Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise):</p>
-                    @if(config('backup.user_id'))
+                    @if(config('backup.user_id') !== null)
                         <div class="bg-gray-900 rounded p-4 mb-4">
                             <code class="text-sm text-green-400">docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue codex login --device-auth</code>
                         </div>
@@ -100,7 +100,7 @@
                 <div id="content-json" class="tab-content hidden">
                     <p class="text-gray-300 mb-4">Use an OpenAI API key for pay-per-use access:</p>
 
-                    @if(config('backup.user_id'))
+                    @if(config('backup.user_id') !== null)
                         <div class="bg-gray-900/50 border border-gray-700 rounded p-4 mb-4 text-sm">
                             <p class="text-gray-400 mb-2"><strong>Option 1:</strong> CLI command</p>
                             <code class="text-green-400">echo "sk-your-key" | docker exec -i -u {{ config('backup.user_id') }} pocket-dev-queue codex login --with-api-key</code>

--- a/www/resources/views/partials/chat/modals/claude-code-auth.blade.php
+++ b/www/resources/views/partials/chat/modals/claude-code-auth.blade.php
@@ -10,7 +10,7 @@
             <p class="text-gray-300 text-sm mb-3">
                 Use your monthly subscription. Run this command in your terminal:
             </p>
-            @if(config('backup.user_id'))
+            @if(config('backup.user_id') !== null)
                 <div class="bg-gray-900 rounded p-3 font-mono text-sm text-green-400 select-all">
                     docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude
                 </div>

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -108,7 +108,7 @@
                 <p class="text-sm text-gray-400 mb-4">
                     Run this command in your terminal to authenticate with your Claude Pro/Team subscription:
                 </p>
-                @if(config('backup.user_id'))
+                @if(config('backup.user_id') !== null)
                     <div class="relative">
                         <div
                             @click="copyCommand('docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude', 'claude')"
@@ -152,7 +152,7 @@
                 <p class="text-sm text-gray-400 mb-4">
                     Run this command on your <strong class="text-white">host machine</strong> (not in Docker) to authenticate:
                 </p>
-                @if(config('backup.user_id') && config('backup.group_id'))
+                @if(config('backup.user_id') !== null && config('backup.group_id') !== null)
                     <div class="relative">
                         <div
                             @click="copyCommand('sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json pocket-dev-queue:/home/appuser/.codex/auth.json && docker exec -u root pocket-dev-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec pocket-dev-queue chmod 600 /home/appuser/.codex/auth.json', 'codex')"


### PR DESCRIPTION
## Summary

Add `-u www-data` flag to all `docker exec` commands shown in the UI for CLI authentication setup.

## Problem

When running `docker exec -it pocket-dev-queue claude` without the `-u` flag:
1. Command runs as root (container's default user)
2. Credential files are created with `root:root` ownership
3. PHP-FPM (running as `www-data`) cannot read the credentials
4. Authentication appears to fail even though setup completed

## Fix

Added `-u www-data` to all docker exec commands:

| File | Command |
|------|---------|
| `setup/wizard.blade.php` | `docker exec -it -u www-data pocket-dev-queue claude` |
| `claude-code-auth.blade.php` | `docker exec -it -u www-data pocket-dev-queue claude` |
| `claude-auth.blade.php` | `docker exec -it -u www-data pocket-dev-php claude setup-token` |
| `codex-auth.blade.php` | `docker exec -it -u www-data pocket-dev-queue codex login --device-auth` |
| `codex-auth.blade.php` | `echo "..." \| docker exec -i -u www-data pocket-dev-queue codex login --with-api-key` |

## Test plan
- [ ] Run Claude setup command - credentials should be owned by www-data
- [ ] Run Codex setup command - credentials should be owned by www-data
- [ ] PHP should be able to read credentials after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Container command examples now run under the configured execution user to avoid permission/ownership issues.
  * Setup flows apply correct ownership when user/group are configured.

* **User Experience**
  * Commands are gated by configuration; clear red notices appear when USER_ID/GROUP_ID are missing.
  * Copy/verification UX improved with "Copied!" indicators and updated interactive login verification messaging.

* **Chores**
  * Environment-aware defaults for USER_ID/GROUP_ID added to configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->