### PR TITLE
fix: Add Docker socket and UID/GID config to deploy PHP container

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -33,7 +33,7 @@ services:
       - HOME=/home/appuser
       - PD_TARGET_UID=${PD_USER_ID:-1000}
       - PD_TARGET_GID=${PD_GROUP_ID:-1000}
-      - PD_HOST_PROJECT_PATH=${PWD}
+      - PD_HOST_PROJECT_PATH=${PD_HOST_PROJECT_PATH:-${PWD}}
       - PD_DOCKER_GID=${PD_DOCKER_GID:-}
     volumes:
       - .env:/var/www/.env


### PR DESCRIPTION
## Summary
- Adds Docker socket mount to `pocket-dev-php` service in `deploy/compose.yml`
- Adds environment variables for UID/GID configuration to match local development setup

## Problem
The backup feature fails in deployed instances with:
```
failed to connect to the docker API at unix:///var/run/docker.sock: no such file or directory
```

This is because the PHP container needs Docker socket access to:
- Run `pg_dump` via `docker exec`
- Export volumes via `docker run`
- Fix permissions after restore

Additionally, the UID/GID environment variables were not being passed, which prevented proper file ownership configuration.

## Changes
Added to `pocket-dev-php` service:

**Environment variables:**
- `HOME=/home/appuser`
- `PD_TARGET_UID=${PD_USER_ID:-1000}`
- `PD_TARGET_GID=${PD_GROUP_ID:-1000}`
- `PD_HOST_PROJECT_PATH=${PWD}`
- `PD_DOCKER_GID=${PD_DOCKER_GID:-}`

**Volume mount:**
- `/var/run/docker.sock:/var/run/docker.sock`

## Test plan
- [ ] Deploy with updated compose.yml
- [ ] Verify backup creation works
- [ ] Verify backup restore works
- [ ] Verify UID/GID can be configured via `.env`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled Docker-in-container capability by mounting the host Docker socket into the PHP development container.
  * Added environment-driven settings to configure container user IDs and the host project path, improving flexibility of the development environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->