### PR TITLE
fix: sync deploy compose.yml with root and clean up redundancy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,6 @@ services:
       - pocket-dev-nginx
     networks:
       - pocket-dev
-      - pocket-dev-public
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:80/health || exit 1"]
       interval: 10s
@@ -34,20 +33,20 @@ services:
     working_dir: /var/www
     # No 'user:' - container starts as root, entrypoint drops to TARGET_UID via gosu
     # This allows privileged operations (package install, permission fixes) before dropping privileges
-    group_add:
-      - "1000"
-      - "${DOCKER_GID:-1001}"
     environment:
       - HOME=/home/appuser
       - COMPOSER_HOME=/tmp/.composer
       - NPM_CONFIG_CACHE=/tmp/.npm
       - TARGET_UID=${USER_ID:-1000}
       - TARGET_GID=${GROUP_ID:-1000}
+      # TODO: Remove git credential env vars? git/gh CLI read from env directly.
+      # If removed, also clean up .env.example and docs.
       - GIT_TOKEN=${GIT_TOKEN:-}
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GIT_TOKEN:-}
       - HOST_PROJECT_PATH=${PWD}
+      # TODO: Remove ADDITIONAL_SYSTEM_PROMPT_FILE? Not used in deploy (file not baked/mounted).
       - ADDITIONAL_SYSTEM_PROMPT_FILE=${ADDITIONAL_SYSTEM_PROMPT_FILE:-/pocketdev/CLAUDE.md}
       - DOCKER_GID=${DOCKER_GID:-}
     entrypoint: ["/entrypoint.sh"]
@@ -146,20 +145,20 @@ services:
     restart: unless-stopped
     working_dir: /var/www
     # No 'user:' - container starts as root, entrypoint drops to TARGET_UID via gosu
-    group_add:
-      - "1000"
-      - "${DOCKER_GID:-1001}"
     entrypoint: ["/queue-entrypoint.sh"]
     # Command removed - supervisord in entrypoint manages multiple workers
     environment:
       - HOME=/home/appuser
       - TARGET_UID=${USER_ID:-1000}
       - TARGET_GID=${GROUP_ID:-1000}
+      # TODO: Remove git credential env vars? git/gh CLI read from env directly.
+      # If removed, also clean up .env.example and docs.
       - GIT_TOKEN=${GIT_TOKEN:-}
       - GIT_USER_NAME=${GIT_USER_NAME:-}
       - GIT_USER_EMAIL=${GIT_USER_EMAIL:-}
       - GH_TOKEN=${GIT_TOKEN:-}
       - HOST_PROJECT_PATH=${PWD}
+      # TODO: Remove ADDITIONAL_SYSTEM_PROMPT_FILE? Not used in deploy (file not baked/mounted).
       - ADDITIONAL_SYSTEM_PROMPT_FILE=${ADDITIONAL_SYSTEM_PROMPT_FILE:-/pocketdev/CLAUDE.md}
       - DOCKER_GID=${DOCKER_GID:-}
     volumes:
@@ -185,9 +184,6 @@ services:
 networks:
   pocket-dev:
     name: pocket-dev
-    driver: bridge
-  pocket-dev-public:
-    name: pocket-dev-public
     driver: bridge
 
 volumes:

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -34,6 +34,8 @@ services:
       - user-data:/home/appuser
       - workspace-data:/workspace
       - proxy-config-data:/etc/nginx-proxy-config
+      - pocketdev-storage:/var/www/storage/pocketdev
+      - shared-tmp:/tmp
     networks:
       - pocket-dev
     depends_on:


### PR DESCRIPTION
## Summary

- **Critical fix**: Add missing `pocketdev-storage` and `shared-tmp` volumes to deploy PHP container
  - Without these, PHP and queue containers couldn't share temp files or storage
- **Cleanup**: Remove redundant `group_add` from root compose (entrypoints handle docker group setup dynamically)
- **Cleanup**: Remove unused `pocket-dev-public` network from root compose
- **TODOs added** for future cleanup:
  - Git credential env vars (git/gh CLI read from env directly)
  - ADDITIONAL_SYSTEM_PROMPT_FILE (not used in deploy - file not baked/mounted)

## Test plan

- [ ] Verify deploy containers start correctly with new volume mounts
- [ ] Verify docker socket access still works in queue container (entrypoint handles group setup)
- [ ] Verify PHP and queue can share files via /tmp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented persistent storage volumes (pocketdev-storage and shared-tmp) for enhanced data management and shared temporary directory access across services
  * Streamlined container networking infrastructure by updating and simplifying network configuration settings
  * Updated environment variable configuration with additional system settings and deployment-related options
  * Adjusted service-level permissions and access control mechanisms across multiple services
  * Removed legacy network bridge references from service and network configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->