### PR TITLE
feat: Auto-select next session below on archive/delete

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -3697,7 +3697,7 @@
                 // Used when archiving/deleting to select the session "below" in the sidebar
                 findNextSessionByPosition(excludeSessionId, options = {}) {
                     const { excludeArchived = true, sessionsArray = null } = options;
-                    const sessions = sessionsArray || this.sessions;
+                    const sessions = sessionsArray || this.filteredSessions;
 
                     // Find current index
                     const currentIndex = sessions.findIndex(s => s.id === excludeSessionId);


### PR DESCRIPTION
## Summary
- When archiving or deleting a session, now selects the **next session below** (older by timestamp) instead of jumping to the first available session
- Falls back to selecting above if nothing below, or creates new session if none available
- Adds `findNextSessionByPosition()` helper for position-based lookup

## Test plan
- [ ] Create 3+ sessions in the sidebar
- [ ] Select the middle session
- [ ] Archive it → verify it selects the session below (older)
- [ ] Delete a session → verify it selects the session below (older)
- [ ] Archive the bottom session → verify it selects the one above as fallback
- [ ] Archive all but one → verify it stays on last session or creates new

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat session navigation when archiving or deleting conversations. The app now more reliably selects the next appropriate session to display based on position order, providing a smoother experience when managing chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->