### PR TITLE
Fix SSE connection drops during long-running tool calls

### DIFF
--- a/www/app/Streaming/SseWriter.php
+++ b/www/app/Streaming/SseWriter.php
@@ -85,6 +85,20 @@ class SseWriter
     }
 
     /**
+     * Write a keepalive comment to maintain the connection.
+     *
+     * SSE comments (lines starting with :) are ignored by clients but
+     * keep the connection alive for proxies and prevent idle timeouts.
+     */
+    public function writeKeepalive(): void
+    {
+        $this->initialize();
+
+        echo ": keepalive " . time() . "\n\n";
+        flush();
+    }
+
+    /**
      * Get standard SSE headers for StreamedResponse.
      */
     public static function headers(): array


### PR DESCRIPTION
## Summary
- Add keepalive mechanism that sends SSE comments (`: keepalive`) every 30 seconds during idle periods
- Increase SSE connection timeout from 60s to 300s to accommodate long-running tool operations
- Remove ineffective `flush()` call after `usleep()` (nothing to flush when no data written)

## Problem
When tool calls take longer than 60 seconds, the SSE connection would silently die due to:
- PHP's default socket timeout (60s)
- Proxy/firewall idle connection timeouts
- No data being sent during tool execution

This caused `net::ERR_INCOMPLETE_CHUNKED_ENCODING` errors in the browser when the server tried to send data on a dead connection.

## Solution
SSE comments (lines starting with `:`) are ignored by clients per the SSE specification but keep the connection alive for proxies and PHP sockets. By sending a keepalive every 30 seconds, the connection stays open even during long tool executions.

## Test plan
- [ ] Trigger a long-running tool call (60+ seconds)
- [ ] Verify no `ERR_INCOMPLETE_CHUNKED_ENCODING` errors
- [ ] Check browser Network tab shows periodic `: keepalive` comments in SSE stream
- [ ] Verify normal streaming still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability with keepalive intervals and enhanced timeout handling for conversation streams.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->