### PR TITLE
Fix race condition when switching workspaces with default conversations

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1415,6 +1415,7 @@
                             // Clear old workspace state before loading new data
                             this.agents = [];
                             this.currentAgentId = null;
+                            this.currentConversationUuid = null;
 
                             // Reload conversations and agents for the new workspace
                             await this.fetchConversations();


### PR DESCRIPTION
## Summary

- When switching between workspaces that both have a default conversation with an agent assigned, the agent selector would incorrectly show "Select an Agent" instead of the correct agent
- Root cause: `selectAgent()` was called without `await` in `fetchAgents()`, causing it to overwrite the correct agent after `loadConversation()` had already set it
- Secondary issue: old workspace state wasn't cleared before loading new data

## Changes

- Add `await` to both `selectAgent()` calls in `fetchAgents()`
- Clear `agents[]` and `currentAgentId` at start of `selectWorkspace()` before loading new workspace data

## Test plan

- [ ] Switch from Workspace A (with default conversation using Agent X) to Workspace B (with default conversation using Agent Y)
- [ ] Verify Agent Y is shown in the selector, not "Select an Agent"
- [ ] Switch back to Workspace A, verify Agent X is shown
- [ ] Test switching to a workspace with no default conversation (should show default agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Await agent selection during automatic default selection to prevent race conditions.
  * Improved workspace switching: clears previous state, reloads agents and conversations, and restores or starts the appropriate conversation.

* **Public API**
  * Updated the agent selection API to allow conditional backend synchronization when switching agents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->