### PR TITLE
fix: unify memory section data source across all paths

### DIFF
--- a/www/app/Http/Controllers/Api/AgentController.php
+++ b/www/app/Http/Controllers/Api/AgentController.php
@@ -249,6 +249,12 @@ class AgentController extends Controller
         $memorySchemas = $request->input('memory_schemas', []);
         $workspaceId = $request->input('workspace_id');
         $workspace = $workspaceId ? Workspace::find($workspaceId) : null;
+        $inheritWorkspaceSchemas = $request->boolean('inherit_workspace_schemas', false);
+
+        // If inheriting from workspace, use workspace's enabled schemas
+        if ($inheritWorkspaceSchemas && $workspace) {
+            $memorySchemas = $workspace->enabledMemoryDatabases()->pluck('memory_databases.id')->toArray();
+        }
 
         // Use the same builder that generates actual conversation prompts
         $preview = $this->systemPromptBuilder->buildPreviewSections(

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -16,7 +16,7 @@
             const allowedPaths = @json(config('ai.file_preview.allowed_paths', ['/var/www']));
             // Escape all regex metacharacters, then strip leading /
             const escapeRegex = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-            const pathsPattern = allowedPaths.map(p => escapeRegex(p).replace(/^\\\//, '')).join('|');
+            const pathsPattern = allowedPaths.map(p => escapeRegex(p).replace(/^\//, '')).join('|');
             const filePathPattern = new RegExp(`((?:^|[^"'=\\w])((?:\\/(?:${pathsPattern})|\\.\\.\\/|\\.\\/|~\\/)[^\\s<>"'\`\\)]+\\.[a-zA-Z0-9]+))`, 'g');
             const escapeHtml = (text) => String(text)
                 .replace(/&/g, '&amp;')

--- a/www/resources/views/config/agents/form.blade.php
+++ b/www/resources/views/config/agents/form.blade.php
@@ -783,6 +783,7 @@
                             allowed_tools: this.allToolsSelected ? null : this.selectedTools,
                             memory_schemas: this.selectedSchemas,
                             workspace_id: workspaceId,
+                            inherit_workspace_schemas: this.inheritWorkspaceSchemas === '1' || this.inheritWorkspaceSchemas === true,
                         }),
                     });
                     if (!response.ok) {


### PR DESCRIPTION
## Summary

- `buildMemorySection()` now uses `buildMemoryPreviewHierarchy()` as single source of truth, then flattens it for the actual system prompt
- Agent form preview now sends `inherit_workspace_schemas` flag
- Backend `previewSystemPrompt` handles inheritance by fetching workspace schemas when flag is true
- All three paths (actual prompt, chat preview, agent form preview) now use the same data

This ensures the memory section in the actual system prompt includes full table details (descriptions, row counts, embed fields) matching what the preview displays.

## Before
- Actual CLI prompt: 710 chars (just schema names, no tables)
- Chat preview: 10,885 tokens (full table details)
- Agent form preview: broken when "inherit from workspace" selected

## After
- All three paths: ~10,885 tokens with full table details
- Agent form preview works correctly with inheritance

## Test plan
- [ ] Verify memory section appears in actual system prompt with table details
- [ ] Verify chat page preview shows Memory section
- [ ] Verify agent form preview shows Memory section when "Inherit from Workspace" is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace memory schema inheritance option to system prompt preview, automatically using workspace-defined memory databases when enabled.
  * Improved memory section presentation with enhanced hierarchy and flattening logic.

* **Bug Fixes**
  * Fixed leading slash normalization in file path pattern matching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->