### PR TITLE
fix: Update production queue entrypoint to use PD_DOCKER_GID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This guide is for developers who want to contribute to PocketDev itself.
 git clone https://github.com/tetrixdev/pocket-dev.git
 cd pocket-dev
 
-# Run setup (auto-detects USER_ID, GROUP_ID, DOCKER_GID)
+# Run setup (auto-detects and sets PD_USER_ID, PD_GROUP_ID, PD_DOCKER_GID)
 ./setup.sh
 
 # Start development environment
@@ -129,4 +129,4 @@ docker compose down -v && docker compose up -d
 ```
 
 **Permission issues?**
-Check that USER_ID and GROUP_ID in `.env` match your host user (`id -u` and `id -g`).
+Check that `PD_USER_ID` and `PD_GROUP_ID` in `.env` match your host user (`id -u` and `id -g`).

--- a/docker-laravel/production/php/queue-entrypoint.sh
+++ b/docker-laravel/production/php/queue-entrypoint.sh
@@ -16,23 +16,24 @@ echo "Starting queue container initialization..."
 # =============================================================================
 
 # Set up Docker socket access for www-data
-if [ -n "$DOCKER_GID" ]; then
+# PD_DOCKER_GID is passed from compose.yml and matches the host's docker group
+if [ -n "$PD_DOCKER_GID" ]; then
     echo "🐳 Setting up Docker socket access for www-data..."
 
     # Create the docker group with the host's GID if it doesn't exist
-    if ! getent group "$DOCKER_GID" > /dev/null 2>&1; then
-        groupadd -g "$DOCKER_GID" hostdocker_runtime 2>/dev/null || true
+    if ! getent group "$PD_DOCKER_GID" > /dev/null 2>&1; then
+        groupadd -g "$PD_DOCKER_GID" hostdocker_runtime 2>/dev/null || true
     fi
 
     # Get the group name for this GID
-    DOCKER_GROUP_NAME=$(getent group "$DOCKER_GID" | cut -d: -f1)
+    DOCKER_GROUP_NAME=$(getent group "$PD_DOCKER_GID" | cut -d: -f1)
     if [ -z "$DOCKER_GROUP_NAME" ]; then
         DOCKER_GROUP_NAME="hostdocker_runtime"
     fi
 
     # Add www-data to docker group
     usermod -aG "$DOCKER_GROUP_NAME" www-data 2>/dev/null || true
-    echo "  ✅ Added www-data to group $DOCKER_GROUP_NAME (GID $DOCKER_GID)"
+    echo "  ✅ Added www-data to group $DOCKER_GROUP_NAME (GID $PD_DOCKER_GID)"
 
     # Ensure docker socket has correct group ownership
     if [ -S /var/run/docker.sock ]; then

--- a/www/app/Http/Controllers/BackupController.php
+++ b/www/app/Http/Controllers/BackupController.php
@@ -423,7 +423,7 @@ class BackupController extends Controller
         $groupId = config('backup.group_id');
 
         if ($userId === null || $groupId === null || $userId === '' || $groupId === '') {
-            throw new \RuntimeException('USER_ID and GROUP_ID must be set in .env for volume permission fixes');
+            throw new \RuntimeException('PD_USER_ID and PD_GROUP_ID must be set in .env for volume permission fixes');
         }
 
         // user-data: needs host user ownership for CLI tools (Claude, Codex, etc.)

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -141,7 +141,7 @@
                     </p>
                 @else
                     <div class="bg-red-900/50 border border-red-500/50 rounded p-3 text-red-300 text-sm mb-3">
-                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">USER_ID</code> in your .env file.
+                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">PD_USER_ID</code> in your .env file.
                         <span class="text-red-400 text-xs block mt-1">Run <code>id -u</code> on your host to get the value.</span>
                     </div>
                 @endif
@@ -182,7 +182,7 @@
                     </div>
                 @else
                     <div class="bg-red-900/50 border border-red-500/50 rounded p-3 text-red-300 text-sm mb-3">
-                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">USER_ID</code> and <code class="bg-red-900 px-1 rounded">GROUP_ID</code> in your .env file.
+                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">PD_USER_ID</code> and <code class="bg-red-900 px-1 rounded">PD_GROUP_ID</code> in your .env file.
                         <span class="text-red-400 text-xs block mt-1">Run <code>id -u</code> and <code>id -g</code> on your host to get the values.</span>
                     </div>
                 @endif


### PR DESCRIPTION
## Summary

- Fixes Docker socket permission issue in production deployments introduced in v0.27.0
- The production queue entrypoint was missed during the `PD_` prefix migration
- Also updates documentation/UI to reference correct `PD_*` variable names

## Root Cause

In commit `a23754d` (feat: prefix all env vars with PD_ to prevent bleeding), the file `docker-laravel/production/php/queue-entrypoint.sh` was not updated. It continued checking for `$DOCKER_GID` while `deploy/compose.yml` was updated to pass `$PD_DOCKER_GID`.

Result: The Docker socket permission setup block never executed, leaving `www-data` without access to the Docker socket.

## Changes

| File | Change |
|------|--------|
| `docker-laravel/production/php/queue-entrypoint.sh` | Replace `DOCKER_GID` → `PD_DOCKER_GID` (5 occurrences) |
| `CONTRIBUTING.md` | Update variable name references |
| `www/resources/views/setup/wizard.blade.php` | Update error messages to show `PD_USER_ID`/`PD_GROUP_ID` |
| `www/app/Http/Controllers/BackupController.php` | Update error message |

## Test plan

- [ ] Deploy to production environment
- [ ] Verify queue container starts with Docker socket access: `docker exec pocket-dev-queue id www-data` should include the `hostdocker_runtime` group
- [ ] Verify Docker commands work: `docker exec pocket-dev-queue docker ps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup documentation and troubleshooting guides to reflect new environment variable naming conventions for consistency.

* **Chores**
  * Updated environment variable references across initialization scripts, error messages, and configuration displays to align with new naming scheme.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->