### PR TITLE
Fix panel content race condition when AI opens panels

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -5452,24 +5452,6 @@
                                 }
                                 // Remove from pending set - tool execution is complete
                                 state.waitingForToolResults.delete(toolResultId);
-
-                                // Detect if a panel was opened and refresh screens
-                                // The content may be raw text OR JSON with an "output" field
-                                let panelOutput = event.content;
-                                if (typeof panelOutput === 'string') {
-                                    try {
-                                        const parsed = JSON.parse(panelOutput);
-                                        if (parsed.output) {
-                                            panelOutput = parsed.output;
-                                        }
-                                    } catch (e) {
-                                        // Not JSON, use as-is
-                                    }
-                                }
-                                const outputStr = typeof panelOutput === 'string' ? panelOutput : '';
-                                if (outputStr.startsWith("Opened panel '")) {
-                                    this.refreshSessionScreens();
-                                }
                             } else {
                                 console.warn('tool_result event missing tool_id in metadata');
                             }


### PR DESCRIPTION
## Summary
- Removes redundant string-parsing mechanism from the `tool_result` SSE handler that detected `"Opened panel '..."` output and called `refreshSessionScreens()`
- The `screen_created` SSE event (added in `2f752ff`) was designed to replace this approach, but the original code was never removed
- Two concurrent `refreshSessionScreens()` calls raced each other, causing panels to show wrong content (e.g. git-status tab showing file-explorer content)
- Also fixes a secondary bug where the string-parsing path did not check `_isReplaying`, causing spurious refreshes during page-refresh replays

## Root Cause
When AI opens a panel via `tool:run`, both events fire in quick succession:
1. `screen_created` SSE event → calls `refreshSessionScreens()`
2. `tool_result` SSE event (string parsing) → also calls `refreshSessionScreens()`

The two concurrent async calls race each other, and the caching logic in `loadPanelContent` can cause the wrong panel content to persist in the iframe buffer.

## Edge Cases Verified
- **AI opens panel (live stream):** `screen_created` always fires — `streamManager` and `conversationUuid` are always provided in the streaming job
- **Panel opened via CLI:** No SSE stream, `visibilitychange` handler catches it
- **Panel opened via UI button:** Handled via HTTP response directly
- **Session template panels:** Included in initial session load
- **Page refresh replay:** `screen_created` already checks `_isReplaying`
- **Stream reconnect:** `screen_created` is persisted in Redis and replayed

## Test plan
- [ ] AI opens a panel → verify correct content shows immediately
- [ ] Switch between panel tabs → verify correct content for each
- [ ] Page refresh during streaming → verify replay works correctly
- [ ] UI "Add Panel" button → regression test, should be unaffected
- [ ] CLI `pd tool:run <panel>` → verify panel created, visibilitychange catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session screens no longer automatically refresh when receiving tool results with panel-opening information. This change removes automatic refresh behavior, giving users more explicit control over screen state updates following tool execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->