### PR TITLE
Add CLAUDE_CODE_VERSION env var for pinning CLI version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ docker compose pull && docker compose up -d
 
 Want to run PocketDev on a VPS instead of locally? See the [Secure Server Setup Guide](docs/deployment/secure-server-setup.md) for a Tailscale-based deployment that keeps your instance private and invisible to the public internet.
 
+## Troubleshooting
+
+### Claude Code Version Issues
+
+If you encounter API errors like "tool use concurrency issues" or other Claude Code bugs, you can pin to a specific version by adding this to your `.env` file:
+
+```bash
+CLAUDE_CODE_VERSION=2.1.17
+```
+
+Then restart the containers:
+
+```bash
+docker compose down && docker compose up -d
+```
+
+The queue container will automatically install the specified version on startup. Remove the variable or set it empty to use the default (latest) version.
+
 ## Contributing
 
 Want to contribute to PocketDev? See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.

--- a/compose.yml
+++ b/compose.yml
@@ -149,6 +149,8 @@ services:
       # TODO: Remove PD_ADDITIONAL_SYSTEM_PROMPT_FILE? Not used in deploy (file not baked/mounted).
       - PD_ADDITIONAL_SYSTEM_PROMPT_FILE=${PD_ADDITIONAL_SYSTEM_PROMPT_FILE:-/pocketdev/CLAUDE.md}
       - PD_DOCKER_GID=${PD_DOCKER_GID:-}
+      # Optional: Pin Claude Code CLI to a specific version (e.g., "2.1.17")
+      - CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION:-}
     volumes:
       - ./www:/var/www
       - .env:/var/www/.env

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -131,6 +131,8 @@ services:
       - PD_TARGET_GID=${PD_GROUP_ID:-1000}
       - PD_HOST_PROJECT_PATH=${PD_HOST_PROJECT_PATH:-${PWD}}
       - PD_DOCKER_GID=${PD_DOCKER_GID:-}
+      # Optional: Pin Claude Code CLI to a specific version (e.g., "2.1.17")
+      - CLAUDE_CODE_VERSION=${CLAUDE_CODE_VERSION:-}
     volumes:
       - .env:/var/www/.env
       - user-data:/home/appuser

--- a/docker-laravel/local/php/queue-entrypoint.sh
+++ b/docker-laravel/local/php/queue-entrypoint.sh
@@ -216,6 +216,28 @@ else
     echo "WARNING: jq not available - skipping package installation"
 fi
 
+# =============================================================================
+# CLAUDE CODE VERSION OVERRIDE
+# =============================================================================
+# If CLAUDE_CODE_VERSION is set, reinstall Claude Code at that specific version.
+# This is a fallback mechanism for pinning to a known-working version.
+# Example: CLAUDE_CODE_VERSION=2.1.17
+
+if [ -n "$CLAUDE_CODE_VERSION" ]; then
+    current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+    if [ "$current_version" != "$CLAUDE_CODE_VERSION" ]; then
+        echo "📦 Installing Claude Code version $CLAUDE_CODE_VERSION (current: $current_version)..."
+        if npm install -g "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" --force 2>&1; then
+            new_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+            echo "  ✓ Claude Code $new_version installed"
+        else
+            echo "  ✗ Failed to install Claude Code $CLAUDE_CODE_VERSION"
+        fi
+    else
+        echo "Claude Code already at requested version $CLAUDE_CODE_VERSION"
+    fi
+fi
+
 # Export user-configured credentials as environment variables
 # These will be inherited by supervisord and all queue workers
 echo "Loading credentials into environment..."


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_VERSION` environment variable to pin Claude Code CLI to a specific version
- Queue container checks this on startup and installs the specified version if needed
- Documented in README as a troubleshooting fallback for version-specific bugs

## Motivation
Claude Code 2.1.19+ has a known bug with "tool use concurrency issues" in print mode ([#18131](https://github.com/anthropics/claude-code/issues/18131)). Users can work around this by pinning to 2.1.17.

## Usage
Add to `.env`:
```bash
CLAUDE_CODE_VERSION=2.1.17
```
Then restart containers.

## Test plan
- [ ] Add `CLAUDE_CODE_VERSION=2.1.17` to .env
- [ ] Restart containers (`docker compose down && docker compose up -d`)
- [ ] Verify queue container logs show version installation
- [ ] Verify `claude --version` inside container shows pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now pin specific Claude Code versions via the CLAUDE_CODE_VERSION environment variable; the queue container installs the specified version on startup after containers are restarted. Removing the variable reverts to the latest version.

* **Documentation**
  * Added troubleshooting section explaining version pinning configuration and required workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->