### PR TITLE
Add skills/ directory to export script

### DIFF
--- a/scripts/export-claude-config.sh
+++ b/scripts/export-claude-config.sh
@@ -106,6 +106,7 @@ copy_if_exists "$CLAUDE_DIR/CLAUDE.md" "$EXPORT_DIR/CLAUDE.md" "CLAUDE.md"
 # Export directories
 copy_dir_if_exists "$CLAUDE_DIR/agents" "$EXPORT_DIR/agents" "agents/"
 copy_dir_if_exists "$CLAUDE_DIR/commands" "$EXPORT_DIR/commands" "commands/"
+copy_dir_if_exists "$CLAUDE_DIR/skills" "$EXPORT_DIR/skills" "skills/"
 copy_dir_if_exists "$CLAUDE_DIR/rules" "$EXPORT_DIR/rules" "rules/"
 
 # Export MCP servers from claude.json (if jq available)


### PR DESCRIPTION
## Summary

- Add `skills/` directory to the export script so Claude Code skills are included in exports
- The import system already handles skills correctly, this was the only missing piece

## Test plan

- [ ] Run the export script with skills present in `~/.claude/skills/`
- [ ] Verify the archive includes the skills directory
- [ ] Import into PocketDev and confirm skills appear in the target memory schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended exported content to include the skills directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->