### PR TITLE
Add rename session to sidebar context menu

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1253,6 +1253,7 @@
 
                 // Session name (rename)
                 renameSessionName: '',
+                renameSessionTargetId: null,
                 renameSessionSaving: false,
                 _systemPromptPreviewNonce: 0,
                 systemPromptPreview: {
@@ -2557,9 +2558,15 @@
                     }
                 },
 
-                openRenameSessionModal() {
-                    if (!this.currentSession) return;
-                    this.renameSessionName = this.currentSession.name || '';
+                openRenameSessionModal(sessionId = null) {
+                    const targetId = sessionId || this.currentSession?.id;
+                    if (!targetId) return;
+
+                    const session = this.filteredSessions.find(s => s.id === targetId) || this.currentSession;
+                    if (!session) return;
+
+                    this.renameSessionTargetId = targetId;
+                    this.renameSessionName = session.name || '';
                     this.showRenameSessionModal = true;
                     // Focus input after modal opens
                     this.$nextTick(() => {
@@ -2569,7 +2576,8 @@
                 },
 
                 async saveSessionName() {
-                    if (!this.currentSession || !this.renameSessionName.trim()) return;
+                    const targetId = this.renameSessionTargetId || this.currentSession?.id;
+                    if (!targetId || !this.renameSessionName.trim()) return;
 
                     // Enforce max character limit
                     if (this.renameSessionName.trim().length > window.TITLE_MAX_LENGTH) {
@@ -2579,7 +2587,7 @@
 
                     this.renameSessionSaving = true;
                     try {
-                        const response = await fetch(`/api/sessions/${this.currentSession.id}`, {
+                        const response = await fetch(`/api/sessions/${targetId}`, {
                             method: 'PATCH',
                             headers: {
                                 'Content-Type': 'application/json',
@@ -2591,15 +2599,20 @@
                         if (!response.ok) throw new Error(`HTTP ${response.status}`);
 
                         const data = await response.json();
-                        this.currentSession.name = data.name;
 
-                        // Also update the session in the sessions list for sidebar
-                        const sessionInList = this.filteredSessions.find(s => s.id === this.currentSession.id);
+                        // Update the current session if it's the one being renamed
+                        if (this.currentSession?.id === targetId) {
+                            this.currentSession.name = data.name;
+                        }
+
+                        // Update the session in the sessions list for sidebar
+                        const sessionInList = this.filteredSessions.find(s => s.id === targetId);
                         if (sessionInList) {
                             sessionInList.name = data.name;
                         }
 
                         this.showRenameSessionModal = false;
+                        this.renameSessionTargetId = null;
                     } catch (err) {
                         console.error('Failed to rename session:', err);
                         this.showError('Failed to rename session');

--- a/www/resources/views/partials/chat/sidebar.blade.php
+++ b/www/resources/views/partials/chat/sidebar.blade.php
@@ -94,6 +94,12 @@
              x-transition:leave-end="opacity-0 scale-95"
              class="fixed w-48 bg-gray-700 rounded-lg shadow-lg border border-gray-600 py-1 z-50"
              :style="{ top: sessionMenuPos.top + 'px', left: sessionMenuPos.left + 'px' }">
+            {{-- Rename Session --}}
+            <button x-on:click="openRenameSessionModal(sessionMenuId); closeSessionMenu()"
+                    class="flex items-center gap-2 px-4 py-2 text-sm text-gray-200 hover:bg-gray-600 w-full text-left cursor-pointer">
+                <i class="fa-solid fa-pen w-4 text-center"></i>
+                Rename session
+            </button>
             {{-- Save as Default --}}
             <button @click="saveSessionAsDefault(filteredSessions.find(s => s.id === sessionMenuId))"
                     class="flex items-center gap-2 px-4 py-2 text-sm text-gray-200 hover:bg-gray-600 w-full text-left cursor-pointer">


### PR DESCRIPTION
## Summary
- Adds a **Rename session** option as the first item in the sidebar 3-dots context menu (previously only available from the hamburger menu)
- Refactors `openRenameSessionModal()` and `saveSessionName()` to accept any session ID, so renaming works for non-active sessions too
- Introduces `renameSessionTargetId` to track which session is being renamed, with proper cleanup after save

## Test plan
- [ ] Click the 3-dots menu on the **current** session in the sidebar → Rename session → verify modal opens with correct name, save works
- [ ] Click the 3-dots menu on a **different** (non-active) session → Rename session → verify modal opens with that session's name, save updates the sidebar without switching sessions
- [ ] Verify the hamburger menu rename still works as before (backward compatible, no sessionId passed)
- [ ] Verify the rename modal's character limit and error handling still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Rename Session" button to the session context menu, enabling quick and convenient session renaming without leaving your current view. Better organize and manage multiple active chat sessions by assigning descriptive names for easy identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->