### PR TITLE
fix: remove incorrect $root prefix from Alpine method call

### DIFF
--- a/www/resources/views/partials/chat/modals/agent-selector.blade.php
+++ b/www/resources/views/partials/chat/modals/agent-selector.blade.php
@@ -90,7 +90,7 @@
                 <x-button
                     variant="ghost"
                     size="sm"
-                    @click="showAgentSelector = false; $root.openSystemPromptPreview()"
+                    @click="showAgentSelector = false; openSystemPromptPreview()"
                     x-show="currentAgentId"
                     title="View system prompt for selected agent"
                 >


### PR DESCRIPTION
## Summary
- Fixes the System Prompt button in the agent selector modal not working on mobile (and likely desktop too)
- Removes incorrect `$root.` prefix from `openSystemPromptPreview()` call

## Root Cause
Commit 356026f added `$root.` as part of CodeRabbit review feedback suggesting "explicit scope reference". However, in Alpine.js v3:
- `$root` refers to the root **DOM element**, not the Alpine data object
- The modal doesn't have its own `x-data`, so it already inherits the parent `chatApp()` scope
- Calling `$root.openSystemPromptPreview()` tries to invoke a method on the DOM element, which doesn't exist

## Test plan
- [ ] Open chat on mobile
- [ ] Tap agent name to open agent selector
- [ ] Select an agent
- [ ] Tap "System Prompt" button
- [ ] Verify the system prompt preview modal opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal function resolution for the System Prompt button functionality in the agent selector modal with no changes to user-facing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->