### PR TITLE
Fix voice transcription cutting off final sentence

### DIFF
--- a/www/app/Services/TranscriptionService.php
+++ b/www/app/Services/TranscriptionService.php
@@ -65,11 +65,13 @@ class TranscriptionService
                                 'type' => 'near_field',
                             ],
                             // Server-side VAD: detects speech pauses to segment transcription
+                            // Note: silence_duration_ms increased from default 500 to 800 to reduce
+                            // premature cutoff of final words (per OpenAI Cookbook recommendations)
                             'turn_detection' => [
                                 'type' => 'server_vad',
                                 'threshold' => 0.5,           // Speech detection sensitivity (0-1)
                                 'prefix_padding_ms' => 300,   // Audio to include before speech
-                                'silence_duration_ms' => 500, // Silence before ending turn
+                                'silence_duration_ms' => 800, // Silence before ending turn (increased from 500)
                             ],
                         ],
                     ],
@@ -132,6 +134,11 @@ class TranscriptionService
                 'model' => 'gpt-4o-transcribe',
                 'response_format' => 'text',
                 'language' => 'en', // Force English to avoid detection issues on short segments
+                'temperature' => 0.2, // Lower temperature for more consistent transcription
+                // Anti-truncation prompt: gpt-4o-transcribe has a known tendency to truncate
+                // the final sentence. This prompt significantly reduces that behavior.
+                // See: https://community.openai.com/t/persistent-truncation-issues-with-gpt-4o-transcribe
+                'prompt' => 'Transcribe completely. Do NOT omit, summarize, or truncate any speech. Output every word as spoken, including the final sentence.',
             ]);
 
             if (!$response->successful()) {


### PR DESCRIPTION
## Summary

- **Real-time mode**: Increase `silence_duration_ms` from 500ms to 800ms to reduce premature VAD cutoff of final words
- **File upload mode**: Add anti-truncation prompt and `temperature=0.2` to prevent model from summarizing/truncating

## Problem

OpenAI's `gpt-4o-transcribe` has a well-documented tendency to cut off or truncate the last sentence of audio transcriptions. This affects both:
1. Real-time streaming (VAD ends turn too early)
2. File upload transcription (model truncates output)

## Investigation

Research confirmed this is a known issue:
- [OpenAI Community: Persistent Truncation Issues](https://community.openai.com/t/persistent-truncation-issues-with-gpt-4o-transcribe)
- [OpenAI Community: GPT-4o-Transcribe Truncates](https://community.openai.com/t/gpt-4o-transcribe-truncates-the-transcript)
- [Whisper GitHub: Silence Detection Issues](https://github.com/openai/whisper/discussions/29)

## Solution

**Real-time mode fix:**
- The [OpenAI Cookbook](https://cookbook.openai.com/examples/realtime_out_of_band_transcription) uses `silence_duration_ms: 800` vs the default 500ms
- Longer silence detection window prevents cutting off final words

**File upload fix:**
- Community reports "99% success" with an anti-truncation prompt
- Added: `"Transcribe completely. Do NOT omit, summarize, or truncate any speech."`
- Added: `temperature: 0.2` for more consistent output

## Test plan

- [ ] Test real-time transcription - verify final words are captured
- [ ] Test file upload transcription - verify complete sentences
- [ ] Test with deliberate pauses to ensure VAD still segments appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice activity detection accuracy to better handle silence during transcription.
  * Enhanced transcription quality and consistency with refined processing parameters.
  * Fixed potential transcription truncation issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->