### PR TITLE
Add conversation renaming feature

### DIFF
--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -484,6 +484,25 @@ class ConversationController extends Controller
     }
 
     /**
+     * Update the conversation title.
+     */
+    public function updateTitle(Request $request, Conversation $conversation): JsonResponse
+    {
+        $validated = $request->validate([
+            'title' => 'required|string|max:30',
+        ]);
+
+        $conversation->update([
+            'title' => trim($validated['title']),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'title' => $conversation->title,
+        ]);
+    }
+
+    /**
      * Abort an active stream.
      *
      * Sets the abort flag which the job will check and terminate gracefully.

--- a/www/resources/views/partials/chat/mobile-layout.blade.php
+++ b/www/resources/views/partials/chat/mobile-layout.blade.php
@@ -6,7 +6,13 @@
         </svg>
     </button>
     <div class="flex flex-col items-center">
-        <h2 class="text-base font-semibold leading-tight">PocketDev</h2>
+        <button @click="openRenameModal()"
+                :disabled="!currentConversationUuid"
+                class="text-base font-semibold leading-tight hover:text-blue-400 transition-colors max-w-[30ch] truncate disabled:cursor-default disabled:hover:text-white"
+                :class="{ 'cursor-pointer': currentConversationUuid }"
+                :title="currentConversationUuid ? 'Click to rename' : ''"
+                x-text="currentConversationTitle || 'New Conversation'">
+        </button>
         <div class="flex items-center gap-2">
             <button @click="showAgentSelector = true"
                     class="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200 underline decoration-gray-600 hover:decoration-gray-400"
@@ -120,7 +126,7 @@
      style="display: none;">
     <div class="p-4 border-b border-gray-700">
         <div class="flex items-center justify-between mb-3">
-            <h2 class="text-lg font-semibold">Conversations</h2>
+            <h2 class="text-lg font-semibold">PocketDev</h2>
             {{-- Close drawer --}}
             <button @click="showMobileDrawer = false" class="w-8 h-8 flex items-center justify-center text-gray-400 hover:text-white">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/www/resources/views/partials/chat/modals.blade.php
+++ b/www/resources/views/partials/chat/modals.blade.php
@@ -10,6 +10,7 @@
 @include('partials.chat.modals.shortcuts')
 @include('partials.chat.modals.error')
 @include('partials.chat.modals.conversation-search')
+@include('partials.chat.modals.rename-conversation')
 
 {{-- File Preview Modal --}}
 <x-file-preview-modal />

--- a/www/resources/views/partials/chat/modals/rename-conversation.blade.php
+++ b/www/resources/views/partials/chat/modals/rename-conversation.blade.php
@@ -1,0 +1,34 @@
+{{-- Rename Conversation Modal --}}
+<x-modal show="showRenameModal" title="Rename Conversation" max-width="sm">
+    <div class="space-y-4">
+        <x-text-input
+            type="text"
+            x-model="renameTitle"
+            x-ref="renameTitleInput"
+            @keydown.enter="saveConversationTitle()"
+            @keydown.escape="showRenameModal = false"
+            placeholder="Enter conversation name..."
+            label="Title"
+            maxlength="30"
+        />
+
+        <p class="text-gray-500 text-xs">
+            Maximum 30 characters. This name will appear in the header and sidebar.
+        </p>
+
+        <div class="flex gap-2">
+            <x-button variant="secondary" class="flex-1" @click="showRenameModal = false">
+                Cancel
+            </x-button>
+            <x-button
+                variant="primary"
+                class="flex-1"
+                @click="saveConversationTitle()"
+                :disabled="!renameTitle.trim() || renameSaving"
+            >
+                <span x-show="!renameSaving">Save</span>
+                <span x-show="renameSaving">Saving...</span>
+            </x-button>
+        </div>
+    </div>
+</x-modal>

--- a/www/resources/views/partials/chat/sidebar.blade.php
+++ b/www/resources/views/partials/chat/sidebar.blade.php
@@ -1,7 +1,7 @@
 {{-- Desktop Sidebar --}}
 <div class="w-64 h-full bg-gray-800 border-r border-gray-700 flex flex-col">
     <div class="p-4 border-b border-gray-700">
-        <h2 class="text-lg font-semibold mb-3">Conversations</h2>
+        <h2 class="text-lg font-semibold mb-3">PocketDev</h2>
         <div class="flex items-center gap-2">
             {{-- New conversation button (green) --}}
             <button @click="newConversation()"

--- a/www/routes/api.php
+++ b/www/routes/api.php
@@ -83,6 +83,7 @@ Route::prefix('conversations/{conversation}')->group(function () {
     Route::post('archive', [ConversationController::class, 'archive']);
     Route::post('unarchive', [ConversationController::class, 'unarchive']);
     Route::patch('agent', [ConversationController::class, 'switchAgent']);
+    Route::patch('title', [ConversationController::class, 'updateTitle']);
 });
 
 /*


### PR DESCRIPTION
## Summary

- Add clickable conversation title in header (replaces static "PocketDev")
- Tapping title opens a modal to rename the conversation
- New API endpoint: `PATCH /api/conversations/{uuid}/title`
- Sidebar header changed from "Conversations" to "PocketDev"
- Max 30 characters for titles

## Test plan

- [ ] Load an existing conversation - title should appear in header
- [ ] Click the title - rename modal should open with current title
- [ ] Enter a new name and save - title updates in header and sidebar
- [ ] Press Escape or Cancel to close modal without saving
- [ ] New conversation shows "New Conversation" (not clickable until saved)
- [ ] Test on mobile - same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now rename conversations by clicking the header button
  * Renamed titles persist and display in the chat header across sessions
  * Modal dialog with 30-character limit ensures valid conversation names
  * Rename functionality available on both desktop and mobile layouts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->