### PR TITLE
Fix memory schema import to create MemoryDatabase record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .idea/
 .claude/
+worktrees/


### PR DESCRIPTION
## Summary
- Fix bug where importing a memory schema to a new name created the PostgreSQL schema but not the MemoryDatabase record, causing imported schemas to be invisible in the UI
- Handle edge case of soft-deleted records by restoring them instead of creating duplicates
- Add `worktrees/` to .gitignore for git worktree cleanup

## Test plan
- [ ] Export an existing memory schema
- [ ] Import to a new schema name
- [ ] Verify the new schema appears in the Memory overview
- [ ] Delete a memory database (soft delete)
- [ ] Import to that same schema name
- [ ] Verify the soft-deleted record is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to ignore worktrees directory.

* **Bug Fixes**
  * Enhanced import process to automatically ensure memory database records are properly created or restored for target schemas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->