### PR TITLE
perf: skip reinstalling system packages that are already present [ready to merge]

### DIFF
--- a/docker-laravel/shared/scripts/install-system-packages.sh
+++ b/docker-laravel/shared/scripts/install-system-packages.sh
@@ -46,6 +46,24 @@ echo "$packages_json" | jq -c '.[]' 2>/dev/null | while read -r pkg; do
     pkg_id=$(echo "$pkg" | jq -r '.id')
     pkg_name=$(echo "$pkg" | jq -r '.name')
     pkg_script=$(echo "$pkg" | jq -r '.script')
+    pkg_status=$(echo "$pkg" | jq -r '.status // ""')
+    pkg_cli=$(echo "$pkg" | jq -r '.cli_commands // ""')
+
+    # Skip if already installed and all CLI commands are present in PATH.
+    # This avoids re-running expensive install scripts (e.g. dotnet, az) on every container restart.
+    if [ "$pkg_status" = "installed" ] && [ -n "$pkg_cli" ]; then
+        all_present=true
+        for cmd in $(echo "$pkg_cli" | tr ',' '\n' | tr -d ' '); do
+            if [ -n "$cmd" ] && ! command -v "$cmd" > /dev/null 2>&1; then
+                all_present=false
+                break
+            fi
+        done
+        if [ "$all_present" = "true" ]; then
+            echo "  ✓ $pkg_name already installed (skipping)"
+            continue
+        fi
+    fi
 
     # Auto-rewrite /tmp/ to /var/tmp/ in install scripts
     # This fixes curl write errors caused by the shared /tmp volume during startup

--- a/docker-laravel/shared/scripts/install-system-packages.sh
+++ b/docker-laravel/shared/scripts/install-system-packages.sh
@@ -53,13 +53,17 @@ echo "$packages_json" | jq -c '.[]' 2>/dev/null | while read -r pkg; do
     # This avoids re-running expensive install scripts (e.g. dotnet, az) on every container restart.
     if [ "$pkg_status" = "installed" ] && [ -n "$pkg_cli" ]; then
         all_present=true
+        checked=0
         for cmd in $(echo "$pkg_cli" | tr ',' '\n' | tr -d ' '); do
-            if [ -n "$cmd" ] && ! command -v "$cmd" > /dev/null 2>&1; then
+            [ -z "$cmd" ] && continue
+            checked=$((checked + 1))
+            if ! command -v "$cmd" > /dev/null 2>&1; then
                 all_present=false
                 break
             fi
         done
-        if [ "$all_present" = "true" ]; then
+        # Only skip if at least one command was verified (guards against empty/whitespace cli_commands)
+        if [ "$all_present" = "true" ] && [ "$checked" -gt 0 ]; then
             echo "  ✓ $pkg_name already installed (skipping)"
             continue
         fi

--- a/www/app/Models/SystemPackage.php
+++ b/www/app/Models/SystemPackage.php
@@ -44,12 +44,14 @@ class SystemPackage extends Model
      */
     public static function getAllWithScripts(): array
     {
-        return static::select('id', 'name', 'install_script')
+        return static::select('id', 'name', 'install_script', 'cli_commands', 'status')
             ->get()
             ->map(fn($p) => [
                 'id' => $p->id,
                 'name' => $p->name,
                 'script' => $p->install_script,
+                'cli_commands' => $p->cli_commands,
+                'status' => $p->status,
             ])
             ->toArray();
     }


### PR DESCRIPTION
## Summary

- System packages were reinstalled on every container restart, even when already present
- For large packages (dotnet, az-cli, etc.) this could take minutes on each update
- Now skips reinstall if `status=installed` and all configured `cli_commands` are found in `PATH`

## How it works

`install-system-packages.sh` checks before running each install script:
1. Is the package `status=installed` in the DB?
2. Are all `cli_commands` present in `PATH`?

If both true → skip with `✓ already installed (skipping)`. Otherwise → install as normal.

Packages without `cli_commands` configured always run (safe fallback).

Also adds `cli_commands` and `status` to `getAllWithScripts()` export so the shell script has the data available.

## Test plan
- [ ] Add a package (e.g. `jq`) and restart containers — installs normally
- [ ] Restart containers again — `✓ jq already installed (skipping)` appears, fast
- [ ] Remove the binary manually, restart — reinstalls correctly
- [ ] Package with no `cli_commands` set — always runs (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved system package installation to better detect preinstalled tools via declared CLI checks and skip reinstallation when present, reducing install time and avoiding redundant operations.
  * Installation flow now updates package metadata so future installs are more accurate and faster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->