### PR TITLE
Improve compose:transform trigger documentation

### DIFF
--- a/www/app/Tools/ComposeTransformTool.php
+++ b/www/app/Tools/ComposeTransformTool.php
@@ -40,12 +40,19 @@ class ComposeTransformTool extends Tool
     }
 
     public ?string $instructions = <<<'INSTRUCTIONS'
-Transforms a Docker Compose file to use PocketDev workspace volume mounts instead of bind mounts.
+**CRITICAL: Always use this tool before running a user's Docker Compose project for the first time.**
+
+Docker Compose bind mounts (e.g., `./src:/app`) reference paths on the HOST filesystem. Inside PocketDev, the workspace lives in a Docker volume—host paths don't exist. Without transformation, bind mounts will fail or mount empty directories.
 
 **When to use:**
-- User wants to run their Docker project inside PocketDev
-- User has a compose file with bind mounts (`./path:/target`)
-- Setting up a new project's Docker environment
+- User clones/creates a Docker Compose project in /workspace/
+- User wants to run `docker compose up` on an untransformed project
+- User's containers can't see their code (empty mounts, "path not found" errors)
+- BEFORE the first `docker compose up` on any external project
+
+**When NOT needed:**
+- Project already has `compose.override.yaml` from previous transformation
+- Project uses only named volumes (no `./path:/target` mounts)
 
 **How it works:**
 1. Reads the compose file you specify


### PR DESCRIPTION
## Summary

- Make the trigger more directive so AI understands this tool is **mandatory** for external Docker Compose projects
- Lead with CRITICAL and imperative "Always use"
- Explain WHY bind mounts don't work inside containers
- Make timing clear: "BEFORE the first docker compose up"
- Add failure symptoms as triggers (empty mounts, path errors)
- Add "When NOT needed" section to prevent unnecessary runs

## Test plan

- [x] Documentation change only - no functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced guidance for the Compose Transform tool with critical notices and expanded usage scenarios to clarify when and how to use the feature effectively.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->