### PR TITLE
feat: native cross-provider subagents

### DIFF
--- a/www/app/Console/Commands/SubAgentOutputCommand.php
+++ b/www/app/Console/Commands/SubAgentOutputCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentOutputTool;
+use Illuminate\Console\Command;
+
+class SubAgentOutputCommand extends Command
+{
+    protected $signature = 'subagent:output
+        {--task-id= : The task UUID returned by subagent:run --background}';
+
+    protected $description = 'Retrieve the status and output of a sub-agent task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentOutputTool();
+
+        $input = [
+            'task_id' => $this->option('task-id') ?? '',
+        ];
+
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Console/Commands/SubAgentRunCommand.php
+++ b/www/app/Console/Commands/SubAgentRunCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Session;
+use App\Models\Workspace;
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentTool;
+use Illuminate\Console\Command;
+
+class SubAgentRunCommand extends Command
+{
+    protected $signature = 'subagent:run
+        {--agent= : Agent slug or UUID}
+        {--prompt= : The task/prompt to send to the sub-agent}
+        {--background : Return immediately with a task ID (default: wait for completion)}';
+
+    protected $description = 'Spawn a child PocketDev agent to handle a task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentTool();
+
+        $input = [
+            'agent' => $this->option('agent') ?? '',
+            'prompt' => $this->option('prompt') ?? '',
+            'background' => $this->option('background'),
+        ];
+
+        // Build execution context from environment
+        $session = null;
+        $workspace = null;
+        $conversationUuid = null;
+
+        $sessionId = getenv('POCKETDEV_SESSION_ID') ?: null;
+        if ($sessionId) {
+            $session = Session::find($sessionId);
+        }
+
+        $workspaceId = getenv('POCKETDEV_WORKSPACE_ID') ?: null;
+        if ($workspaceId) {
+            $workspace = Workspace::find($workspaceId);
+        }
+
+        $conversationUuid = getenv('POCKETDEV_CONVERSATION_UUID') ?: null;
+
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+            workspace: $workspace,
+            session: $session,
+            conversationUuid: $conversationUuid,
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Models/SubAgentTask.php
+++ b/www/app/Models/SubAgentTask.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SubAgentTask extends Model
+{
+    use HasUuids;
+
+    protected $table = 'subagent_tasks';
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'parent_conversation_uuid',
+        'child_conversation_uuid',
+        'agent_id',
+        'prompt',
+        'is_background',
+    ];
+
+    protected $casts = [
+        'is_background' => 'boolean',
+    ];
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    public function childConversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class, 'child_conversation_uuid', 'uuid');
+    }
+
+    public function parentConversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class, 'parent_conversation_uuid', 'uuid');
+    }
+
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Agent::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Derived methods (read from the child conversation live, no caching)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the current status of the subagent task.
+     * Derived from the child conversation's status.
+     */
+    public function getStatus(): string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation) {
+            return 'pending';
+        }
+        return match ($conversation->status) {
+            Conversation::STATUS_IDLE => 'completed',
+            Conversation::STATUS_PROCESSING => 'running',
+            Conversation::STATUS_FAILED => 'failed',
+            default => 'pending',
+        };
+    }
+
+    /**
+     * Collect the output from all assistant messages in the child conversation.
+     */
+    public function collectOutput(): string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation) {
+            return '';
+        }
+
+        $messages = $conversation->messages()
+            ->where('role', 'assistant')
+            ->orderBy('sequence')
+            ->get();
+
+        $output = [];
+        foreach ($messages as $message) {
+            $content = $message->content;
+            if (!is_array($content)) {
+                continue;
+            }
+            foreach ($content as $block) {
+                if (is_array($block) && ($block['type'] ?? '') === 'text' && !empty($block['text'])) {
+                    $output[] = $block['text'];
+                }
+            }
+        }
+
+        return implode("\n\n", $output);
+    }
+
+    /**
+     * Get error message if the task failed.
+     */
+    public function getError(): ?string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation || $conversation->status !== Conversation::STATUS_FAILED) {
+            return null;
+        }
+
+        $errorMessage = $conversation->messages()
+            ->where('role', 'error')
+            ->orderByDesc('sequence')
+            ->first();
+
+        if ($errorMessage) {
+            $content = $errorMessage->content;
+            if (is_array($content)) {
+                foreach ($content as $block) {
+                    if (is_array($block) && ($block['type'] ?? '') === 'text') {
+                        return $block['text'];
+                    }
+                }
+            }
+            if (is_string($content)) {
+                return $content;
+            }
+        }
+
+        return 'Task failed (no error details available)';
+    }
+}

