### PR TITLE
Exclude archived chats from sidebar tab count

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1847,6 +1847,15 @@
                     return screen.conversation?.status || 'idle';
                 },
 
+                getActiveTabCount(session) {
+                    if (!session.screens) return 0;
+                    return session.screens.filter(s => {
+                        if (!s) return false;
+                        if (s.type === 'panel') return true;
+                        return s.conversation?.status !== 'archived';
+                    }).length;
+                },
+
                 getSessionStatus(session) {
                     if (session.is_archived) return 'archived';
 

--- a/www/resources/views/partials/chat/mobile-layout.blade.php
+++ b/www/resources/views/partials/chat/mobile-layout.blade.php
@@ -229,7 +229,7 @@
             <div @click="loadSession(session.id); showMobileDrawer = false"
                  :class="{'bg-gray-700': currentSession?.id === session.id}"
                  class="group relative p-2 mb-1 rounded hover:bg-gray-700 cursor-pointer transition-colors"
-                 x-data="{ get _status() { return getSessionStatus(session) } }">
+                 x-data="{ get _status() { return getSessionStatus(session) }, get _tabCount() { return getActiveTabCount(session) } }">
                 <div class="flex items-center gap-1.5">
                     <span class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-sm shrink-0"
                           :class="getStatusColorClass(_status)">
@@ -237,7 +237,7 @@
                     </span>
                     <span class="text-xs text-gray-300 truncate flex-1" x-text="session.name || 'New Session'"></span>
                     {{-- Screen count badge --}}
-                    <span class="text-[10px] text-gray-500" x-text="(session.screens?.length || 0) + ' tab' + ((session.screens?.length || 0) === 1 ? '' : 's')"></span>
+                    <span class="text-[10px] text-gray-500" x-show="_tabCount > 0" x-text="_tabCount + ' tab' + (_tabCount === 1 ? '' : 's')"></span>
                     {{-- Session menu button (always visible) --}}
                     <button @click.stop="openSessionMenu($event, session)"
                             class="w-5 h-5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-gray-600 rounded cursor-pointer shrink-0"

--- a/www/resources/views/partials/chat/sidebar.blade.php
+++ b/www/resources/views/partials/chat/sidebar.blade.php
@@ -54,7 +54,7 @@
             <div @click="loadSession(session.id)"
                  :class="{'bg-gray-700': currentSession?.id === session.id}"
                  class="group relative p-2 mb-1 rounded hover:bg-gray-700 cursor-pointer transition-colors"
-                 x-data="{ get _status() { return getSessionStatus(session) } }">
+                 x-data="{ get _status() { return getSessionStatus(session) }, get _tabCount() { return getActiveTabCount(session) } }">
                 <div class="flex items-center gap-1.5">
                     <span class="inline-flex items-center justify-center w-3.5 h-3.5 rounded-sm shrink-0"
                           :class="getStatusColorClass(_status)">
@@ -62,7 +62,7 @@
                     </span>
                     <span class="text-xs text-gray-300 truncate flex-1" x-text="session.name || 'New Session'"></span>
                     {{-- Screen count badge --}}
-                    <span class="text-[10px] text-gray-500" x-text="(session.screens?.length || 0) + ' tab' + ((session.screens?.length || 0) === 1 ? '' : 's')"></span>
+                    <span class="text-[10px] text-gray-500" x-show="_tabCount > 0" x-text="_tabCount + ' tab' + (_tabCount === 1 ? '' : 's')"></span>
                     {{-- Session menu button (always visible) --}}
                     <button @click.stop="openSessionMenu($event, session)"
                             class="w-5 h-5 flex items-center justify-center text-gray-400 hover:text-white hover:bg-gray-600 rounded cursor-pointer shrink-0"


### PR DESCRIPTION
## Summary
- The sidebar tab count badge (e.g., "8 tabs") was including screens with archived conversations, even though the tab bar itself already filtered them out via `visibleScreenOrder`
- Added `getActiveTabCount(session)` helper with the same filter logic (panels always count, archived chats excluded, null guard for safety)
- Badge now hides entirely when count reaches 0 (avoids confusing "0 tabs" display)
- Applied to both desktop sidebar and mobile drawer

## Test plan
- [ ] Open a session with multiple chats, archive one — tab count should decrease
- [ ] Archive all chats in a session — tab count badge should disappear (not show "0 tabs")
- [ ] Restore an archived chat — tab count should increase and badge reappear
- [ ] Verify panel screens are always counted regardless of chat archive state
- [ ] Check mobile drawer shows the same behavior as desktop sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the accuracy of tab count display in chat sessions. Session tab count badges now dynamically calculate and display the actual number of active tabs across all session types, appearing only when tabs exist. Both mobile and sidebar views now implement consistent, accurate tab counting with proper singular/plural text handling and correct badge visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->