### PR TITLE
revert: Revert compact/context changes (PRs #256, #277, #284) to v0.59.0

### DIFF
--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -297,25 +297,6 @@ class ConversationController extends Controller
             ], 409);
         }
 
-        // Detect /compact slash command for Claude Code CLI conversations.
-        // When triggered, the job bypasses the normal turn and sends /compact to the CLI directly.
-        // Must be checked BEFORE startStream() to avoid leaving an orphaned stream state on error.
-        $jobOptions = [];
-        $isCompactCommand = $conversation->provider_type === 'claude_code'
-            && strtolower(trim($validated['prompt'])) === '/compact';
-
-        if ($isCompactCommand) {
-            if (empty($conversation->provider_session_id)) {
-                RequestFlowLogger::log('controller.stream.compact_no_session', '/compact requires an active session');
-                RequestFlowLogger::endRequest('error');
-                return response()->json([
-                    'success' => false,
-                    'error' => '/compact requires an active Claude Code session. Send a message first to start one.',
-                ], 422);
-            }
-            $jobOptions['is_compact_command'] = true;
-        }
-
         // Initialize stream state BEFORE cleanup to prevent race condition
         // This ensures clients won't see 'not_found' after cleanup and before job starts
         RequestFlowLogger::log('controller.stream.initializing', 'Initializing stream state in Redis');
@@ -331,7 +312,7 @@ class ConversationController extends Controller
         ProcessConversationStream::dispatch(
             $conversation->uuid,
             $validated['prompt'],
-            $jobOptions
+            [] // Options no longer needed for reasoning - stored on conversation
         );
         RequestFlowLogger::log('controller.stream.job_dispatched', 'Job dispatched to queue');
 

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -84,6 +84,12 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             // Mark conversation as processing
             $conversation->startProcessing();
             RequestFlowLogger::log('job.handle.processing_started', 'Marked conversation as processing');
+            // Save user message and keep reference for abort sync
+            RequestFlowLogger::log('job.handle.saving_user_message', 'Saving user message');
+            $userMessage = $this->saveUserMessage($conversation, $this->prompt);
+            RequestFlowLogger::log('job.handle.user_message_saved', 'User message saved', [
+                'message_id' => $userMessage->id,
+            ]);
 
             // Get provider
             $provider = $providerFactory->make($conversation->provider_type);
@@ -96,42 +102,19 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                 throw new \RuntimeException("Provider '{$conversation->provider_type}' is not available");
             }
 
-            // /compact command: trigger CLI compaction without saving a user message turn
-            if (!empty($this->options['is_compact_command'])) {
-                RequestFlowLogger::log('job.handle.compact_command', 'Handling /compact command');
-                // Wire abort checker so /abort can interrupt the compact stream
-                if ($provider instanceof AbstractCliProvider) {
-                    $provider->setAbortChecker(fn() => $streamManager->checkAbortFlag($this->conversationUuid));
-                }
-                $this->handleCompactCommand(
-                    $conversation,
-                    $provider,
-                    $streamManager,
-                    $this->options,
-                );
-                RequestFlowLogger::log('job.handle.compact_command_completed', '/compact command completed');
-            } else {
-                // Save user message and keep reference for abort sync
-                RequestFlowLogger::log('job.handle.saving_user_message', 'Saving user message');
-                $userMessage = $this->saveUserMessage($conversation, $this->prompt);
-                RequestFlowLogger::log('job.handle.user_message_saved', 'User message saved', [
-                    'message_id' => $userMessage->id,
-                ]);
-
-                // Stream with tool execution loop
-                RequestFlowLogger::log('job.handle.starting_stream_loop', 'Starting stream with tool loop');
-                $this->streamWithToolLoop(
-                    $conversation,
-                    $provider,
-                    $streamManager,
-                    $toolRegistry,
-                    $systemPromptBuilder,
-                    $modelRepository,
-                    $this->options,
-                    userMessage: $userMessage
-                );
-                RequestFlowLogger::log('job.handle.stream_loop_completed', 'Stream loop completed');
-            }
+            // Stream with tool execution loop
+            RequestFlowLogger::log('job.handle.starting_stream_loop', 'Starting stream with tool loop');
+            $this->streamWithToolLoop(
+                $conversation,
+                $provider,
+                $streamManager,
+                $toolRegistry,
+                $systemPromptBuilder,
+                $modelRepository,
+                $this->options,
+                userMessage: $userMessage
+            );
+            RequestFlowLogger::log('job.handle.stream_loop_completed', 'Stream loop completed');
 
             // Only finalize if not already completed/aborted inside streamWithToolLoop
             $currentStatus = $conversation->fresh()->status;