--- a/www/app/Models/SubAgentTask.php
+++ b/www/app/Models/SubAgentTask.php
@@ -60,7 +60,7 @@ class SubAgentTask extends Model
             return 'pending';
         }
         return match ($conversation->status) {
-            Conversation::STATUS_IDLE => 'completed',
+            Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED => 'completed',
             Conversation::STATUS_PROCESSING => 'running',
             Conversation::STATUS_FAILED => 'failed',
             default => 'pending',

--- a/www/app/Models/SubAgentTask.php
+++ b/www/app/Models/SubAgentTask.php
@@ -84,14 +84,9 @@ class SubAgentTask extends Model
 
         $output = [];
         foreach ($messages as $message) {
-            $content = $message->content;
-            if (!is_array($content)) {
-                continue;
-            }
-            foreach ($content as $block) {
-                if (is_array($block) && ($block['type'] ?? '') === 'text' && !empty($block['text'])) {
-                    $output[] = $block['text'];
-                }
+            $text = trim($message->getTextContent());
+            if ($text !== '') {
+                $output[] = $text;
             }
         }
 

--- a/www/app/Services/Providers/AbstractCliProvider.php
+++ b/www/app/Services/Providers/AbstractCliProvider.php
@@ -192,6 +192,12 @@ abstract class AbstractCliProvider implements AIProviderInterface, HasNativeSess
             $env['POCKETDEV_SESSION_ID'] = $sessionId;
         }
 
+        // Inject conversation UUID and workspace ID for sub-agent spawning
+        $env['POCKETDEV_CONVERSATION_UUID'] = $conversation->uuid;
+        if ($conversation->workspace_id) {
+            $env['POCKETDEV_WORKSPACE_ID'] = $conversation->workspace_id;
+        }
+
         return $env;
     }
 

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -494,9 +494,23 @@ PROMPT;
         $lines[] = "| Slug | Provider | Model | Description |";
         $lines[] = "|------|----------|-------|-------------|";
 
+        $escapeCell = static function (?string $value): string {
+            $value = preg_replace('/\s+/', ' ', trim((string) $value)) ?? '';
+            return str_replace('|', '\|', $value === '' ? '-' : $value);
+        };
+
         foreach ($agents as $agent) {
-            $desc = $agent->description ? Str::limit($agent->description, 60) : '-';
-            $lines[] = "| {$agent->slug} | {$agent->provider} | {$agent->model} | {$desc} |";
+            $desc = $agent->description
+                ? Str::limit(preg_replace('/\s+/', ' ', trim($agent->description)) ?? '', 60)
+                : '-';
+
+            $lines[] = sprintf(
+                '| %s | %s | %s | %s |',
+                $escapeCell($agent->slug),
+                $escapeCell($agent->provider),
+                $escapeCell($agent->model),
+                $escapeCell($desc),
+            );
         }
 
         return implode("\n", $lines);

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -10,6 +10,7 @@ use App\Models\MemoryDatabase;
 use App\Models\Screen;
 use App\Models\SystemPackage;
 use App\Models\Workspace;
