### PR TITLE
fix: Add CLAUDE_CODE_VERSION support to production queue entrypoint

### DIFF
--- a/docker-laravel/production/php/queue-entrypoint.sh
+++ b/docker-laravel/production/php/queue-entrypoint.sh
@@ -254,6 +254,27 @@ else
     echo "WARNING: jq not available - skipping package installation"
 fi
 
+# CLAUDE CODE VERSION OVERRIDE
+# =============================================================================
+# If CLAUDE_CODE_VERSION is set, reinstall Claude Code at that specific version.
+# This is a fallback mechanism for pinning to a known-working version.
+# Example: CLAUDE_CODE_VERSION=2.1.17
+
+if [ -n "$CLAUDE_CODE_VERSION" ]; then
+    current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+    if [ "$current_version" != "$CLAUDE_CODE_VERSION" ]; then
+        echo "📦 Installing Claude Code version $CLAUDE_CODE_VERSION (current: $current_version)..."
+        if npm install -g "@anthropic-ai/claude-code@$CLAUDE_CODE_VERSION" --force 2>&1; then
+            new_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+            echo "  ✓ Claude Code $new_version installed"
+        else
+            echo "  ✗ Failed to install Claude Code $CLAUDE_CODE_VERSION"
+        fi
+    else
+        echo "Claude Code already at requested version $CLAUDE_CODE_VERSION"
+    fi
+fi
+
 # Export user-configured credentials as environment variables
 # These will be inherited by supervisord and all queue workers
 echo "Loading credentials into environment..."


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_VERSION` env var support to the production queue entrypoint
- The feature was added to local in #145 but missed for production

## Problem
PR #145 added the ability to pin Claude Code CLI to a specific version via `CLAUDE_CODE_VERSION` env var. However, the change was only made to `docker-laravel/local/php/queue-entrypoint.sh` and not the production equivalent at `docker-laravel/production/php/queue-entrypoint.sh`.

## Solution
Add the same version override block to the production queue entrypoint, matching the local implementation.

## Test plan
- [ ] Set `CLAUDE_CODE_VERSION=2.1.17` in production `.env`
- [ ] Restart production containers
- [ ] Verify queue container logs show version installation
- [ ] Verify `claude --version` shows pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents runtime issues caused by Claude Code version mismatches by ensuring the specified version is installed at startup.
  - Reduces intermittent startup failures related to version drift.

- Chores
  - Introduces an environment variable to pin the Claude Code version, with automatic reinstall if the installed version differs.
  - Adds clear success/failure reporting during the version check and install process to improve observability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->