### PR TITLE
Fix Alpine duplicate key crash on page refresh during streaming

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -5589,7 +5589,7 @@
                                 complete: false
                             };
                             this.messages.push({
-                                id: 'msg-' + Date.now() + '-thinking-' + thinkingBlockIndex,
+                                id: 'msg-' + Date.now() + '-thinking-' + thinkingBlockIndex + '-' + Math.random(),
                                 role: 'thinking',
                                 content: '',
                                 timestamp: state.startedAt || new Date().toISOString(),
@@ -5663,7 +5663,7 @@
                             state.turnCacheCreationTokens = 0;
                             state.turnCacheReadTokens = 0;
                             this.messages.push({
-                                id: 'msg-' + Date.now() + '-text',
+                                id: 'msg-' + Date.now() + '-text-' + Math.random(),
                                 role: 'assistant',
                                 content: '',
                                 timestamp: state.startedAt || new Date().toISOString(),
@@ -5717,7 +5717,7 @@
                                 console.warn('tool_use_start event missing tool_id in metadata');
                             }
                             this.messages.push({
-                                id: 'msg-' + Date.now() + '-tool',
+                                id: 'msg-' + Date.now() + '-tool-' + Math.random(),
                                 role: 'tool',
                                 toolName: event.metadata?.tool_name || 'Tool',
                                 toolId: toolId,


### PR DESCRIPTION
## Summary

- Streaming message IDs (`thinking_start`, `text_start`, `tool_use_start`) used only `Date.now()` for uniqueness, while DB-loaded messages used `Date.now() + Math.random()`
- On page refresh during an active stream, all SSE events replay synchronously in a tight loop — multiple events process within the same millisecond, causing `Date.now()` collisions
- Duplicate `:key` values crash Alpine's DOM reconciliation, resulting in `Cannot read properties of undefined (reading 'after')` and messages failing to render after the collision point
- Fix: append `Math.random()` to streaming message IDs, matching the existing DB-loaded message pattern

## Test plan

- [ ] Start a conversation that uses multiple tool calls
- [ ] While streaming is active, refresh the page (F5)
- [ ] Verify no Alpine warnings in console (`Duplicate key on x-for`, `':key' is undefined`)
- [ ] Verify all messages render correctly after refresh (thinking blocks, text, tool calls with results)
- [ ] Verify normal streaming (without refresh) still works correctly
- [ ] Verify tab-switch reconnection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat reliability by ensuring each message has a unique identifier, preventing rare clashes during rapid or concurrent message generation. This reduces instances of missing, duplicated, or misordered messages.
  * Enhances real-time message rendering consistency, minimizing visual glitches such as flicker or messages being unexpectedly replaced during fast updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->