### PR TITLE
Allow typing and voice input while streaming responses

### DIFF
--- a/www/resources/views/partials/chat/input-desktop.blade.php
+++ b/www/resources/views/partials/chat/input-desktop.blade.php
@@ -5,7 +5,7 @@
         <button type="button"
                 @click="toggleVoiceRecording()"
                 :class="voiceButtonClass"
-                :disabled="isProcessing || isStreaming || waitingForFinalTranscript"
+                :disabled="isProcessing || waitingForFinalTranscript"
                 class="px-4 py-[10px] min-w-[106px] rounded-lg font-medium text-sm flex items-center justify-center gap-2 transition-colors cursor-pointer disabled:cursor-not-allowed"
                 title="Voice input (Ctrl+Space)"
                 @keydown.ctrl.space.window.prevent="toggleVoiceRecording()"
@@ -176,7 +176,6 @@
 
             <textarea x-model="prompt"
                       x-ref="promptInput"
-                      :disabled="isStreaming"
                       :placeholder="activeSkill ? 'Add additional context... (optional)' : 'Hey PocketDev, can you... (type / for skills)'"
                       rows="1"
                       class="block w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500 text-white resize-none"

--- a/www/resources/views/partials/chat/input-mobile.blade.php
+++ b/www/resources/views/partials/chat/input-mobile.blade.php
@@ -6,7 +6,7 @@
         <button type="button"
                 @click="toggleVoiceRecording()"
                 :class="voiceButtonClass"
-                :disabled="isProcessing || isStreaming || waitingForFinalTranscript"
+                :disabled="isProcessing || waitingForFinalTranscript"
                 class="w-12 py-[10px] rounded-lg text-xl flex items-center justify-center transition-colors cursor-pointer disabled:cursor-not-allowed"
                 title="Voice input">
             <i :class="isProcessing || waitingForFinalTranscript ? 'fa-solid fa-spinner fa-spin' : (isRecording ? 'fa-solid fa-stop' : 'fa-solid fa-microphone')"></i>
@@ -34,7 +34,6 @@
 
             <textarea x-model="prompt"
                       x-ref="promptInput"
-                      :disabled="isStreaming"
                       :placeholder="activeSkill ? 'Add context... (optional)' : 'Hey PocketDev... (/ for skills)'"
                       rows="1"
                       class="block w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded-lg focus:outline-none focus:border-blue-500 text-white resize-none"


### PR DESCRIPTION
## Summary
- Remove `isStreaming` from disabled conditions on textarea and voice button
- Users can now prepare follow-up messages while waiting for responses
- Applies to both desktop and mobile input components

## Test plan
- [ ] Start a conversation that generates a long response
- [ ] While streaming, verify you can type in the textarea
- [ ] While streaming, verify you can use voice recording
- [ ] Verify the Stop button still works to abort streaming
- [ ] Verify sending still works after streaming completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Users can now continue typing in the chat input and use the voice button while the AI is streaming responses, instead of having these inputs disabled during streaming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->