### PR TITLE
fix: separate auto-compact + blocking limit for 1M context agents

### DIFF
--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -310,11 +310,18 @@ class ConversationController extends Controller
         // Detect /compact slash command for Claude Code CLI conversations.
         // When triggered, the job bypasses the normal turn and sends /compact to the CLI directly.
         $jobOptions = [];
-        if (
-            $conversation->provider_type === 'claude_code'
-            && strtolower(trim($validated['prompt'])) === '/compact'
-            && !empty($conversation->provider_session_id)
-        ) {
+        $isCompactCommand = $conversation->provider_type === 'claude_code'
+            && strtolower(trim($validated['prompt'])) === '/compact';
+
+        if ($isCompactCommand) {
+            if (empty($conversation->provider_session_id)) {
+                RequestFlowLogger::log('controller.stream.compact_no_session', '/compact requires an active session');
+                RequestFlowLogger::endRequest('error');
+                return response()->json([
+                    'success' => false,
+                    'error' => '/compact requires an active Claude Code session. Send a message first to start one.',
+                ], 422);
+            }
             $jobOptions['is_compact_command'] = true;
         }
 

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -307,8 +307,10 @@ class ConversationController extends Controller
         // Note: startStream() already clears old events inside its MULTI/EXEC transaction
         RequestFlowLogger::log('controller.stream.redis_initialized', 'Stream state initialized');
 
+
         // Detect /compact slash command for Claude Code CLI conversations.
         // When triggered, the job bypasses the normal turn and sends /compact to the CLI directly.
+        // Must be checked BEFORE startStream() to avoid leaving an orphaned stream state on error.
         $jobOptions = [];
         $isCompactCommand = $conversation->provider_type === 'claude_code'
             && strtolower(trim($validated['prompt'])) === '/compact';
@@ -324,6 +326,16 @@ class ConversationController extends Controller
             }
             $jobOptions['is_compact_command'] = true;
         }
+
+        // Initialize stream state BEFORE cleanup to prevent race condition
+        // This ensures clients won't see 'not_found' after cleanup and before job starts
+        RequestFlowLogger::log('controller.stream.initializing', 'Initializing stream state in Redis');
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+        ]);
+        // Note: startStream() already clears old events inside its MULTI/EXEC transaction
+        RequestFlowLogger::log('controller.stream.redis_initialized', 'Stream state initialized');
 
         // Dispatch background job - reasoning settings are now stored on conversation
         RequestFlowLogger::log('controller.stream.dispatching_job', 'Dispatching ProcessConversationStream job');

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -307,6 +307,17 @@ class ConversationController extends Controller
         // Note: startStream() already clears old events inside its MULTI/EXEC transaction
         RequestFlowLogger::log('controller.stream.redis_initialized', 'Stream state initialized');
 
+        // Detect /compact slash command for Claude Code CLI conversations.
+        // When triggered, the job bypasses the normal turn and sends /compact to the CLI directly.
+        $jobOptions = [];
+        if (
+            $conversation->provider_type === 'claude_code'
+            && strtolower(trim($validated['prompt'])) === '/compact'
+            && !empty($conversation->provider_session_id)
+        ) {
+            $jobOptions['is_compact_command'] = true;
+        }
+
         // Dispatch background job - reasoning settings are now stored on conversation
         RequestFlowLogger::log('controller.stream.dispatching_job', 'Dispatching ProcessConversationStream job');
         ProcessConversationStream::dispatch(

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -297,17 +297,6 @@ class ConversationController extends Controller
             ], 409);
         }
 
-        // Initialize stream state BEFORE cleanup to prevent race condition
-        // This ensures clients won't see 'not_found' after cleanup and before job starts
-        RequestFlowLogger::log('controller.stream.initializing', 'Initializing stream state in Redis');
-        $this->streamManager->startStream($conversation->uuid, [
-            'model' => $conversation->model,
-            'provider' => $conversation->provider_type,
-        ]);
-        // Note: startStream() already clears old events inside its MULTI/EXEC transaction
-        RequestFlowLogger::log('controller.stream.redis_initialized', 'Stream state initialized');
-
-
         // Detect /compact slash command for Claude Code CLI conversations.
         // When triggered, the job bypasses the normal turn and sends /compact to the CLI directly.
         // Must be checked BEFORE startStream() to avoid leaving an orphaned stream state on error.