@@ -713,92 +696,6 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             $this->saveToolResultMessage($conversation, $streamedToolResults);
         } else {
             RequestFlowLogger::log('job.loop.no_tools', 'No tool execution needed - loop complete');
-        }
-    }
-
-    /**
-     * Handle a /compact slash command for Claude Code sessions.
-     *
-     * Passes "/compact" as the prompt to the CLI (via override_user_message) so it triggers
-     * a context compaction. No user or assistant message is saved — only a compaction message
-     * if the CLI emits COMPACTION_SUMMARY.
-     */
-    private function handleCompactCommand(
-        Conversation $conversation,
-        AIProviderInterface $provider,
-        StreamManager $streamManager,
-        array $options,
-    ): void {
-        $streamOptions = array_merge($options, ['override_user_message' => '/compact']);
-        $compactionReceived = false;
-
-        foreach ($provider->streamMessage($conversation, $streamOptions) as $event) {
-            // Check abort flag before processing each event
-            if ($streamManager->checkAbortFlag($this->conversationUuid)) {
-                RequestFlowLogger::log('job.compact.aborted', 'Abort detected during compact stream');
-                $conversation->completeProcessing();
-                $streamManager->appendEvent($this->conversationUuid, StreamEvent::done('aborted'));
-                $streamManager->completeStream($this->conversationUuid, 'aborted');
-                $streamManager->clearAbortFlag($this->conversationUuid);
-                // abort() may block on proc_close() — called after stream is already marked done
-                if ($provider instanceof AbstractCliProvider) {
-                    $provider->abort();
-                }
-                return;
-            }
-
-            RequestFlowLogger::log('job.compact.event', 'Compact stream event', [
-                'type' => $event->type,
-            ]);
-
-            switch ($event->type) {
-                case StreamEvent::COMPACTION_SUMMARY:
-                    $compactionReceived = true;
-                    RequestFlowLogger::log('job.compact.summary_received', 'Compaction summary received', [
-                        'summary_length' => strlen($event->content ?? ''),
-                        'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
-                    ]);
-                    Message::create([
-                        'conversation_id' => $conversation->id,
-                        'role' => Message::ROLE_COMPACTION,
-                        'content' => [
-                            'summary' => $event->content,
-                            'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
-                            'trigger' => 'manual',
-                        ],
-                    ]);
-                    // Forward the event so the frontend can display the compaction banner
-                    $streamManager->appendEvent($this->conversationUuid, $event);
-                    Log::channel('api')->info('ProcessConversationStream: Manual compaction saved', [
-                        'conversation' => $this->conversationUuid,
-                        'pre_tokens' => $event->metadata['pre_tokens'] ?? null,
-                    ]);
-                    break;
-
-                case StreamEvent::DONE:
-                    // Stream ended — fail if no compaction summary was received.
-                    // This catches timeout/no-op paths where the CLI exits without compacting.
-                    if (!$compactionReceived) {
-                        throw new \RuntimeException('Compact command completed without producing a compaction summary. The context may be too small to compact.');
-                    }
-                    break;
-
-                case StreamEvent::ERROR:
-                    throw new \RuntimeException($event->content ?? 'Compact command failed');
-            }
-        }
-
-        // Post-loop abort check: handles the case where the CLI's inner abort checker fired
-        // and the generator returned early without yielding another event.
-        if ($streamManager->checkAbortFlag($this->conversationUuid)) {
-            RequestFlowLogger::log('job.compact.aborted', 'Abort detected after compact stream ended');
-            $conversation->completeProcessing();
-            $streamManager->appendEvent($this->conversationUuid, StreamEvent::done('aborted'));
-            $streamManager->completeStream($this->conversationUuid, 'aborted');
-            $streamManager->clearAbortFlag($this->conversationUuid);
-            if ($provider instanceof AbstractCliProvider) {
-                $provider->abort();
-            }
         }
     }
 

--- a/www/app/Services/Providers/AbstractCliProvider.php
+++ b/www/app/Services/Providers/AbstractCliProvider.php
@@ -311,7 +311,7 @@ abstract class AbstractCliProvider implements AIProviderInterface, HasNativeSess
             return;
         }
 
