### PR TITLE
Fix notification blocking back button after fade out

### DIFF
--- a/www/resources/views/layouts/config.blade.php
+++ b/www/resources/views/layouts/config.blade.php
@@ -69,7 +69,7 @@
         /* Notification styles */
         .notification {
             position: fixed;
-            top: 20px;
+            top: 70px;
             right: 20px;
             padding: 16px 24px;
             border-radius: 8px;
@@ -99,7 +99,7 @@
         }
 
         @keyframes fadeOut {
-            to { opacity: 0; transform: translateX(400px); }
+            to { opacity: 0; transform: translateX(400px); pointer-events: none; }
         }
 
         /* Hide desktop layout on mobile */


### PR DESCRIPTION
## Summary
- Move notification from `top: 20px` to `top: 70px` to position below the header area
- Add `pointer-events: none` to the fadeOut animation final state so the invisible notification doesn't block clicks on elements behind it (like the back button)

## Test plan
- [ ] Go to Settings and trigger a success notification (e.g., save a setting)
- [ ] Verify notification appears below the header, not overlapping it
- [ ] Wait for notification to fade out (~3 seconds)
- [ ] Verify the back button is immediately clickable after fade out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repositioned notifications on the screen for better visibility.
  * Prevented user interactions with notifications after they fade out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->