### PR TITLE
feat: add clipboard image paste support

### DIFF
--- a/www/resources/views/partials/chat/input-desktop.blade.php
+++ b/www/resources/views/partials/chat/input-desktop.blade.php
@@ -185,7 +185,25 @@
                       @keydown.ctrl.t.prevent="cycleReasoningLevel()"
                       @keydown.ctrl.space.prevent="toggleVoiceRecording()"
                       @keydown="handleSkillKeydown($event)"
-                      @keydown.enter="if (!$event.shiftKey && !showSkillSuggestions) { $event.preventDefault(); sendMessage(); }"></textarea>
+                      @keydown.enter="if (!$event.shiftKey && !showSkillSuggestions) { $event.preventDefault(); sendMessage(); }"
+                      @paste="
+                          const items = $event.clipboardData?.items;
+                          if (items) {
+                              for (const item of items) {
+                                  if (item.type.startsWith('image/')) {
+                                      const blob = item.getAsFile();
+                                      if (blob) {
+                                          const now = new Date();
+                                          const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+                                          const ext = item.type.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+                                          const filename = `pasted-image-${timestamp}.${ext}`;
+                                          const file = new File([blob], filename, { type: item.type });
+                                          Alpine.store('attachments').addFile(file);
+                                      }
+                                  }
+                              }
+                          }
+                      "></textarea>
 
             {{-- Skill Suggestions Dropdown --}}
             <div x-show="showSkillSuggestions"

--- a/www/resources/views/partials/chat/input-mobile.blade.php
+++ b/www/resources/views/partials/chat/input-mobile.blade.php
@@ -41,7 +41,25 @@
                       style="height: 40px; min-height: 40px; max-height: 168px; overflow-y: hidden;"
                       x-effect="prompt; $nextTick(() => { $el.style.height = 'auto'; const sh = $el.scrollHeight; $el.style.height = Math.min(sh, 168) + 'px'; $el.style.overflowY = sh > 168 ? 'auto' : 'hidden'; if (prompt) $el.scrollTop = $el.scrollHeight; }); updateSkillSuggestions();"
                       @keydown="handleSkillKeydown($event)"
-                      @keydown.enter="if (!$event.shiftKey && !showSkillSuggestions) { $event.preventDefault(); sendMessage(); }"></textarea>
+                      @keydown.enter="if (!$event.shiftKey && !showSkillSuggestions) { $event.preventDefault(); sendMessage(); }"
+                      @paste="
+                          const items = $event.clipboardData?.items;
+                          if (items) {
+                              for (const item of items) {
+                                  if (item.type.startsWith('image/')) {
+                                      const blob = item.getAsFile();
+                                      if (blob) {
+                                          const now = new Date();
+                                          const timestamp = now.toISOString().replace(/[-:T]/g, '').slice(0, 14);
+                                          const ext = item.type.split('/')[1]?.replace('jpeg', 'jpg') || 'png';
+                                          const filename = `pasted-image-${timestamp}.${ext}`;
+                                          const file = new File([blob], filename, { type: item.type });
+                                          Alpine.store('attachments').addFile(file);
+                                      }
+                                  }
+                              }
+                          }
+                      "></textarea>
 
             {{-- Skill Suggestions Dropdown (Mobile) --}}
             <div x-show="showSkillSuggestions"


### PR DESCRIPTION
## Summary
- Add ability to paste images from clipboard directly into chat textarea
- Images are automatically uploaded as attachments using existing attachment system
- Auto-generates filenames as `pasted-image-YYYYMMDDHHMMSS.png/jpg`
- Works on both desktop and mobile views

## Test plan
- [ ] Copy a screenshot to clipboard (e.g., with Print Screen or snipping tool)
- [ ] Click in chat textarea and press Ctrl+V / Cmd+V
- [ ] Verify image appears in attachments list with auto-generated filename
- [ ] Verify upload progress shows and completes
- [ ] Verify normal text paste still works (copy text, paste into textarea)
- [ ] Send a message with pasted image and verify Claude can read it
- [ ] Test on mobile view (resize browser or use device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paste image support: Users can now paste images directly into the chat input on both desktop and mobile platforms. Pasted images are automatically processed and added to message attachments without requiring file browser navigation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->