### PR TITLE
Add workspace guidance and script environment documentation

### DIFF
--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -577,6 +577,11 @@ PROMPT;
             $doc .= "### Card Component\n```blade\n" . trim($examples['card']) . "\n```\n\n";
         }
 
+        // Add script environment documentation if present
+        if (!empty($config['script_environment'])) {
+            $doc .= "\n" . $config['script_environment'] . "\n";
+        }
+
         return $doc;
     }
 }

--- a/www/config/panels.php
+++ b/www/config/panels.php
@@ -133,4 +133,38 @@ EXAMPLE,
 </div>
 EXAMPLE,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Script Environment Documentation
+    |--------------------------------------------------------------------------
+    |
+    | Documentation about the script execution environment, included in the
+    | Panel Dependencies section of the system prompt.
+    |
+    */
+    'script_environment' => <<<'DOC'
+## Script Environment
+
+Scripts run with POSIX shell (`sh`), not bash. Avoid bash-specific syntax:
+
+| Avoid | Use Instead |
+|-------|-------------|
+| `[[ ]]` | `[ ]` |
+| `${var,,}` | `echo "$var" \| tr '[:upper:]' '[:lower:]'` |
+| `<<<` | `echo ... \| cmd` |
+| `source file` | `. file` |
+
+**Available commands:** curl, wget, git, jq, php, node, npm, python3
+
+**Error handling pattern:**
+
+```sh
+#!/bin/sh
+set -e  # Exit on first error
+[ -z "$TOOL_INPUT" ] && { echo '{"error":"input required"}'; exit 0; }
+result=$(command) || { echo '{"error":"command failed"}'; exit 0; }
+echo "{\"data\":$result}"
+```
+DOC,
 ];

--- a/www/resources/defaults/system-prompt.md
+++ b/www/resources/defaults/system-prompt.md
@@ -8,9 +8,13 @@ Two core capabilities:
 
 ## Environment
 
-**Persistent locations** (survive container rebuilds):
-- `/home/appuser` - your home directory
-- `/workspace` - workspace files
+**Project files** belong in your workspace directory:
+- Clone repositories and create projects here
+- The current workspace path is shown in "Working Directory" below
+- Each workspace is isolated (e.g., `/workspace/default/`)
+
+**Other persistent locations:**
+- `/home/appuser` - user configuration only (dotfiles, global tools)
 - `/tmp` - temporary files
 
 Everything else may be reset on container rebuild.


### PR DESCRIPTION
## Summary

- Clarifies that project files belong in the workspace directory, not `/home/appuser`
- Adds script environment documentation to Panel Dependencies section (POSIX shell compatibility, available commands, error handling patterns)

## Test plan

- [ ] New conversation → ask to clone a repo → should go to `/workspace/`
- [ ] Check system prompt when `tool:create` is allowed → should show shell compatibility section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated script environment guidance with POSIX shell usage patterns, syntax recommendations, and error-handling best practices.
  * Refined file persistence documentation to clarify project file handling, workspace isolation, and user configuration locations.

* **Configuration**
  * Added script environment documentation to system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->