-        $latestMessage = $options['override_user_message'] ?? $this->getLatestUserMessage($conversation);
+        $latestMessage = $this->getLatestUserMessage($conversation);
         if ($latestMessage === null) {
             yield StreamEvent::error('No user message found in conversation');
             return;

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -98,11 +98,6 @@ class ClaudeCodeProvider extends AbstractCliProvider
             ?: $conversation->model
             ?: config('ai.providers.claude_code.default_model', 'opus');
 
-        // Detect if this is a 1M context conversation so we can disable CLI auto-compaction.
-        // The CLI's internal compaction threshold is based on ~200K regardless of model.
-        $isExtendedContext = $conversation->agent?->extended_context
-            && $this->models->getMaxContextWindow($model) > 200000;
-
         // Get global allowed tools setting (Setting::get already decodes JSON)
         $globalAllowedTools = \App\Models\Setting::get('chat.claude_code_allowed_tools', []);
         if (!is_array($globalAllowedTools)) {
@@ -191,17 +186,6 @@ class ClaudeCodeProvider extends AbstractCliProvider
 
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
-
-        // For 1M context agents: disable CLI auto-compaction entirely.
-        // The CLI's internal compaction threshold is ~200K regardless of model, so it would
-        // compact at ~180K — far too early for a 1M context window. DISABLE_AUTO_COMPACT=1
-        // disables both the auto-compact trigger and the blocking limit check (both are gated
-        // by zb() in the CLI source), letting the conversation grow to the API's actual 1M limit.
-        $agent = $conversation->agent;
-        $model = $conversation->model ?? config('ai.providers.claude_code.default_model', 'opus');
-        if ($agent?->extended_context && $this->models->getMaxContextWindow($model) > 200000) {
-            $env['DISABLE_AUTO_COMPACT'] = '1';
-        }
 
         return $env;
     }

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -187,16 +187,6 @@ class ClaudeCodeProvider extends AbstractCliProvider
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
 
-        // Disable the CLI's automatic context compaction. The CLI determines its
-        // context window from server-sent SDK betas: Max subscribers receive the
-        // "context-1m-2025-08-07" beta and get a ~950K auto-compact threshold,
-        // while all other users default to 200K (auto-compact at ~180K). Because
-        // PocketDev uses OAuth and cannot control which betas the server sends,
-        // we disable auto-compact for everyone. Users can compact manually via
-        // the /compact command, which triggers at the right moment for their
-        // actual context window.
-        $env['DISABLE_AUTO_COMPACT'] = '1';
-
         return $env;
     }
 

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -98,6 +98,11 @@ class ClaudeCodeProvider extends AbstractCliProvider
             ?: $conversation->model
             ?: config('ai.providers.claude_code.default_model', 'opus');
 
+        // Detect if this is a 1M context conversation so we can disable CLI auto-compaction.
+        // The CLI's internal compaction threshold is based on ~200K regardless of model.
+        $isExtendedContext = $conversation->agent?->extended_context
+            && $this->models->getMaxContextWindow($model) > 200000;
+
         // Get global allowed tools setting (Setting::get already decodes JSON)
         $globalAllowedTools = \App\Models\Setting::get('chat.claude_code_allowed_tools', []);
         if (!is_array($globalAllowedTools)) {
@@ -186,6 +191,17 @@ class ClaudeCodeProvider extends AbstractCliProvider
 
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
+
+        // For 1M context agents: disable CLI auto-compaction entirely.
+        // The CLI's internal compaction threshold is ~200K regardless of model, so it would
+        // compact at ~180K — far too early for a 1M context window. DISABLE_AUTO_COMPACT=1
+        // disables both the auto-compact trigger and the blocking limit check (both are gated
+        // by zb() in the CLI source), letting the conversation grow to the API's actual 1M limit.
+        $agent = $conversation->agent;
+        $model = $conversation->model ?? config('ai.providers.claude_code.default_model', 'opus');
+        if ($agent?->extended_context && $this->models->getMaxContextWindow($model) > 200000) {
+            $env['DISABLE_AUTO_COMPACT'] = '1';
+        }
 
         return $env;
     }

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1925,40 +1925,18 @@
 
                     const query = this.prompt.slice(1).toLowerCase();
 
-                    // Built-in commands for Claude Code — shown in autocomplete but sent
-                    // directly as /command rather than activating the skill system.
-                    const activeProvider = this.conversationProvider || this.provider;
-                    const builtInDefs = activeProvider === 'claude_code' ? [
-                        { name: 'compact', when_to_use: 'Compact conversation to reduce context usage', isBuiltin: true },
-                    ] : [];
-                    const builtInSuggestions = builtInDefs.filter(cmd =>
-                        cmd.name.includes(query) || cmd.when_to_use.toLowerCase().includes(query)
-                    );
-
                     // Filter skills matching the query (guard against null when_to_use)
-                    const skillSuggestions = this.skills.filter(skill => {
+                    this.skillSuggestions = this.skills.filter(skill => {
                         const name = (skill.name || '').toLowerCase();
                         const whenToUse = (skill.when_to_use || '').toLowerCase();
                         return name.includes(query) || whenToUse.includes(query);
-                    });
+                    }).slice(0, 8);
 
