### PR TITLE
feat(subagents): end parent turn immediately after background dispatch + SubAgentCancel tool

### DIFF
--- a/www/app/Console/Commands/SubAgentCancelCommand.php
+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentCancelTool;
+use Illuminate\Console\Command;
+
+class SubAgentCancelCommand extends Command
+{
+    protected $signature = 'subagent:cancel
+        {--task-id= : The task UUID returned by subagent:run --background}';
+
+    protected $description = 'Cancel a running background sub-agent task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentCancelTool();
+
+        $input = [
+            'task_id' => $this->option('task-id') ?? '',
+        ];
+
+        // Note: when called from CLI (not from within a conversation), there is no
+        // parent conversation UUID — the ownership guard in the tool is skipped.
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -666,6 +666,32 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             RequestFlowLogger::log('job.loop.saving_tool_results', 'Saving tool results message');
             $this->saveToolResultMessage($conversation, $toolResults);
 
+            // Check for end-turn signal from a tool (e.g. SubAgent in background mode).
+            // When present, finalize the parent turn immediately without a second AI call,
+            // saving a synthetic assistant message to keep the conversation history well-formed
+            // (avoids two consecutive user messages on the next turn).
+            $endTurnResult = null;
+            foreach ($toolResults as $r) {
+                if ($r['end_turn'] ?? false) {
+                    $endTurnResult = $r;
+                    break;
+                }
+            }
+
+            if ($endTurnResult !== null) {
+                $endTurnMessage = $endTurnResult['end_turn_message'] ?? 'Background agent started.';
+                RequestFlowLogger::log('job.loop.end_turn_signal', 'End-turn signal from tool — ending parent turn early', [
+                    'tool_use_id' => $endTurnResult['tool_use_id'],
+                ]);
+                $this->saveAssistantMessage(
+                    $conversation,
+                    [['type' => 'text', 'text' => $endTurnMessage]],
+                    0, 0, null, null,
+                    'end_turn',
+                );
+                return; // handle() will call completeProcessing()
+            }
+
             // Continue with tool results (recursive)
             // Pass the original user message for abort sync consistency
             RequestFlowLogger::log('job.loop.recursive_call', 'Making recursive call for tool results', [
@@ -808,9 +834,11 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             );
 
             $results[] = [
-                'tool_use_id' => $toolUse['id'],
-                'content' => $result->output,
-                'is_error' => $result->isError,
+                'tool_use_id'      => $toolUse['id'],
+                'content'          => $result->output,
+                'is_error'         => $result->isError,
+                'end_turn'         => $result->endTurn,
+                'end_turn_message' => $result->endTurnMessage,
             ];
         }
 

--- a/www/app/Tools/SubAgentCancelTool.php
+++ b/www/app/Tools/SubAgentCancelTool.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Services\StreamManager;
+
+class SubAgentCancelTool extends Tool
+{
+    public string $name = 'SubAgentCancel';
+
+    public string $description = 'Cancel a running background sub-agent task.';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'task_id' => [
+                'type' => 'string',
+                'description' => 'The task UUID returned by SubAgent when launched with background=true.',
+            ],
+        ],
+        'required' => ['task_id'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Cancel a running background sub-agent task by its task ID.
+
+## When to Use
+- After launching a sub-agent with background=true and deciding to stop it
+- When a background task is no longer needed
+
+## How It Works
+Sets an abort flag on the child conversation. The running sub-agent detects the flag
+within ~1 second on its next event-loop tick and shuts down cleanly.
+Cancellation is non-blocking — this tool returns immediately.
+
+## Notes
+- Only tasks you spawned (from this conversation) can be cancelled
+- If the task has already completed or failed, cancellation is a no-op
+- After cancellation the task status becomes "failed" (same as a user-initiated stop)
+
+## Parameters
+- task_id: The UUID returned by SubAgent when background=true
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+pd subagent:cancel --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:cancel';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $taskId = trim($input['task_id'] ?? '');
+
+        if (empty($taskId)) {
+            return ToolResult::error('task_id is required');
+        }
+
+        $task = SubAgentTask::with('childConversation')->find($taskId);
+
+        if (!$task) {
+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
+        }
+
+        // Guard: only allow cancellation of tasks spawned by this conversation.
+        // Prevents one conversation from aborting another conversation's subagents.
+        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
+            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
+        }
+
+        $conversation = $task->childConversation;
+
+        if (!$conversation) {
+            return ToolResult::error("Sub-agent task '{$taskId}' has no associated conversation.");
+        }
+
+        // If already terminal, nothing to cancel
+        $terminalStatuses = [
+            Conversation::STATUS_IDLE,
+            Conversation::STATUS_ARCHIVED,
+            Conversation::STATUS_FAILED,
+        ];
+
+        if (in_array($conversation->status, $terminalStatuses, true)) {
+            $status = $task->getStatus();
+            return ToolResult::success(json_encode([
+                'task_id'   => $task->id,
+                'cancelled' => false,
+                'status'    => $status,
+                'message'   => "Task is already {$status} — nothing to cancel.",
+            ], JSON_PRETTY_PRINT));
+        }
+
+        // Set the abort flag on the child conversation's stream.
+        // ProcessConversationStream checks this flag in its event loop and will
+        // shut down the child cleanly within ~1 second.
+        $streamManager = app(StreamManager::class);
+        $streamManager->setAbortFlag($conversation->uuid);
+
+        return ToolResult::success(json_encode([
+            'task_id'   => $task->id,
+            'cancelled' => true,
+            'status'    => 'cancelling',
+            'message'   => "Abort signal sent to sub-agent task '{$task->id}'. "
+                . 'The task will stop within ~1 second. '
+                . "Use SubAgentOutput with task_id '{$task->id}' to confirm.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -65,6 +65,7 @@ Returns immediately with a task_id. Use SubAgentOutput to check status and retri
 - The sub-agent shares your working directory and workspace
 - Foreground mode has a 10-minute timeout
 - For background tasks, use SubAgentOutput to poll for completion
+- To stop a running background task, use SubAgentCancel with its task_id
 INSTRUCTIONS;
 
     public ?string $cliExamples = <<<'CLI'
@@ -177,16 +178,23 @@ API;
                 'background' => $isBackground,
             ]);
 
-            // Background mode: return immediately
+            // Background mode: return immediately and signal the stream loop to end
+            // the parent turn without a second AI round-trip.
             if ($isBackground) {
-                return ToolResult::success(json_encode([
-                    'task_id' => $task->id,
-                    'status' => 'running',
-                    'agent' => $agent->slug,
+                $jsonOutput = json_encode([
+                    'task_id'  => $task->id,
+                    'status'   => 'running',
+                    'agent'    => $agent->slug,
                     'provider' => $agent->provider,
-                    'model' => $conversation->model,
-                    'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output.",
-                ], JSON_PRETTY_PRINT));
+                    'model'    => $conversation->model,
+                    'message'  => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output. Use SubAgentCancel with task_id '{$task->id}' to cancel.",
+                ], JSON_PRETTY_PRINT);
+
+                $endTurnMessage = "Background sub-agent started (task `{$task->id}`, agent `{$agent->slug}`). "
+                    . "Use SubAgentOutput to check status and retrieve results, "
+                    . "or SubAgentCancel to stop it.";
+
+                return ToolResult::successEndTurn($jsonOutput, $endTurnMessage);
             }
 
             // Foreground mode: poll until complete

--- a/www/app/Tools/ToolResult.php
+++ b/www/app/Tools/ToolResult.php
@@ -4,6 +4,21 @@ namespace App\Tools;
 
 class ToolResult
 {
+    /**
+     * When true, the stream loop should end the parent turn immediately after
+     * this tool result is saved — without making another AI round-trip.
+     * Used by SubAgentTool in background mode so the parent conversation
+     * becomes interactive again as soon as the child job is dispatched.
+     */
+    public bool $endTurn = false;
+
+    /**
+     * Human-readable text saved as a synthetic closing assistant message
+     * when $endTurn is true. Keeps the conversation history well-formed
+     * (prevents two consecutive user messages on the next turn).
+     */
+    public ?string $endTurnMessage = null;
+
     public function __construct(
         public string $output,
         public bool $isError = false,
@@ -12,6 +27,21 @@ class ToolResult
     public static function success(string $output): self
     {
         return new self($output, false);
+    }
+
+    /**
+     * Like success(), but signals the stream loop to end the parent turn
+     * immediately without a second AI call.
+     *
+     * @param string $output       JSON output returned as the tool result content
+     * @param string $endTurnMessage  Text for the synthetic closing assistant message
+     */
+    public static function successEndTurn(string $output, string $endTurnMessage): self
+    {
+        $result = new self($output, false);
+        $result->endTurn = true;
+        $result->endTurnMessage = $endTurnMessage;
+        return $result;
     }
 
     public static function error(string $message): self


### PR DESCRIPTION
## Summary

Closes #280. Depends on #248 (targets `feature/native-subagents-v2`).

- **Parent turn ends immediately** after spawning a background subagent — no second AI round-trip, no waiting. The user can send new messages as soon as the child job is dispatched.
- **New `SubAgentCancel` tool** lets the parent agent (or CLI) cancel a running background task by task ID.

## Changes

### `ToolResult` — end-turn signal
Added `$endTurn`, `$endTurnMessage`, and `successEndTurn()` factory. A tool can now signal to the stream loop that the parent turn should close immediately after its result is saved, without making another API call.

### `SubAgentTool` — use signal in background mode
Background mode now returns `successEndTurn()` instead of plain `success()`, including a human-readable `$endTurnMessage` that becomes the synthetic closing assistant message.

### `ProcessConversationStream` — detect and handle signal
- `executeTools()` propagates `end_turn` / `end_turn_message` from `ToolResult` to its result array.
- `streamWithToolLoop()` checks after saving tool results. When the flag is set: saves a **synthetic assistant message** (keeps history well-formed — prevents two consecutive user messages on the next API call), then returns early. `handle()` calls `completeProcessing()` normally.

### `SubAgentCancelTool` + `SubAgentCancelCommand`
- Calls `StreamManager::setAbortFlag($childConversationUuid)` — the same abort mechanism used by user-initiated stops. The child detects it within ~1 second and shuts down cleanly.
- **Ownership guard**: only the conversation that spawned the task can cancel it (skipped from CLI).
- **No-op** with a clear message if the task is already `completed` / `failed` / `archived`.
- Artisan: `pd subagent:cancel --task-id=<uuid>`

## Conversation history after background spawn

```
[user: "Build X in the background"]
[assistant: text... + SubAgent(background=true) tool_use]
[user: tool_result { task_id, status: running }]
[assistant: "Background sub-agent started (task `<id>`, agent `<slug>`). Use SubAgentOutput to check status..." ]  ← synthetic, no API call
← conversation idle, user can chat again →
```

## Tool trio for background subagents

| Tool | Purpose |
|------|---------|
| `SubAgent` (`background: true`) | Spawn — returns `task_id`, ends parent turn |
| `SubAgentOutput` | Poll status / collect output |
| `SubAgentCancel` | Send abort signal to child |

## Test plan

- [ ] `pd subagent:run --agent=<slug> --prompt="..." --background` → parent conversation idles immediately after tool result
- [ ] Send a new message to parent immediately — no errors, history is well-formed
- [ ] DB check: history ends `[assistant+tool_use] → [user: tool_result] → [assistant: synthetic]`
- [ ] Child conversation runs to completion independently
- [ ] `pd subagent:output --task-id=<id>` returns `running` then `completed`
- [ ] `pd subagent:cancel --task-id=<id>` while running → child aborts within ~1s, status becomes `failed`
- [ ] `pd subagent:cancel --task-id=<id>` after completed → returns no-op message
- [ ] Cancel from wrong conversation → ownership error

🤖 Generated with [Claude Code](https://claude.com/claude-code)