### PR TITLE
Fix potential audio cutoff when stopping voice recording

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -4156,6 +4156,7 @@
 
                 stopFileUploadRecording() {
                     if (this.mediaRecorder && this.mediaRecorder.state !== 'inactive') {
+                        this.mediaRecorder.requestData(); // Flush any pending audio before stopping
                         this.mediaRecorder.stop();
                         this.isRecording = false;
                         this.isProcessing = true; // Show processing state while uploading
@@ -4208,7 +4209,7 @@
                         if (data.success && data.transcription) {
                             // Append to existing prompt (preserve what user typed)
                             const existing = this.prompt.trim();
-                            this.prompt = existing ? existing + ' ' + data.transcription : data.transcription;
+                            this.prompt = existing ? existing + '\n\n' + data.transcription : data.transcription;
 
                             if (this.autoSendAfterTranscription) {
                                 this.autoSendAfterTranscription = false;
@@ -4233,8 +4234,8 @@
                 async startRealtimeRecording() {
                     try {
                         this.isProcessing = true;
-                        // Preserve existing prompt text, add space if needed
-                        this.realtimeTranscript = this.prompt.trim() ? this.prompt.trim() + ' ' : '';
+                        // Preserve existing prompt text, add newlines if needed
+                        this.realtimeTranscript = this.prompt.trim() ? this.prompt.trim() + '\n\n' : '';
                         this.currentTranscriptItemId = null;
 
                         // Get ephemeral token from backend


### PR DESCRIPTION
## Summary
- Call `requestData()` before `stop()` to flush any pending audio from the MediaRecorder buffer, preventing potential cutoff of the last sentence when clicking stop quickly
- Change separator between existing prompt text and new transcription from single space to two newlines for better visual separation
- Apply same newline separator to realtime recording mode for consistency

## Test plan
- [ ] Record a voice message and click stop immediately after finishing a sentence - verify no cutoff
- [ ] Record multiple voice messages in sequence - verify they're separated by blank line
- [ ] Test with existing text in prompt field before recording - verify proper newline separation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio data capture during file uploads to ensure all pending data is processed.
  * Enhanced transcription formatting to provide better separation and readability when appending transcriptions to prompts in both file-upload and realtime transcription modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->