-                    this.skillSuggestions = [...builtInSuggestions, ...skillSuggestions].slice(0, 8);
                     this.showSkillSuggestions = this.skillSuggestions.length > 0;
                     this.selectedSkillIndex = 0;
                 },
 
                 selectSkill(skill) {
-                    // Built-in commands (e.g. /compact) are sent directly as /command text
-                    // rather than activating the skill system with instruction prepending.
-                    if (skill.isBuiltin) {
-                        this.prompt = '/' + skill.name;
-                        this.showSkillSuggestions = false;
-                        this.$nextTick(() => {
-                            this.$refs.promptInput?.focus();
-                        });
-                        return;
-                    }
-
                     // Set active skill and clear prompt (skill shown as chip above textarea)
                     this.activeSkill = skill;
                     this.prompt = '';
@@ -4792,21 +4770,17 @@
                     }
 
                     // Block unmatched /commands - if prompt starts with / but no skill is active
-                    // Built-in commands that bypass the skill system and are sent directly as messages
-                    const builtInCommands = ['compact'];
                     if (this.prompt.trim().startsWith('/') && !this.activeSkill) {
-                        const potentialSkillName = this.prompt.trim().slice(1).split(/\s+/)[0].toLowerCase();
-                        if (!builtInCommands.includes(potentialSkillName)) {
-                            const matchedSkill = this.findSkillByName(potentialSkillName);
-                            if (!matchedSkill) {
-                                this.showError(`Unknown skill: /${potentialSkillName}. Type / to see available skills.`);
-                                return;
-                            }
-                            // If it matches, activate it and continue
-                            this.activeSkill = matchedSkill;
-                            // Remove the /command from prompt, keep any text after it
-                            this.prompt = this.prompt.trim().slice(1 + potentialSkillName.length).trim();
+                        const potentialSkillName = this.prompt.trim().slice(1).split(/\s+/)[0];
+                        const matchedSkill = this.findSkillByName(potentialSkillName);
+                        if (!matchedSkill) {
+                            this.showError(`Unknown skill: /${potentialSkillName}. Type / to see available skills.`);
+                            return;
                         }
+                        // If it matches, activate it and continue
+                        this.activeSkill = matchedSkill;
+                        // Remove the /command from prompt, keep any text after it
+                        this.prompt = this.prompt.trim().slice(1 + potentialSkillName.length).trim();
                     }
 
                     // Block if uploads still in progress


### PR DESCRIPTION
## Summary

Reverts all changes between v0.59.0 and v0.61.0 to address "Prompt is too long" errors.

### PRs Reverted
| PR | Title |
|----|-------|
| #256 | feat: 1M context window support for Claude 4.6 models |
| #277 | fix: revert DISABLE_AUTO_COMPACT + add /compact command |
| #284 | fix: bundle /compact fixes — skill intercept, autocomplete + disable auto-compact |

## Why

Users are experiencing "Prompt is too long" errors on v0.61.0. Investigation showed that with `DISABLE_AUTO_COMPACT=1`:
- The CLI does NOT auto-compact
- Context grows until hitting the **hard API limit** (~200K tokens)
- Results in unrecoverable "Prompt is too long" errors

## What Changes

| Feature | Before (v0.61.0) | After (v0.59.0) |
|---------|------------------|-----------------|
| `DISABLE_AUTO_COMPACT` | Set to `'1'` | **Removed** |
| Auto-compact | Disabled | **Enabled** (~180K threshold) |
| `/compact` command | Available | Removed |
| 1M context tracking | Available | Removed |

## Expected Behavior After Merge

- CLI will **auto-compact at ~180K tokens** (prevents "prompt is too long" hard errors)
- Users lose context earlier but sessions continue working
- No manual `/compact` option (but auto-compact handles it automatically)

## Verification

- ✅ `git diff v0.59.0` returns empty (exact match)
- ✅ `ClaudeCodeProvider.php` has no `DISABLE_AUTO_COMPACT`
- ✅ `ConversationController.php` has no `/compact` handling
- ✅ `chat.blade.php` has no `/compact` autocomplete
- ✅ Sub-agent independently verified all changes

## Test Plan

- [ ] Deploy to test instance
- [ ] Verify auto-compact triggers around ~180K tokens
- [ ] Verify "Prompt is too long" errors no longer occur with large tool results
- [ ] Verify `/compact` command is no longer recognized (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed `/compact` command support from Claude Code conversations
  * Streamlined command parsing to resolve skills by exact name match
  * Updated Claude Code message processing flow for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->