@@ -342,7 +331,7 @@ class ConversationController extends Controller
         ProcessConversationStream::dispatch(
             $conversation->uuid,
             $validated['prompt'],
-            [] // Options no longer needed for reasoning - stored on conversation
+            $jobOptions
         );
         RequestFlowLogger::log('controller.stream.job_dispatched', 'Job dispatched to queue');
 

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -106,7 +106,6 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                     $conversation,
                     $provider,
                     $streamManager,
-                    $modelRepository,
                     $this->options,
                 );
                 RequestFlowLogger::log('job.handle.compact_command_completed', '/compact command completed');
@@ -727,7 +726,6 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
         Conversation $conversation,
         AIProviderInterface $provider,
         StreamManager $streamManager,
-        ModelRepository $modelRepository,
         array $options,
     ): void {
         $streamOptions = array_merge($options, ['override_user_message' => '/compact']);

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -84,13 +84,6 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             // Mark conversation as processing
             $conversation->startProcessing();
             RequestFlowLogger::log('job.handle.processing_started', 'Marked conversation as processing');
-            // Save user message and keep reference for abort sync
-            RequestFlowLogger::log('job.handle.saving_user_message', 'Saving user message');
-            $userMessage = $this->saveUserMessage($conversation, $this->prompt);
-            RequestFlowLogger::log('job.handle.user_message_saved', 'User message saved', [
-                'message_id' => $userMessage->id,
-            ]);
-
             // Get provider
             $provider = $providerFactory->make($conversation->provider_type);
             $providerAvailable = $provider->isAvailable();
@@ -102,19 +95,43 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                 throw new \RuntimeException("Provider '{$conversation->provider_type}' is not available");
             }
 
-            // Stream with tool execution loop
-            RequestFlowLogger::log('job.handle.starting_stream_loop', 'Starting stream with tool loop');
-            $this->streamWithToolLoop(
-                $conversation,
-                $provider,
-                $streamManager,
-                $toolRegistry,
-                $systemPromptBuilder,
-                $modelRepository,
-                $this->options,
-                userMessage: $userMessage
-            );
-            RequestFlowLogger::log('job.handle.stream_loop_completed', 'Stream loop completed');
+            // /compact command: trigger CLI compaction without saving a user message turn
+            if (!empty($this->options['is_compact_command'])) {
+                RequestFlowLogger::log('job.handle.compact_command', 'Handling /compact command');
+                // Wire abort checker so /abort can interrupt the compact stream
+                if ($provider instanceof AbstractCliProvider) {
+                    $provider->setAbortChecker(fn() => $streamManager->checkAbortFlag($this->conversationUuid));
+                }
+                $this->handleCompactCommand(
+                    $conversation,
+                    $provider,
+                    $streamManager,
+                    $modelRepository,
+                    $this->options,
+                );
+                RequestFlowLogger::log('job.handle.compact_command_completed', '/compact command completed');
+            } else {
+                // Save user message and keep reference for abort sync
+                RequestFlowLogger::log('job.handle.saving_user_message', 'Saving user message');
+                $userMessage = $this->saveUserMessage($conversation, $this->prompt);
+                RequestFlowLogger::log('job.handle.user_message_saved', 'User message saved', [
+                    'message_id' => $userMessage->id,
+                ]);
+
+                // Stream with tool execution loop
+                RequestFlowLogger::log('job.handle.starting_stream_loop', 'Starting stream with tool loop');
+                $this->streamWithToolLoop(
+                    $conversation,
+                    $provider,
+                    $streamManager,
+                    $toolRegistry,
+                    $systemPromptBuilder,
+                    $modelRepository,
+                    $this->options,
+                    userMessage: $userMessage
+                );
+                RequestFlowLogger::log('job.handle.stream_loop_completed', 'Stream loop completed');
+            }
 
             // Only finalize if not already completed/aborted inside streamWithToolLoop
             $currentStatus = $conversation->fresh()->status;
