### PR TITLE
fix: Add storage/cache permission fixes to production entrypoints

### DIFF
--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -30,6 +30,12 @@ PD_NGINX_PORT=80
 # Required for Docker operations from within PocketDev
 PD_DOCKER_GID=
 
+# User/Group IDs for file ownership (auto-detected by setup.sh)
+# Files in volumes will be owned by this UID:GID
+# Defaults to 1000:1000 if not set
+PD_USER_ID=
+PD_GROUP_ID=
+
 # Proxy deployment mode (local or production)
 # Production mode enables IP blocking for direct IP access
 PD_DEPLOYMENT_MODE=local

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -68,6 +68,13 @@ else
     echo "Warning: Docker socket not found - PD_DOCKER_GID not set"
 fi
 
+# Detect current user's UID/GID for file ownership
+USER_ID=$(id -u)
+GROUP_ID=$(id -g)
+sedi "s|PD_USER_ID=|PD_USER_ID=$USER_ID|" .env
+sedi "s|PD_GROUP_ID=|PD_GROUP_ID=$GROUP_ID|" .env
+echo "Detected PD_USER_ID=$USER_ID, PD_GROUP_ID=$GROUP_ID"
+
 # Ask for NGINX_PORT
 echo ""
 read -p "HTTP port for PocketDev [80]: " NGINX_PORT

--- a/docker-laravel/local/php/entrypoint.sh
+++ b/docker-laravel/local/php/entrypoint.sh
@@ -70,18 +70,19 @@ if [ $# -eq 0 ] || [ "$1" = "php-fpm" ]; then
     # Main PHP container: run full setup
 
     # Fix storage and cache permissions (as root)
+    # Use 2775 (setgid) so new files inherit the group
     echo "Setting storage permissions..."
     chgrp -R "$TARGET_GID" /var/www/storage /var/www/bootstrap/cache 2>/dev/null || true
-    find /var/www/storage -type d -exec chmod 775 {} \; 2>/dev/null || true
+    find /var/www/storage -type d -exec chmod 2775 {} \; 2>/dev/null || true
     find /var/www/storage -type f -exec chmod 664 {} \; 2>/dev/null || true
-    find /var/www/bootstrap/cache -type d -exec chmod 775 {} \; 2>/dev/null || true
+    find /var/www/bootstrap/cache -type d -exec chmod 2775 {} \; 2>/dev/null || true
     find /var/www/bootstrap/cache -type f -exec chmod 664 {} \; 2>/dev/null || true
 
     # Fix permissions for mounted config volumes (for config editor)
     if [ -d "/etc/nginx-proxy-config" ]; then
         echo "Setting permissions on /etc/nginx-proxy-config..."
         chgrp -R "$TARGET_GID" /etc/nginx-proxy-config 2>/dev/null || true
-        find /etc/nginx-proxy-config -type d -exec chmod 775 {} \; 2>/dev/null || true
+        find /etc/nginx-proxy-config -type d -exec chmod 2775 {} \; 2>/dev/null || true
         find /etc/nginx-proxy-config -type f -exec chmod 664 {} \; 2>/dev/null || true
     fi
 

--- a/docker-laravel/production/php/entrypoint.sh
+++ b/docker-laravel/production/php/entrypoint.sh
@@ -137,6 +137,28 @@ for d in /tmp/pocketdev /tmp/pocketdev-uploads; do
     find "$d" -type f -exec chmod 664 {} \; 2>/dev/null || true
 done
 
+# =============================================================================
+# STORAGE AND CACHE PERMISSIONS
+# =============================================================================
+# Fix permissions on Laravel storage and cache directories.
+# Production images bake in files as www-data:www-data, but queue workers run as
+# TARGET_USER. This ensures both PHP-FPM (www-data) and queue workers can write.
+
+echo "Setting storage permissions..."
+chgrp -R "$TARGET_GID" /var/www/storage /var/www/bootstrap/cache 2>/dev/null || true
+find /var/www/storage -type d -exec chmod 2775 {} \; 2>/dev/null || true
+find /var/www/storage -type f -exec chmod 664 {} \; 2>/dev/null || true
+find /var/www/bootstrap/cache -type d -exec chmod 2775 {} \; 2>/dev/null || true
+find /var/www/bootstrap/cache -type f -exec chmod 664 {} \; 2>/dev/null || true
+
+# Fix permissions for mounted config volumes (for config editor)
+if [ -d "/etc/nginx-proxy-config" ]; then
+    echo "Setting permissions on /etc/nginx-proxy-config..."
+    chgrp -R "$TARGET_GID" /etc/nginx-proxy-config 2>/dev/null || true
+    find /etc/nginx-proxy-config -type d -exec chmod 2775 {} \; 2>/dev/null || true
+    find /etc/nginx-proxy-config -type f -exec chmod 664 {} \; 2>/dev/null || true
+fi
+
 # Check if running as main PHP container (no args or php-fpm)
 # vs secondary container (queue worker, scheduler, etc.)
 if [ $# -eq 0 ] || [ "$1" = "php-fpm" ]; then


### PR DESCRIPTION
## Summary
- Add storage/cache permission fixes to production PHP and queue entrypoints
- Add nginx-proxy-config permission fixes to both production entrypoints
- Add storage/cache and supervisor log fixes to local queue entrypoint
- Use setgid (2775) consistently across all entrypoints for new file inheritance
- Add PD_USER_ID and PD_GROUP_ID auto-detection in deploy setup

## Problem
Production entrypoints were missing permission fixes for `/var/www/storage` and `/var/www/bootstrap/cache`. This caused queue workers to crash with "permission denied" when trying to write to log files.

**Root cause**: Production images bake in files as `www-data:www-data`, but queue workers run as `TARGET_USER` (appuser). Without fixing permissions, queue workers can't write to `storage/logs/laravel.log`.

## Solution
Add the same permission fix logic that local entrypoints already had:
```bash
chgrp -R "$TARGET_GID" /var/www/storage /var/www/bootstrap/cache
find /var/www/storage -type d -exec chmod 2775 {} \;
find /var/www/storage -type f -exec chmod 664 {} \;
```

Using `2775` (setgid) ensures new files created in these directories inherit the group, so both PHP-FPM (www-data in appgroup) and queue workers (appuser) can read/write.

## Test plan
- [ ] Deploy with fresh volumes - verify storage permissions are 2775/664
- [ ] Start a chat conversation - verify queue workers can write to laravel.log
- [ ] Check that both PHP container and queue container can create files in storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Automatic detection and setup of user/group IDs during deployment to ensure proper file ownership in Docker containers
* Improved file permissions for storage and cache directories using setgid to enable group inheritance for newly created files
* Enhanced permission configuration for queue workers and web server processes to prevent access conflicts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->