### PR TITLE
feat: Add workspace names to browser tabs and favicon

### DIFF
--- a/www/public/favicon.svg
+++ b/www/public/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <!-- Transparent background -->
+  <rect width="512" height="512" fill="transparent"/>
+
+  <!-- Curly braces - more horizontal/compact -->
+  <g stroke="#60a5fa" stroke-width="36" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Left brace -->
+    <path d="M 100 140 Q 80 200 80 256 Q 80 312 100 372"/>
+    <!-- Right brace -->
+    <path d="M 412 140 Q 432 200 432 256 Q 432 312 412 372"/>
+  </g>
+
+  <!-- Green + circle (left side) -->
+  <circle cx="210" cy="220" r="50" fill="#10b981"/>
+  <!-- Plus sign using rectangles -->
+  <rect x="188" y="210" width="44" height="20" rx="6" fill="#ffffff"/>
+  <rect x="200" y="198" width="20" height="44" rx="6" fill="#ffffff"/>
+
+  <!-- Red − circle (right side) -->
+  <circle cx="302" cy="292" r="50" fill="#ef4444"/>
+  <!-- Minus sign using rectangle -->
+  <rect x="275" y="288" width="54" height="8" rx="2" fill="#ffffff"/>
+</svg>

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>PocketDev Chat</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <title>{{ $workspace ? $workspace->name . ' - ' : '' }}PocketDev Chat</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 
@@ -1756,6 +1757,7 @@
                                 this.currentWorkspace = data.workspace;
                                 this.currentWorkspaceId = data.workspace.id;
                                 this.debugLog('Active workspace loaded', { workspace: data.workspace.name });
+                                this.updateBrowserTitle();
                             }
                         }
                     } catch (err) {
@@ -1792,6 +1794,7 @@
                             this.currentWorkspace = workspace;
                             this.currentWorkspaceId = workspace.id;
                             this.showWorkspaceSelector = false;
+                            this.updateBrowserTitle();
                             this.debugLog('Workspace switched', { workspace: workspace.name, lastConversation: data.last_conversation_uuid });
 
                             // Clear old workspace state before loading new data
@@ -1823,6 +1826,13 @@
                         console.error('Error switching workspace:', err);
                         this.errorMessage = 'Failed to switch workspace. Please try again.';
                     }
+                },
+
+                updateBrowserTitle() {
+                    const workspaceName = this.currentWorkspace?.name;
+                    document.title = workspaceName
+                        ? `${workspaceName} - PocketDev Chat`
+                        : 'PocketDev Chat';
                 },
 
                 // ==================== End Workspace Methods ====================

--- a/www/resources/views/layouts/config.blade.php
+++ b/www/resources/views/layouts/config.blade.php
@@ -4,7 +4,15 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>@yield('title', 'Settings') - PocketDev</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    @php
+        $activeWorkspaceId = session('active_workspace_id');
+        $activeWorkspace = $activeWorkspaceId
+            ? \App\Models\Workspace::find($activeWorkspaceId)
+            : \App\Models\Workspace::first();
+        $workspacePrefix = $activeWorkspace ? $activeWorkspace->name . ' - ' : '';
+    @endphp
+    <title>{{ $workspacePrefix }}@yield('title', 'Settings') - PocketDev</title>
 
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
- Display workspace name in browser tab titles: [Workspace] - PocketDev Chat
- Add custom SVG favicon with curly braces and +/- symbols
- Dynamically update title when workspace changes
- Add favicon links to chat and config layouts
- Fallback to 'PocketDev' when no workspace active

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added favicon to enhance application branding.
  * Browser tab title now dynamically displays the active workspace name, helping users identify workspaces when managing multiple tabs.
  * Settings page title automatically reflects the current workspace for improved context and clarity.
  * Workspace changes automatically update all page titles in real-time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->