@@ -696,6 +713,93 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             $this->saveToolResultMessage($conversation, $streamedToolResults);
         } else {
             RequestFlowLogger::log('job.loop.no_tools', 'No tool execution needed - loop complete');
+        }
+    }
+
+    /**
+     * Handle a /compact slash command for Claude Code sessions.
+     *
+     * Passes "/compact" as the prompt to the CLI (via override_user_message) so it triggers
+     * a context compaction. No user or assistant message is saved — only a compaction message
+     * if the CLI emits COMPACTION_SUMMARY.
+     */
+    private function handleCompactCommand(
+        Conversation $conversation,
+        AIProviderInterface $provider,
+        StreamManager $streamManager,
+        ModelRepository $modelRepository,
+        array $options,
+    ): void {
+        $streamOptions = array_merge($options, ['override_user_message' => '/compact']);
+        $compactionReceived = false;
+
+        foreach ($provider->streamMessage($conversation, $streamOptions) as $event) {
+            // Check abort flag before processing each event
+            if ($streamManager->checkAbortFlag($this->conversationUuid)) {
+                RequestFlowLogger::log('job.compact.aborted', 'Abort detected during compact stream');
+                $conversation->completeProcessing();
+                $streamManager->appendEvent($this->conversationUuid, StreamEvent::done('aborted'));
+                $streamManager->completeStream($this->conversationUuid, 'aborted');
+                $streamManager->clearAbortFlag($this->conversationUuid);
+                // abort() may block on proc_close() — called after stream is already marked done
+                if ($provider instanceof AbstractCliProvider) {
+                    $provider->abort();
+                }
+                return;
+            }
+
+            RequestFlowLogger::log('job.compact.event', 'Compact stream event', [
+                'type' => $event->type,
+            ]);
+
+            switch ($event->type) {
+                case StreamEvent::COMPACTION_SUMMARY:
+                    $compactionReceived = true;
+                    RequestFlowLogger::log('job.compact.summary_received', 'Compaction summary received', [
+                        'summary_length' => strlen($event->content ?? ''),
+                        'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
+                    ]);
+                    Message::create([
+                        'conversation_id' => $conversation->id,
+                        'role' => Message::ROLE_COMPACTION,
+                        'content' => [
+                            'summary' => $event->content,
+                            'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
+                            'trigger' => 'manual',
+                        ],
+                    ]);
+                    // Forward the event so the frontend can display the compaction banner
+                    $streamManager->appendEvent($this->conversationUuid, $event);
+                    Log::channel('api')->info('ProcessConversationStream: Manual compaction saved', [
+                        'conversation' => $this->conversationUuid,
+                        'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
+                    ]);
+                    break;
+
+                case StreamEvent::DONE:
+                    // Stream ended — fail if no compaction summary was received.
+                    // This catches timeout/no-op paths where the CLI exits without compacting.
+                    if (!$compactionReceived) {
+                        throw new \RuntimeException('Compact command completed without producing a compaction summary. The context may be too small to compact.');
+                    }
+                    break;
+
+                case StreamEvent::ERROR:
+                    throw new \RuntimeException($event->content ?? 'Compact command failed');
+            }
+        }
+
+        // Post-loop abort check: handles the case where the CLI's inner abort checker fired
+        // and the generator returned early without yielding another event.
+        if ($streamManager->checkAbortFlag($this->conversationUuid)) {
+            RequestFlowLogger::log('job.compact.aborted', 'Abort detected after compact stream ended');
+            $conversation->completeProcessing();
+            $streamManager->appendEvent($this->conversationUuid, StreamEvent::done('aborted'));
+            $streamManager->completeStream($this->conversationUuid, 'aborted');
+            $streamManager->clearAbortFlag($this->conversationUuid);
+            if ($provider instanceof AbstractCliProvider) {
+                $provider->abort();
+            }
         }
     }
 

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -187,15 +187,28 @@ class ClaudeCodeProvider extends AbstractCliProvider
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
 
