### PR TITLE
fix: Use config() instead of env() in memory_ai migration

### DIFF
--- a/www/database/migrations/2025_12_26_000004_create_memory_ai_user.php
+++ b/www/database/migrations/2025_12_26_000004_create_memory_ai_user.php
@@ -10,7 +10,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        $password = env('DB_MEMORY_AI_PASSWORD');
+        $password = config('database.connections.pgsql_memory_ai.password');
 
         // Check if user already exists
         $userExists = DB::selectOne(
@@ -19,7 +19,7 @@ return new class extends Migration
 
         if (!$userExists) {
             if (empty($password)) {
-                throw new \RuntimeException('DB_MEMORY_AI_PASSWORD must be set in .env file for memory_ai user');
+                throw new \RuntimeException('PD_DB_MEMORY_AI_PASSWORD must be set in .env file for memory_ai user');
             }
 
             // Create the user


### PR DESCRIPTION
## Summary
- Fix migration to use `config('database.connections.pgsql_memory_ai.password')` instead of `env('DB_MEMORY_AI_PASSWORD')`
- Follows Laravel best practice: never use `env()` outside config files
- Fixes incorrect variable name (was missing `PD_` prefix)

## Test plan
- [ ] Fresh install with `PD_DB_MEMORY_AI_PASSWORD` set in `.env`
- [ ] Verify migration `2025_12_26_000004_create_memory_ai_user` completes successfully
- [ ] Verify `memory_ai` database user is created with correct password

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration retrieval mechanism for improved environment management.

---

**Note:** This is an internal infrastructure update with no impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->