### PR TITLE
Fix memory schema prefix stripping to only remove leading prefix

### DIFF
--- a/www/app/Services/MemorySnapshotService.php
+++ b/www/app/Services/MemorySnapshotService.php
@@ -918,7 +918,8 @@ class MemorySnapshotService
             @unlink($path);
 
             // Ensure MemoryDatabase record exists for the target schema
-            $targetSchemaShortName = str_replace('memory_', '', $targetSchema);
+            // Use preg_replace to only strip leading 'memory_' prefix, not all occurrences
+            $targetSchemaShortName = preg_replace('/^memory_/', '', $targetSchema);
             $memoryDb = MemoryDatabase::where('schema_name', $targetSchemaShortName)->first();
             if (!$memoryDb) {
                 // Check if there's a soft-deleted record we can restore


### PR DESCRIPTION
## Summary
- Fix `str_replace('memory_', '', ...)` which removed ALL occurrences of `memory_`
- Use `preg_replace('/^memory_/', '', ...)` to only strip the leading prefix
- Prevents mangling schema names like `memory_memory_test` → `_test`

## Context
Addresses CodeRabbit review feedback from PR #106.

## Test plan
- [ ] Import a schema with `memory_` in the name (e.g., export `memory_test`, import as `memory_memory_test`)
- [ ] Verify the MemoryDatabase record has correct `schema_name` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory database handling during backup and post-restore operations by refining how schema references are processed. This ensures more accurate database lookups and prevents potential data inconsistencies when managing memory database snapshots, enhancing overall reliability across the backup and recovery workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->