-        // Disable auto-compact only for 1M context conversations. For standard
-        // 200K users, auto-compact works correctly and prevents "Prompt is too long"
-        // errors caused by unbounded session history accumulation. For 1M users
-        // (Max subscribers), the CLI detects 200K from server betas and would
-        // compact at ~166K — far too early — so we disable it and let them use
-        // /compact manually instead.
-        $contextWindow = $conversation->context_window_size ?? 0;
-        if ($contextWindow >= 900000) {
+        // For 1M context agents, the CLI has two separate limits that must both be addressed:
+        //
+        // 1. DISABLE_AUTO_COMPACT=1 — prevents auto-compact at ~167K tokens.
+        //    The CLI determines context window from server-sent SDK betas. Max subscribers
+        //    receive "context-1m-2025-08-07" at the API level, but the CLI still calculates
+        //    its compact threshold against ~200K, causing premature compaction at ~167K.
+        //
+        // 2. CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE=977000 — bypasses the hard blocking limit.
+        //    DISABLE_AUTO_COMPACT does NOT bypass this limit (different code path in CLI).
+        //    Without this override, the CLI blocks requests at ~177K tokens regardless.
+        //    Formula: ZQ(model) - We1 = (200K - 20K) - 3K = 177K (empirically confirmed).
+        //    With this override, the CLI allows up to 977K tokens before blocking, matching
+        //    the actual 1M API window available to Max subscribers.
+        //
+        // For standard 200K agents, auto-compact works correctly at ~167K and prevents
+        // "Prompt is too long" errors from unbounded session history accumulation.
+        $is1mAgent = $conversation->agent?->extended_context
+            && $this->models->getMaxContextWindow($conversation->model ?? '') > 200000;
+
+        if ($is1mAgent) {
             $env['DISABLE_AUTO_COMPACT'] = '1';
+            $env['CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE'] = '977000';
         }
 
         return $env;

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -187,6 +187,17 @@ class ClaudeCodeProvider extends AbstractCliProvider
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
 
+        // Disable auto-compact only for 1M context conversations. For standard
+        // 200K users, auto-compact works correctly and prevents "Prompt is too long"
+        // errors caused by unbounded session history accumulation. For 1M users
+        // (Max subscribers), the CLI detects 200K from server betas and would
+        // compact at ~166K — far too early — so we disable it and let them use
+        // /compact manually instead.
+        $contextWindow = $conversation->context_window_size ?? 0;
+        if ($contextWindow >= 900000) {
+            $env['DISABLE_AUTO_COMPACT'] = '1';
+        }
+
         return $env;
     }
 


### PR DESCRIPTION
## Problem

Two separate bugs affecting 1M context agents:

1. **"Prompt too long" for standard users** — `DISABLE_AUTO_COMPACT=1` was set globally, causing unbounded session history accumulation. Closes #288.
2. **1M context capped at ~177K** — `DISABLE_AUTO_COMPACT` does NOT bypass the CLI's hard blocking limit. This is a different code path. So 1M agents were hitting "Prompt is too long" at ~177K even with the flag set.

## Root cause (from CLI source + empirical testing)

The CLI has **two separate checks**:

```javascript
// Auto-compact threshold (~167K) — gated by DISABLE_AUTO_COMPACT ✅
isAboveAutoCompactThreshold: zb() && q >= et6(K)

// Hard blocking limit (~177K) — NOT gated by DISABLE_AUTO_COMPACT ❌
let J = ZQ(K) - We1;  // (200K - 20K) - 3K = 177K
let D = CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE ?? J;
isAtBlockingLimit: q >= D
```

**Empirically verified:**
| Test | Tokens | Result |
|---|---|---|
| ~187K words | ~187K | ❌ "Prompt is too long" |
| ~187K + `DISABLE_AUTO_COMPACT=1` | ~187K | ❌ "Prompt is too long" (no change) |
| ~187K + `CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE=977000` | ~187K | ✅ Reaches API (rate limit, not CLI block) |

## Fix

For 1M agents (`agent.extended_context = true` on a >200K model):
```php
$env['DISABLE_AUTO_COMPACT'] = '1';           // prevent early compaction at 167K
$env['CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE'] = '977000';  // allow up to 977K (1M window)
```

For standard 200K agents: auto-compact works normally at ~167K ✅

Also switches 1M detection from `context_window_size` (only available after first turn) to `agent->extended_context` (set at conversation creation).

## Test plan
- [ ] Standard conversation: auto-compact fires normally, no "prompt too long" errors
- [ ] 1M agent: conversation goes past 200K without blocking
- [ ] 1M agent: `/compact` still works for manual compaction

/cc @jasper-tetrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Code environment now adapts to agents with extended context windows, preserving previous behavior for standard agents.
  * The `/compact` command now validates required session info and returns a clear error if missing.
  * Streaming for Claude Code conversations is more reliable with earlier stream start and improved logging to reduce race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->