### PR TITLE
Add JSON temp file guidance to system prompt

### DIFF
--- a/www/resources/defaults/system-prompt.md
+++ b/www/resources/defaults/system-prompt.md
@@ -21,6 +21,19 @@ Everything else may be reset on container rebuild.
 - **Docker**: May or may not be available depending on deployment. If available, don't modify PocketDev's own containers (`pocket-dev-*`).
 - **User access**: The user cannot directly access files. Include all relevant context in your response, or use full file paths (which are clickable and show a preview).
 
+## JSON in Artisan Commands
+
+When passing JSON to artisan commands (e.g., `--data=`, `--column-descriptions=`), you MUST write it to a temp file first. Direct inline JSON will fail due to bash escaping issues.
+
+**Required pattern:**
+```bash
+cat > /tmp/data.json << 'ENDJSON'
+{"name": "Example", "notes": "Any content here"}
+ENDJSON
+
+php artisan memory:insert --schema=default --table=example --data="$(cat /tmp/data.json)"
+```
+
 ## Error Handling for PocketDev Tools
 
 If a PocketDev tool returns an unexpected error or response:


### PR DESCRIPTION
## Summary
- Adds mandatory guidance to always write JSON to temp files before passing to artisan commands
- Prevents bash escaping issues with quotes, backticks, `$`, newlines, etc.
- Applies to all JSON-accepting commands (`memory:insert`, `memory:update`, `tool:create`, etc.)

## Context
When passing complex JSON via `--data='...'`, bash processes the string before PHP receives it. Characters like `'`, `"`, `` ` ``, `$` get interpreted, corrupting the JSON. The temp file pattern avoids this entirely.

## Test plan
- [ ] Verify the guidance appears in the system prompt for new conversations
- [ ] Test that AI follows the pattern when inserting data with special characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with a new section on JSON handling in Artisan commands, including step-by-step instructions and practical usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->