### PR TITLE
feat: increase file upload limits and fix error handling

### DIFF
--- a/docker-laravel/shared/nginx/default.conf
+++ b/docker-laravel/shared/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    client_max_body_size 250M;
+    client_max_body_size 2G;
     index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;

--- a/docker-laravel/shared/php/local.ini
+++ b/docker-laravel/shared/php/local.ini
@@ -1,6 +1,6 @@
-upload_max_filesize=250M
-post_max_size=250M
-memory_limit=256M
-max_execution_time=120
+upload_max_filesize=2G
+post_max_size=2G
+memory_limit=3G
+max_execution_time=600
 max_input_vars=1000
 date.timezone=UTC

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -32,6 +32,15 @@ Configuration files and environment variables for PocketDev.
 | `CLAUDE_MODEL` | `claude-sonnet-4-5-20250929` | Default model |
 | `CLAUDE_MAX_TURNS` | `100` | Max conversation turns |
 
+### File Upload Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PD_MAX_UPLOAD_SIZE_MB` | `250` | Max file upload size for chat attachments (MB). Hard limit: 2048 MB (2GB). |
+| `PD_MAX_PREVIEW_SIZE_MB` | `25` | Max file size for browser preview modal (MB). |
+
+**Note:** The infrastructure (Nginx/PHP) supports up to 2GB uploads. The application defaults are more conservative but can be increased via these environment variables.
+
 ## Configuration Files
 
 ### Laravel (`config/claude.php`)

--- a/www/config/ai.php
+++ b/www/config/ai.php
@@ -385,8 +385,9 @@ return [
     */
 
     'file_preview' => [
-        // Maximum file size for preview (bytes)
-        'max_file_size' => 2 * 1024 * 1024, // 2MB
+        // Maximum file size for preview (in MB, converted to bytes)
+        // Default: 25MB - generous for most text files, HTML reports, etc.
+        'max_file_size' => (int) env('PD_MAX_PREVIEW_SIZE_MB', 25) * 1024 * 1024,
 
         // Allowed base directories for file access
         // Paths outside these directories will be rejected

--- a/www/config/uploads.php
+++ b/www/config/uploads.php
@@ -1,0 +1,28 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | File Upload Settings
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for file uploads in PocketDev. The infrastructure (Nginx/PHP)
+    | supports up to 2GB, but the application default is more conservative.
+    |
+    | To increase the limit, set PD_MAX_UPLOAD_SIZE_MB in your .env file.
+    | Note: The hard limit is 2GB due to infrastructure constraints.
+    |
+    */
+
+    // Maximum file size for chat attachments (in MB)
+    // Default: 250MB, Max: 2048MB (2GB)
+    'max_size_mb' => min(
+        (int) env('PD_MAX_UPLOAD_SIZE_MB', 250),
+        2048 // Hard limit - infrastructure ceiling
+    ),
+
+    // Upload directory (shared across containers via pocket-dev-shared-tmp volume)
+    'directory' => env('PD_UPLOAD_DIR', '/tmp/pocketdev-uploads'),
+
+];


### PR DESCRIPTION
## Summary

- Increase infrastructure limits to 2GB (Nginx/PHP) to support larger file uploads
- Add configurable upload limit via `PD_MAX_UPLOAD_SIZE_MB` env variable (default: 250MB)
- Add configurable preview limit via `PD_MAX_PREVIEW_SIZE_MB` env variable (default: 25MB)
- Fix frontend JSON parsing bug that caused cryptic "Unexpected token '<'" error
- Add client-side file size validation for immediate user feedback

## Problem

Users uploading files larger than 10MB received a cryptic error:
```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

This was caused by:
1. **Application limit** (10MB) was far below infrastructure limits (250MB)
2. **Frontend bug** - `response.json()` was called before checking `response.ok`, so HTML error pages caused JSON parse failures

## Solution

| Change | Details |
|--------|---------|
| Infrastructure | Nginx/PHP now support 2GB uploads |
| Default limit | 250MB (configurable via ENV) |
| Preview limit | 25MB default (was 2MB) |
| Error handling | Check `response.ok` before parsing JSON |
| Client-side | Validate file size before upload attempt |

## Configuration

New environment variables (optional, not in .env.example):

| Variable | Default | Description |
|----------|---------|-------------|
| `PD_MAX_UPLOAD_SIZE_MB` | 250 | Max upload size (hard limit: 2GB) |
| `PD_MAX_PREVIEW_SIZE_MB` | 25 | Max file preview size |

## Test plan

- [ ] Upload file >10MB, <250MB → should succeed
- [ ] Upload file >250MB → should show friendly error immediately (client-side)
- [ ] Upload file >2GB → should show server error message (not JSON parse error)
- [ ] Set `PD_MAX_UPLOAD_SIZE_MB=500` → limit should increase to 500MB
- [ ] Preview 6MB HTML file → should work (was failing at 2MB limit)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File upload limits now configurable, supporting up to 2GB
  * Client-side file size validation before upload
  * Improved error messages for failed uploads

* **Configuration**
  * Updated infrastructure to support larger file uploads
  * New environment variables: PD_MAX_UPLOAD_SIZE_MB and PD_MAX_PREVIEW_SIZE_MB for customizing upload and preview sizes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->