### PR TITLE
Fix cross-process file permissions between PHP-FPM and queue workers

### DIFF
--- a/docker-laravel/shared/supervisor/queue-workers.conf
+++ b/docker-laravel/shared/supervisor/queue-workers.conf
@@ -4,12 +4,14 @@ logfile=/tmp/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=0
 pidfile=/tmp/supervisord.pid
+umask=002
 
 [program:queue-worker]
 process_name=%(program_name)s_%(process_num)02d
 command=php /var/www/artisan queue:work redis --sleep=1 --tries=1 --timeout=600
 directory=/var/www
 environment=HOME="/home/appuser"
+umask=002
 numprocs=10
 autostart=true
 autorestart=true

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ What are you looking for?
 | Job queue (Redis) | `architecture/system-overview.md` | Background processing |
 | Authentication (Basic Auth, IP whitelist) | `architecture/authentication.md` | Proxy layer |
 | API key storage | `architecture/authentication.md` | Encrypted in DB |
+| File permissions (PHP-FPM vs queue) | `architecture/file-permissions.md` | umask, group perms |
 | **Database** | | |
 | Full schema reference | `database/schema.md` | Tables, indexes, queries |
 | Model pricing/config | `database/schema.md` | ai_models table |
@@ -62,6 +63,7 @@ What are you looking for?
 - `system-overview.md` - Container architecture, networking, volumes, data flow
 - `authentication.md` - Basic Auth, IP whitelist, Claude credential management
 - `technology-stack.md` - Laravel, Alpine.js, Docker, key dependencies
+- `file-permissions.md` - Cross-process file permissions (PHP-FPM vs queue workers)
 
 ### 📦 Modules (`modules/`)
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -7,6 +7,7 @@ PocketDev is a multi-container Docker application that wraps Claude Code CLI wit
 - `system-overview.md` - Container architecture, networking, volumes, data flow diagrams
 - `authentication.md` - Basic Auth, IP whitelist, Claude credential management
 - `technology-stack.md` - Laravel, Alpine.js, Docker, and key dependencies
+- `file-permissions.md` - Cross-process file permissions (PHP-FPM vs queue workers)
 
 ## Quick Summary
 

--- a/docs/architecture/file-permissions.md
+++ b/docs/architecture/file-permissions.md
@@ -1,0 +1,112 @@
+# File Permissions Model
+
+PocketDev runs multiple processes that need to share files. This document explains how file permissions work across these processes.
+
+## The Problem
+
+Two main processes write to shared locations (logs, storage, etc.):
+
+| Process | User | Container | Role |
+|---------|------|-----------|------|
+| PHP-FPM | `www-data` | pocket-dev-php | Web requests |
+| Queue Workers | `appuser` | pocket-dev-queue | Background jobs |
+
+By default, files created by one user aren't writable by the other (umask `022` creates `644` files). This causes permission errors when:
+- A web request creates a log file, then a queue job tries to append to it
+- A queue job creates a cache file, then a web request tries to update it
+
+## The Solution
+
+Both users are members of `appgroup`. We use two mechanisms to ensure group-writable files:
+
+### 1. Umask Configuration
+
+Set `umask(0002)` so new files are created with `664` (group-writable) instead of `644`:
+
+| Location | File | Purpose |
+|----------|------|---------|
+| PHP bootstrap | `www/bootstrap/app.php` | Applies to all PHP-FPM requests |
+| Supervisor | `docker-laravel/shared/supervisor/queue-workers.conf` | Applies to queue worker processes |
+
+**Without umask fix:**
+```
+-rw-r--r-- www-data appgroup  request-flow.log  # Queue can't write!
+```
+
+**With umask fix:**
+```
+-rw-rw-r-- www-data appgroup  request-flow.log  # Queue can write via group
+```
+
+### 2. Explicit Permission Setting
+
+For extra reliability, critical code paths explicitly set permissions after creating files:
+
+```php
+// Create directory with group permissions
+File::makeDirectory($path, 0775, true);
+@chmod($path, 0775);
+@chgrp($path, 'appgroup');
+
+// Set file permissions after creation
+if ($isNewFile) {
+    @chmod($filepath, 0664);
+    @chgrp($filepath, 'appgroup');
+}
+```
+
+The `@` suppresses errors if the operation fails (e.g., on a read-only filesystem).
+
+## Defensive Error Handling
+
+Logging and other infrastructure code must **never** cause application failures. The `RequestFlowLogger` wraps all file operations in try-catch and falls back to Laravel's error log:
+
+```php
+try {
+    // File operations...
+} catch (\Throwable $e) {
+    // Fall back to Laravel log - never throw
+    \Log::warning('RequestFlowLogger: Failed to write entry', [...]);
+}
+```
+
+This prevents permission issues from causing conversations to get stuck in "processing" state.
+
+## Directory Permissions Reference
+
+| Directory | Permissions | Owner | Purpose |
+|-----------|-------------|-------|---------|
+| `storage/logs/` | `775` | www-data:appgroup | Laravel logs |
+| `storage/logs/request-flow/` | `775` | www-data:appgroup | Request flow logs |
+| `storage/framework/cache/` | `775` | www-data:appgroup | File cache |
+
+## Troubleshooting
+
+### Permission denied errors in logs
+
+Check if files have correct group permissions:
+```bash
+ls -la storage/logs/
+# Should show: -rw-rw-r-- www-data appgroup
+```
+
+Fix existing files:
+```bash
+chgrp -R appgroup storage/
+chmod -R g+w storage/
+```
+
+### New files not group-writable
+
+Verify umask is set correctly:
+```bash
+# In PHP container
+php -r "echo 'umask: ' . sprintf('%04o', umask()) . PHP_EOL;"
+# Should output: umask: 0002
+```
+
+### Queue jobs failing on file writes
+
+1. Check supervisor config has `umask=002`
+2. Restart supervisor: `supervisorctl restart all`
+3. Check the queue container logs for permission errors

--- a/www/bootstrap/app.php
+++ b/www/bootstrap/app.php
@@ -1,5 +1,10 @@
 <?php
 
+// Set group-writable umask so both www-data (PHP-FPM) and appuser (queue workers)
+// can read/write each other's files. Both users are in appgroup.
+// Default umask 022 creates 644 files; umask 002 creates 664 files (group-writable).
+umask(0002);
+
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;


### PR DESCRIPTION
## Summary
- Fix file permission issues where PHP-FPM (www-data) and queue workers (appuser) couldn't write to each other's files
- Set umask to 0002 so new files are group-writable (664 instead of 644)
- Add defensive error handling in RequestFlowLogger to prevent logging failures from causing stuck conversations

## Changes
- `www/bootstrap/app.php` - Set umask(0002) for all PHP-FPM requests
- `docker-laravel/shared/supervisor/queue-workers.conf` - Set umask=002 for queue workers
- `www/app/Services/RequestFlowLogger.php` - Wrap in try-catch, add explicit chmod/chgrp
- `docs/architecture/file-permissions.md` - New documentation explaining the permission model

## Test plan
- [ ] Verify web requests can write to logs created by queue workers
- [ ] Verify queue jobs can write to logs created by web requests
- [ ] Verify RequestFlowLogger doesn't throw exceptions on permission errors
- [ ] Check new files have 664 permissions with appgroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New architecture documentation added covering cross-process file permissions between system components.

* **Bug Fixes**
  * Improved logging resilience with enhanced error handling to gracefully manage write failures.

* **Improvements**
  * Strengthened file permission configurations to ensure seamless read/write access across multiple processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->