### PR TITLE
feat: Use build-time file injection instead of runtime privilege dropping

### DIFF
--- a/www/app/Tools/ComposeTransformTool.php
+++ b/www/app/Tools/ComposeTransformTool.php
@@ -64,6 +64,8 @@ Transforms a Docker Compose file to use PocketDev workspace volume mounts instea
 **Known Limitations:**
 - File vs directory detection uses extension-based heuristics. Directories with extensions (e.g., `./configs.d`) may be misclassified as files, and files without extensions (e.g., `./Makefile`) may be misclassified as directories.
 - Dockerfile modification requires a USER directive in the Dockerfile. Falls back to runtime copy if not found.
+- Multi-stage Dockerfiles: Currently picks the last USER in the entire file. If USER is only in a builder stage (not the final stage), files may be injected incorrectly. Falls back to runtime copy for these cases.
+- Build context mismatch: File mount sources must be inside the Docker build context. If build context is a subdirectory and mount source is outside it, the COPY will fail. Use `build: ./` (same as compose dir) to avoid this.
 
 **After running this tool:** Read the generated files and inform the user that file mount changes require a rebuild (`docker compose build`).
 INSTRUCTIONS;


### PR DESCRIPTION
## Summary
- Replace runtime privilege dropping (su/gosu) with build-time file injection via Dockerfile modification
- Parse Dockerfile to find USER directive, insert COPY instructions before it
- Generate `Dockerfile.pocketdev` with injected files, reference in compose.override.yaml
- Fall back to runtime copy for services without USER directive (upstream images)

## Problem
Runtime privilege dropping breaks file descriptor permissions. When supervisord runs as a non-root user after switching from root via gosu/su, it cannot set up dispatchers for `/dev/stdout` and `/dev/stderr`, causing EACCES errors:

```
EACCES unknown error making dispatchers for 'npm-dev'
```

This meant supervisor configs had to use `stdout_logfile=AUTO` instead of `/dev/stdout`, losing `docker logs` functionality.

## Solution
Inject files at BUILD time instead of runtime:

1. `parseDockerfileStructure()` - Find USER directive location
2. `generateModifiedDockerfile()` - Insert COPY instructions BEFORE USER
3. Write `Dockerfile.pocketdev` and reference it in compose.override.yaml
4. Container starts directly as correct user with properly initialized file descriptors

**Before (runtime copy):**
```yaml
user: root
entrypoint: ["/bin/sh","-c","cp '/stage/file' '/target' && exec su -s /bin/sh 'linux' -c 'supervisord'"]
```

**After (build-time injection):**
```yaml
build:
  context: ./
  dockerfile: Dockerfile.pocketdev
# No user override, no entrypoint - uses Dockerfile's USER and CMD directly
```

## Benefits
- `/dev/stdout` and `/dev/stderr` work correctly for supervisor
- `docker logs` captures output as expected
- Simpler compose.override.yaml
- No runtime user switching complexity

## Trade-off
Changes to mounted files require `docker compose build`. For config files that change infrequently, this is acceptable. The tool output now includes a note about this.

## Test plan
- [x] Run compose:transform on ZeroPlex project
- [x] Verify Dockerfile.pocketdev has COPY before USER directive
- [x] Verify compose.override.yaml uses Dockerfile.pocketdev (no user/entrypoint for PHP service)
- [x] Verify nginx/mariadb fall back to runtime copy (no USER in upstream images)
- [ ] Build and start containers, verify supervisor processes run correctly
- [ ] Verify `docker logs` captures supervisor output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build-time injection of mounted files into Docker builds, with automatic generation of auxiliary Dockerfiles and guidance to rebuild when mounts change.

* **Improvements**
  * Transform output now includes metadata about generated Dockerfiles and clearer structured override results for more reliable deploy behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->