### PR TITLE
Make Claude Code default model configurable via .env

### DIFF
--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -211,9 +211,8 @@ class ClaudeCodeProvider implements AIProviderInterface
         Conversation $conversation,
         array $options
     ): string {
-        // CLAUDE_CODE_DEFAULT_MODEL in .env always takes precedence over agent/UI selection
         $envModel = config('ai.providers.claude_code.default_model');
-        $model = $envModel ?: ($conversation->model ?? 'opus');
+        $model = $envModel ?? ($conversation->model ?? 'opus');
 
         // Get global allowed tools setting (Setting::get already decodes JSON)
         $globalAllowedTools = \App\Models\Setting::get('chat.claude_code_allowed_tools', []);

--- a/www/config/ai.php
+++ b/www/config/ai.php
@@ -40,7 +40,7 @@ return [
 
         'claude_code' => [
             // No API key needed - uses Claude Code CLI authentication (setup via `claude setup-token`)
-            'default_model' => env('CLAUDE_CODE_DEFAULT_MODEL', 'opus'),
+            'default_model' => env('CLAUDE_CODE_DEFAULT_MODEL'),
             // Available tools that can be enabled/disabled via UI
             // Empty array = all tools allowed (default behavior)
             'available_tools' => [


### PR DESCRIPTION
## Summary
- Makes the Claude Code model configurable via `CLAUDE_CODE_DEFAULT_MODEL` in `.env`
- When set, the `.env` value **always takes precedence** over the agent/UI model selection
- When not set, falls back to whatever the agent has configured (default behavior)

## Usage
Add to `.env`:
```
CLAUDE_CODE_DEFAULT_MODEL=claude-opus-4-5-20251101
```

## Precedence
| `.env` set? | Agent model | Model used |
|---|---|---|
| `claude-opus-4-5-20251101` | opus | `claude-opus-4-5-20251101` |
| `claude-opus-4-5-20251101` | haiku | `claude-opus-4-5-20251101` |
| `claude-opus-4-5-20251101` | sonnet | `claude-opus-4-5-20251101` |
| *(not set)* | opus | `opus` |
| *(not set)* | haiku | `haiku` |

## Test plan
- [ ] With `CLAUDE_CODE_DEFAULT_MODEL=claude-opus-4-5-20251101` → always uses Opus 4.5 regardless of agent setting
- [ ] Without env var → agent/UI selection works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)