+use Illuminate\Support\Str;
 
 /**
  * Builds the system prompt for AI providers.
@@ -92,6 +93,11 @@ class SystemPromptBuilder
         // 3. Memory section (separate from tools)
         if ($memorySection = $this->toolSelector->buildMemorySection($agent)) {
             $sections[] = $memorySection;
+        }
+
+        // 3b. Available agents section (for SubAgent tool)
+        if ($agentsSection = $this->buildAvailableAgentsSection($workspace)) {
+            $sections[] = $agentsSection;
         }
 
         // 4. Skills section (slash commands)
@@ -462,6 +468,38 @@ pd panel:peek <panel-slug>
 pd panel:peek <panel-slug> --id=<panel-id>
 ```
 PROMPT;
+    }
+
+    /**
+     * Build the Available Agents section for the SubAgent tool.
+     * Only included when agents exist in the workspace.
+     */
+    private function buildAvailableAgentsSection(?Workspace $workspace): ?string
+    {
+        if (!$workspace) {
+            return null;
+        }
+
+        $agents = Agent::where('workspace_id', $workspace->id)
+            ->where('enabled', true)
+            ->orderBy('name')
+            ->get(['slug', 'name', 'provider', 'model', 'description']);
+
+        if ($agents->isEmpty()) {
+            return null;
+        }
+
+        $lines = ["# Available Agents\n"];
+        $lines[] = "Use these agent slugs with the SubAgent tool (`pd subagent:run --agent=<slug>`).\n";
+        $lines[] = "| Slug | Provider | Model | Description |";
+        $lines[] = "|------|----------|-------|-------------|";
+
+        foreach ($agents as $agent) {
+            $desc = $agent->description ? Str::limit($agent->description, 60) : '-';
+            $lines[] = "| {$agent->slug} | {$agent->provider} | {$agent->model} | {$desc} |";
+        }
+
+        return implode("\n", $lines);
     }
 
     /**

--- a/www/app/Tools/SubAgentOutputTool.php
+++ b/www/app/Tools/SubAgentOutputTool.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\SubAgentTask;
+
+class SubAgentOutputTool extends Tool
+{
+    public string $name = 'SubAgentOutput';
+
+    public string $description = 'Retrieve the status and output of a sub-agent task.';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'task_id' => [
+                'type' => 'string',
+                'description' => 'The task UUID returned by SubAgent when using background mode.',
+            ],
+        ],
+        'required' => ['task_id'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Retrieve the status and output of a background sub-agent task.
+
+## When to Use
+- After launching a sub-agent with background=true
+- To poll for completion of a running sub-agent
+- To retrieve the final output once a sub-agent completes
+
+## Status Values
+- **running**: Sub-agent is still processing
+- **completed**: Sub-agent finished, output is included in the response
+- **failed**: Sub-agent encountered an error, error details are included
+- **pending**: Sub-agent has not started yet (rare, transient state)
+
+## Polling Pattern
+For background tasks, poll periodically until status is "completed" or "failed":
+1. Launch sub-agent with background=true, get task_id
+2. Do other work
+3. Check status with SubAgentOutput
+4. If still "running", wait and check again
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+pd subagent:output --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:output';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $taskId = trim($input['task_id'] ?? '');
+
+        if (empty($taskId)) {
+            return ToolResult::error('task_id is required');
+        }
+
+        $task = SubAgentTask::with('childConversation')->find($taskId);
+
+        if (!$task) {
+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
+        }
+
+        $status = $task->getStatus();
+
+        $result = [
+            'task_id' => $task->id,
+            'status' => $status,
+            'agent_id' => $task->agent_id,
+            'is_background' => $task->is_background,
+            'created_at' => $task->created_at?->toIso8601String(),
+        ];
+
+        if ($status === 'completed') {
+            $result['output'] = $task->collectOutput();
+        } elseif ($status === 'failed') {
+            $result['error'] = $task->getError();
+        } elseif ($status === 'running') {
+            $result['message'] = 'Sub-agent is still processing. Check again later.';
+        }
+
+        return ToolResult::success(json_encode($result, JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -111,12 +111,11 @@ API;
             return ToolResult::error('prompt is required');
         }
 
-        // Resolve agent by slug, or by UUID if input looks like one
-        $query = Agent::where('slug', $agentIdentifier);
-        if (Str::isUuid($agentIdentifier)) {
-            $query->orWhere('id', $agentIdentifier);
+        // Resolve agent by slug first, then fall back to UUID lookup
+        $agent = Agent::where('slug', $agentIdentifier)->first();
+        if (!$agent && Str::isUuid($agentIdentifier)) {
+            $agent = Agent::find($agentIdentifier);
         }
-        $agent = $query->first();
 
         if (!$agent) {
             return ToolResult::error("Agent '{$agentIdentifier}' not found. Use an agent slug or UUID from the Available Agents list.");
@@ -206,8 +205,6 @@ API;
         $startTime = time();
 
         while (time() - $startTime < $maxWaitSeconds) {
-            usleep($pollIntervalMicroseconds);
-
             $conversation->refresh();
 
             if ($conversation->status === Conversation::STATUS_IDLE) {
@@ -224,15 +221,14 @@ API;
             if ($conversation->status === Conversation::STATUS_FAILED) {
                 $task->unsetRelation('childConversation');
                 $error = $task->getError();
-                return ToolResult::error(json_encode([
-                    'task_id' => $task->id,
-                    'status' => 'failed',
-                    'error' => $error,
-                ], JSON_PRETTY_PRINT));
+                return ToolResult::error("Sub-agent task '{$task->id}' failed: {$error}");
             }
+
+            usleep($pollIntervalMicroseconds);
         }
 
-        // Timed out
+        // Timed out — returned as success because the task is still running
+        // and the caller can poll via SubAgentOutput later.
         return ToolResult::success(json_encode([
             'task_id' => $task->id,
             'status' => 'timeout',

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace App\Tools;
+
+use App\Jobs\ProcessConversationStream;
+use App\Models\Agent;
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Models\Workspace;
+use App\Services\ConversationFactory;
+use App\Services\StreamManager;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class SubAgentTool extends Tool
+{
+    public string $name = 'SubAgent';
+
+    public string $description = 'Spawn a child PocketDev agent to handle a task. Supports cross-provider delegation (e.g. Claude Code can call Codex and vice versa).';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'agent' => [
+                'type' => 'string',
+                'description' => 'Agent slug or UUID. See "Available Agents" in the system prompt for valid values.',
+            ],
+            'prompt' => [
+                'type' => 'string',
+                'description' => 'The task/prompt to send to the sub-agent.',
+            ],
+            'background' => [
+                'type' => 'boolean',
+                'description' => 'If true, return immediately with a task_id. If false (default), wait for the sub-agent to complete and return its output.',
+            ],
+        ],
+        'required' => ['agent', 'prompt'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Spawn a child PocketDev agent to handle a task using any configured provider. This enables cross-provider delegation: Claude Code can call a Codex agent, Codex can call a Claude Code agent, etc.
+
+## When to Use
+- Delegate specialized tasks to a different AI model or provider
+- Run multiple tasks in parallel using background mode
+- Break complex work into sub-tasks handled by purpose-built agents
+
+## Foreground Mode (default)
+Blocks until the sub-agent completes and returns its full output. Use for tasks where you need the result before continuing.
+
+## Background Mode
+Returns immediately with a task_id. Use SubAgentOutput to check status and retrieve results later. Ideal for parallelism.
+
+## Parameters
+- agent: Agent slug or UUID (see "Available Agents" section in this prompt)
+- prompt: The task/prompt to send. Be specific and self-contained — the sub-agent has no context from your conversation
+- background: Optional boolean (default: false). Set to true for background execution
+
+## Important Notes
+- The sub-agent starts a fresh conversation — it does NOT see your conversation history
+- Write self-contained prompts with all necessary context
+- The sub-agent shares your working directory and workspace
+- Foreground mode has a 10-minute timeout
+- For background tasks, use SubAgentOutput to poll for completion
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+# Foreground: wait for result
+pd subagent:run --agent=codex-default --prompt="List all TODO comments in the codebase"
+
+# Background: get task ID immediately
+pd subagent:run --agent=claude-code-default --prompt="Refactor the auth module" --background
+
+# Then check output later
+pd subagent:output --task-id=<uuid-from-above>
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "agent": "codex-default",
+  "prompt": "Find and fix all TypeScript type errors",
+  "background": true
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:run';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $agentIdentifier = trim($input['agent'] ?? '');
+        $prompt = trim($input['prompt'] ?? '');
+        $isBackground = (bool) ($input['background'] ?? false);
+
+        if (empty($agentIdentifier)) {
+            return ToolResult::error('agent is required. See "Available Agents" in the system prompt.');
+        }
+        if (empty($prompt)) {
+            return ToolResult::error('prompt is required');
+        }
+
+        // Resolve agent by slug, or by UUID if input looks like one
+        $query = Agent::where('slug', $agentIdentifier);
+        if (Str::isUuid($agentIdentifier)) {
+            $query->orWhere('id', $agentIdentifier);
+        }
+        $agent = $query->first();
+
+        if (!$agent) {
+            return ToolResult::error("Agent '{$agentIdentifier}' not found. Use an agent slug or UUID from the Available Agents list.");
+        }
+
+        if (!$agent->enabled) {
+            return ToolResult::error("Agent '{$agent->name}' is disabled.");
+        }
+
+        // Determine workspace
+        $workspace = $context->getWorkspace() ?? $agent->workspace;
+        $workspaceId = $workspace?->id;
+        $workingDirectory = $context->workingDirectory;
+
+        try {
+            // Create child conversation via the factory
+            $factory = app(ConversationFactory::class);
+            $conversation = $factory->createFromAgent(
+                $agent,
+                $workingDirectory,
+                $workspaceId,
+                'Subagent: ' . Str::limit($prompt, 60)
+            );
+
+            // Create the subagent task record
+            $task = SubAgentTask::create([
+                'parent_conversation_uuid' => $context->conversationUuid,
+                'child_conversation_uuid' => $conversation->uuid,
+                'agent_id' => $agent->id,
+                'prompt' => $prompt,
+                'is_background' => $isBackground,
+            ]);
+
+            // Initialize the Redis stream
+            $streamManager = app(StreamManager::class);
+            $streamManager->startStream($conversation->uuid, [
+                'model' => $conversation->model,
+                'provider' => $conversation->provider_type,
+                'subagent_task_id' => $task->id,
+            ]);
+
+            // Dispatch the streaming job
+            ProcessConversationStream::dispatch(
+                $conversation->uuid,
+                $prompt,
+            );
+
+            Log::info('SubAgent task started', [
+                'task_id' => $task->id,
+                'parent_conversation' => $context->conversationUuid,
+                'child_conversation' => $conversation->uuid,
+                'agent' => $agent->slug,
+                'background' => $isBackground,
+            ]);
+
+            // Background mode: return immediately
+            if ($isBackground) {
+                return ToolResult::success(json_encode([
+                    'task_id' => $task->id,
+                    'status' => 'running',
+                    'agent' => $agent->slug,
+                    'provider' => $agent->provider,
+                    'model' => $conversation->model,
+                    'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output.",
+                ], JSON_PRETTY_PRINT));
+            }
+
+            // Foreground mode: poll until complete
+            return $this->waitForCompletion($task, $conversation);
+
+        } catch (\Exception $e) {
+            Log::error('SubAgent failed to start', [
+                'agent' => $agentIdentifier,
+                'error' => $e->getMessage(),
+            ]);
+            return ToolResult::error('Failed to start sub-agent: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Poll the conversation until it completes or times out.
+     */
+    private function waitForCompletion(SubAgentTask $task, Conversation $conversation): ToolResult
+    {
+        $maxWaitSeconds = 600; // 10 minutes
+        $pollIntervalMicroseconds = 1_000_000; // 1 second
+        $startTime = time();
+
+        while (time() - $startTime < $maxWaitSeconds) {
+            usleep($pollIntervalMicroseconds);
+
+            $conversation->refresh();
+
+            if ($conversation->status === Conversation::STATUS_IDLE) {
+                // Reload task's relationship so collectOutput sees the final messages
+                $task->unsetRelation('childConversation');
+                $output = $task->collectOutput();
+                return ToolResult::success(json_encode([
+                    'task_id' => $task->id,
+                    'status' => 'completed',
+                    'output' => $output,
+                ], JSON_PRETTY_PRINT));
+            }
+
+            if ($conversation->status === Conversation::STATUS_FAILED) {
+                $task->unsetRelation('childConversation');
+                $error = $task->getError();
+                return ToolResult::error(json_encode([
+                    'task_id' => $task->id,
+                    'status' => 'failed',
+                    'error' => $error,
+                ], JSON_PRETTY_PRINT));
+            }
+        }
+
+        // Timed out
+        return ToolResult::success(json_encode([
+            'task_id' => $task->id,
+            'status' => 'timeout',
+            'message' => "Sub-agent did not complete within {$maxWaitSeconds} seconds. Use SubAgentOutput with task_id '{$task->id}' to check status later.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -9,6 +9,7 @@ use App\Models\SubAgentTask;
 use App\Models\Workspace;
 use App\Services\ConversationFactory;
 use App\Services\StreamManager;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
@@ -111,45 +112,50 @@ API;
             return ToolResult::error('prompt is required');
         }
 
-        // Resolve agent by slug first, then fall back to UUID lookup
-        $agent = Agent::where('slug', $agentIdentifier)->first();
+        // Scope agent resolution to the caller's workspace
+        $workspace = $context->getWorkspace();
+        $agentQuery = Agent::query()->where('enabled', true);
+        if ($workspace) {
+            $agentQuery->where('workspace_id', $workspace->id);
+        }
+
+        $agent = (clone $agentQuery)->where('slug', $agentIdentifier)->first();
         if (!$agent && Str::isUuid($agentIdentifier)) {
-            $agent = Agent::find($agentIdentifier);
+            $agent = (clone $agentQuery)->whereKey($agentIdentifier)->first();
         }
 
         if (!$agent) {
             return ToolResult::error("Agent '{$agentIdentifier}' not found. Use an agent slug or UUID from the Available Agents list.");
         }
 
-        if (!$agent->enabled) {
-            return ToolResult::error("Agent '{$agent->name}' is disabled.");
-        }
-
-        // Determine workspace
-        $workspace = $context->getWorkspace() ?? $agent->workspace;
+        // Determine workspace (fall back to agent's workspace if context has none)
+        $workspace = $workspace ?? $agent->workspace;
         $workspaceId = $workspace?->id;
         $workingDirectory = $context->workingDirectory;
 
         try {
-            // Create child conversation via the factory
-            $factory = app(ConversationFactory::class);
-            $conversation = $factory->createFromAgent(
-                $agent,
-                $workingDirectory,
-                $workspaceId,
-                'Subagent: ' . Str::limit($prompt, 60)
-            );
+            // Create child conversation + task atomically
+            [$conversation, $task] = DB::transaction(function () use ($agent, $workingDirectory, $workspaceId, $prompt, $context, $isBackground) {
+                $factory = app(ConversationFactory::class);
+                $conversation = $factory->createFromAgent(
+                    $agent,
+                    $workingDirectory,
+                    $workspaceId,
+                    'Subagent: ' . Str::limit($prompt, 60)
+                );
 
-            // Create the subagent task record
-            $task = SubAgentTask::create([
-                'parent_conversation_uuid' => $context->conversationUuid,
-                'child_conversation_uuid' => $conversation->uuid,
-                'agent_id' => $agent->id,
-                'prompt' => $prompt,
-                'is_background' => $isBackground,
-            ]);
+                $task = SubAgentTask::create([
+                    'parent_conversation_uuid' => $context->conversationUuid,
+                    'child_conversation_uuid' => $conversation->uuid,
+                    'agent_id' => $agent->id,
+                    'prompt' => $prompt,
+                    'is_background' => $isBackground,
+                ]);
 
-            // Initialize the Redis stream
+                return [$conversation, $task];
+            });
+
+            // Initialize the Redis stream (outside transaction — not DB state)
             $streamManager = app(StreamManager::class);
             $streamManager->startStream($conversation->uuid, [
                 'model' => $conversation->model,
@@ -207,7 +213,7 @@ API;
         while (time() - $startTime < $maxWaitSeconds) {
             $conversation->refresh();
 
-            if ($conversation->status === Conversation::STATUS_IDLE) {
+            if (in_array($conversation->status, [Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED], true)) {
                 // Reload task's relationship so collectOutput sees the final messages
                 $task->unsetRelation('childConversation');
                 $output = $task->collectOutput();

--- a/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
+++ b/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subagent_tasks', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            // Links to the parent conversation that spawned this
+            $table->string('parent_conversation_uuid', 36)->nullable()->index();
+
+            // Links to the child conversation running the task
+            $table->string('child_conversation_uuid', 36)->index();
+
+            // Which agent was used
+            $table->uuid('agent_id')->index();
+
+            // The prompt that was sent
+            $table->text('prompt');
+
+            // Whether this is a background task
+            $table->boolean('is_background')->default(false);
+
+            $table->timestamps();
+
+            $table->foreign('child_conversation_uuid')
+                ->references('uuid')
+                ->on('conversations')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subagent_tasks');
+    }
+};


### PR DESCRIPTION
## Summary

Builds on top of PR #202 (`fix/codex-integration-fixes`).

- **SubAgent tool**: any PocketDev agent can spawn a child conversation with any other agent, regardless of provider. Claude Code can delegate to Codex, Codex to Claude Code, etc.
- **Two execution modes**: foreground (blocks up to 10 min until child completes) and background (returns task_id immediately, poll with SubAgentOutput)
- **System prompt injection**: Available Agents table rendered automatically so the calling agent knows valid slugs
- **CLI env vars**: AbstractCliProvider now passes `POCKETDEV_CONVERSATION_UUID` and `POCKETDEV_WORKSPACE_ID` so subagent commands can resolve parent context

## New files (6)

| File | Purpose |
|------|---------|
| `SubAgentTool.php` | Spawns child conversation via ConversationFactory, dispatches ProcessConversationStream, polls or returns immediately |
| `SubAgentOutputTool.php` | Retrieves status/output of background task by task_id |
| `SubAgentRunCommand.php` | `pd subagent:run --agent=<slug> --prompt="..." [--background]` |
| `SubAgentOutputCommand.php` | `pd subagent:output --task-id=<uuid>` |
| `SubAgentTask.php` | Thin model linking parent↔child conversations; status and output derived live from child conversation |
| `create_subagent_tasks_table` migration | UUID PK, parent/child conversation UUIDs, agent_id, prompt, is_background |

## Modified files (2)

| File | Change |
|------|--------|
| `SystemPromptBuilder.php` | Added `buildAvailableAgentsSection()` — renders markdown table of enabled agents between Memory and Skills sections |
| `AbstractCliProvider.php` | Passes `POCKETDEV_CONVERSATION_UUID` and `POCKETDEV_WORKSPACE_ID` env vars to CLI process |

## Design decisions

- **No changes to ProcessConversationStream or ConversationFactory** — reuses the existing job/factory pipeline as-is
- **Status derived live** — `SubAgentTask.getStatus()` maps the child conversation's status at query time (no denormalization, no observer)
- **UUID-safe agent resolution** — only attempts `WHERE id = ?` when input passes `Str::isUuid()`, avoiding PostgreSQL type errors
- **Stale relationship guard** — `unsetRelation('childConversation')` before collecting output in foreground mode

## Test plan

- [x] `pd subagent:run --agent=sonnet-8k --prompt="Reply with exactly: Hello from subagent" --background` → returns task_id
- [x] `pd subagent:output --task-id=<uuid>` → returns status=completed with output "Hello from subagent"
- [x] Foreground: `pd subagent:run --agent=sonnet-8k --prompt="What is 2+2?"` → blocks, returns "4"
- [x] Invalid agent → clean error message
- [x] Invalid task_id → clean error message
- [x] Available Agents section renders in system prompt
- [ ] Cross-provider: Claude Code spawns Codex subagent (requires Codex configured)
- [ ] Timeout behavior (10 min foreground limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spawn sub-agents to delegate tasks with foreground/background modes.
  * Retrieve sub-agent task status and output via a new query command/tool.
  * Added GPT-5.4 Codex model and an explicit "Off" reasoning option.

* **Bug Fixes**
  * Improved Codex authentication flow and OAuth token handling.
  * Host-based Codex login UI and guidance updated.

* **Improvements**
  * System prompts now list available agents.
  * MCP server synchronization from Claude config for Codex.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->