### PR TITLE
feat: Add markdown rendering to user messages

### DIFF
--- a/www/resources/views/components/chat/user-message.blade.php
+++ b/www/resources/views/components/chat/user-message.blade.php
@@ -2,7 +2,7 @@
 <template x-if="msg.role === 'user'">
     <div class="max-w-[calc(100%-1rem)] md:max-w-3xl">
         <div class="px-4 py-3 rounded-lg bg-blue-600">
-            <div class="text-sm whitespace-pre-wrap" x-text="msg.content"></div>
+            <div class="text-sm markdown-content" x-html="renderMarkdown(msg.content)"></div>
             <div class="text-xs mt-2 text-gray-300 flex items-center justify-end gap-2">
                 <span x-text="formatTimestamp(msg.timestamp)"></span>
                 <button @click="copyMessageContent(msg)" class="text-gray-300 hover:text-white transition-colors relative" title="Copy message">


### PR DESCRIPTION
## Summary
- Apply markdown/HTML styling to user messages (same as assistant messages)
- Enables rendering of bold, italic, code blocks, lists, links, etc. when users paste formatted content

## Changes
- Replace `x-text` with `x-html="renderMarkdown(msg.content)"` in user message component
- Add `markdown-content` class for consistent styling

## Test plan
- [ ] Type `**bold**` and `*italic*` in chat - should render formatted
- [ ] Paste a code block with triple backticks - should render with syntax highlighting
- [ ] Paste a bullet list - should render as proper list
- [ ] Verify links still work (may be less visible on blue background but should have underline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User chat messages now fully support Markdown formatting, enabling text styling options such as bold, italics, lists, code blocks, and links. This enhancement provides improved message readability and visual presentation in conversations. Existing features including message timestamps, copy functionality, and all other message actions remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->