### PR TITLE
Fix compose:transform file mount conflicts and parsing bugs

### DIFF
--- a/www/app/Tools/ComposeTransformTool.php
+++ b/www/app/Tools/ComposeTransformTool.php
@@ -458,7 +458,13 @@ CLI;
                 // Collect directory mount targets to detect conflicts with file mounts
                 $directoryMountTargets = [];
                 foreach ($volumesToAdd as $vol) {
-                    if ($vol['type'] !== 'named' && !str_starts_with($vol['target'], '/pocketdev-stage-')) {
+                    if ($vol['type'] === 'named') {
+                        // Extract target from named volume's raw format (e.g., "data:/var/www" → "/var/www")
+                        $parts = explode(':', $vol['raw']);
+                        if (isset($parts[1])) {
+                            $directoryMountTargets[] = rtrim($parts[1], '/');
+                        }
+                    } elseif (!str_starts_with($vol['target'], '/pocketdev-stage-')) {
                         $directoryMountTargets[] = rtrim($vol['target'], '/');
                     }
                 }


### PR DESCRIPTION
## Summary

Three fixes for the compose file transformation tool:

- **File mounts inside directory mounts** now use runtime copy instead of Dockerfile COPY. When a file mount target (e.g., `/var/www/.env`) is inside a directory mount target (e.g., `/var/www`), the volume mount would overwrite the file at runtime. Now detected and handled via entrypoint `cp` command which runs after volumes are mounted.

- **Mount options** (`:ro`, `:rw`, `:z`, etc.) are now properly stripped from target paths. Previously `explode(":", $mount, 2)` kept options attached to the target, causing invalid paths like `/etc/nginx/conf.d/default.conf:ro`

- **Dotfiles** like `.env` are now handled correctly. Previously the code assumed all paths starting with "." were `./path` format, causing `.env` to become `nv` after `substr($source, 2)`.

## Test plan

- [x] Tested with slim-docker-laravel-setup project (blindtest)
- [x] Verified `.env` with PostgreSQL config is runtime-copied to `/var/www/.env`
- [x] Verified nginx config no longer has `:ro` in path
- [x] Verified Laravel app loads correctly with proper database connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable parsing and classification of file/directory mounts (including dot-based paths), improving detection of safe vs conflicting mounts and ensuring correct staging or injection.
  * Expanded runtime-copy fallback to guarantee files are available at service startup when image modification isn't possible.

* **Chores**
  * Improved Dockerfile and build-context handling, with better extraction of startup command/user to more reliably insert copies and startup steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->