### PR TITLE
feat: native subagents + agents as native tool calls (expose_as_tool)

### DIFF
--- a/docs/plans/codex-inline-device-auth.md
+++ b/docs/plans/codex-inline-device-auth.md
@@ -1,0 +1,136 @@
+# Plan: Codex Inline Device Auth
+
+## Probleem
+
+De huidige Codex authenticatie flows werken niet goed op een VPS:
+
+| Flow | Probleem |
+|------|---------|
+| Wizard | Vereist `sudo` + browser op host machine |
+| Settings (device-auth) | Vereist terminal toegang + interactieve TTY |
+
+## Oplossing
+
+Device auth flow volledig ingebouwd in de PocketDev UI. Gebruiker hoeft
+alleen een link te openen op een ander apparaat (telefoon/laptop).
+
+### User flow
+
+1. Gebruiker klikt **"Login met ChatGPT"** in PocketDev UI
+2. PocketDev start `codex login --device-auth` als background process in de queue container
+3. PocketDev parseert stdout/stderr → toont **URL + code groot in de UI**
+4. Gebruiker opent `https://auth.openai.com/codex/device` op telefoon/laptop
+5. Voert de code in → logt in met ChatGPT account
+6. PocketDev pollt `~/.codex/auth.json` → detecteert success → toont ✅
+
+Geen sudo, geen terminal, geen docker commando's.
+
+---
+
+## Implementatie
+
+### 1. Backend: `CodexAuthController`
+
+**Nieuwe endpoints:**
+
+#### `POST /codex/auth/device-start`
+- Start `codex login --device-auth` als background process in de queue container via `docker exec`
+- Parseert output voor URL en user code
+- Slaat process PID op in cache (voor cleanup)
+- Returnt: `{ verification_url, user_code, expires_in: 900 }`
+
+```php
+public function startDeviceAuth(): JsonResponse
+{
+    // Run in queue container where codex is installed
+    $process = Process::start([
+        'docker', 'exec', '-u', 'appuser',
+        config('pocketdev.queue_container', 'pocket-dev-queue'),
+        'codex', 'login', '--device-auth'
+    ]);
+
+    // Parse URL and code from stderr output
+    // Output format:
+    //   1. Open: https://auth.openai.com/codex/device
+    //   2. Enter code: CDB9-2OZPE
+    ...
+}
+```
+
+#### `GET /codex/auth/device-status`
+- Pollt of `~/.codex/auth.json` aangemaakt is in de queue container
+- Returnt: `{ authenticated: bool, auth_type: string }`
+
+---
+
+### 2. Frontend: `codex-auth.blade.php`
+
+**Nieuwe "Subscription" tab UI:**
+
+```
+┌─────────────────────────────────────────┐
+│  Login met ChatGPT Subscription         │
+│                                         │
+│  [Start Login]                          │
+│                                         │
+│  ── na klik ──                          │
+│                                         │
+│  1. Open deze link op je telefoon       │
+│     of laptop:                          │
+│                                         │
+│  https://auth.openai.com/codex/device   │
+│  [📋 Kopieer link]                      │
+│                                         │
+│  2. Voer deze code in:                  │
+│                                         │
+│  ┌──────────────┐                       │
+│  │  CDB9-2OZPE  │  [📋 Kopieer]        │
+│  └──────────────┘                       │
+│                                         │
+│  ⏳ Wachten op authenticatie...         │
+│     (verloopt over 14:32)               │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Copy knoppen:**
+- Kopieer URL → `navigator.clipboard.writeText(url)`
+- Kopieer code → `navigator.clipboard.writeText(code)`
+- Beide tonen ✓ bevestiging na kopiëren
+
+**Polling:**
+- Frontend pollt `GET /codex/auth/device-status` elke 3 seconden
+- Bij success: toont ✅ "Authenticated!" + herlaadt status
+
+**Countdown timer:**
+- 15 minuten aftellen via `setInterval`
+- Bij 0: toont melding "Code verlopen, probeer opnieuw"
+
+---
+
+### 3. Wizard: `setup/wizard.blade.php`
+
+Zelfde inline device auth component hergebruiken in de wizard stap voor Codex.
+
+---
+
+## Bestanden om aan te passen
+
+| Bestand | Wijziging |
+|---------|-----------|
+| `CodexAuthController.php` | `startDeviceAuth()` + `deviceStatus()` endpoints |
+| `routes/web.php` | `POST /codex/auth/device-start` + `GET /codex/auth/device-status` |
+| `codex-auth.blade.php` | Nieuwe subscription tab UI met copy knoppen + polling |
+| `setup/wizard.blade.php` | Inline device auth component |
+| `EnsureSetupComplete.php` | Nieuwe routes whitelisten |
+
+---
+
+## Open vragen
+
+- [ ] Hoe parsen we de URL + code uit `codex login --device-auth` output?
+  - Output gaat naar stderr met ANSI color codes
+  - Regex: `https://auth\.openai\.com/codex/device` + `[A-Z0-9]{4}-[A-Z0-9]{5}`
+- [ ] Timeout afhandeling: process killen als 15 min verstreken zijn
+- [ ] Wat als Docker niet beschikbaar is (non-Docker deployment)?
+  - Fallback: run `codex login --device-auth` direct (niet via docker exec)

--- a/www/app/Console/Commands/SubAgentCancelCommand.php
+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
@@ -1,78 +1,41 @@
-Author: Claude <noreply@anthropic.com>
-Date:   Tue Apr 7 11:54:28 2026 +0000
+<?php
 
-    feat(subagents): end parent turn immediately after background dispatch + cancel tool
-    
-    Closes #280.
-    
-    **End-turn signal**
-    - `ToolResult` gains `$endTurn` / `$endTurnMessage` and a `successEndTurn()` factory.
-    - `SubAgentTool` returns `successEndTurn()` in background mode instead of plain `success()`.
-    - `ProcessConversationStream::executeTools()` propagates the flag to its result array.
-    - `ProcessConversationStream::streamWithToolLoop()` checks for the flag after saving
-      tool results; when set, saves a synthetic closing assistant message and returns early
-      without a second AI round-trip. The parent conversation becomes interactive as soon as
-      the child job is dispatched.
-    
-    A synthetic assistant message is required because the last saved message is a ROLE_USER
-    tool-result row; without a closing ROLE_ASSISTANT row the next turn would present two
-    consecutive user messages to the API provider.
-    
-    **SubAgentCancel tool**
-    - `SubAgentCancelTool` (auto-discovered, registers as `SubAgentCancel`).
-    - Sets `StreamManager::setAbortFlag()` on the child conversation UUID — same mechanism
-      used by user-initiated stop; child detects flag within ~1 s and shuts down cleanly.
-    - Ownership guard: only the conversation that spawned the task can cancel it
-      (skipped when called via CLI where no parent UUID is available).
-    - No-op with a clear message if the task is already terminal.
-    - `SubAgentCancelCommand` exposes `pd subagent:cancel --task-id=<uuid>`.
-    
-    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+namespace App\Console\Commands;
 
-diff --git a/www/app/Console/Commands/SubAgentCancelCommand.php b/www/app/Console/Commands/SubAgentCancelCommand.php
-new file mode 100644
-index 0000000..0851231
---- /dev/null
-+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
-@@ -0,0 +1,41 @@
-+<?php
-+
-+namespace App\Console\Commands;
-+
-+use App\Tools\ExecutionContext;
-+use App\Tools\SubAgentCancelTool;
-+use Illuminate\Console\Command;
-+
-+class SubAgentCancelCommand extends Command
-+{
-+    protected $signature = 'subagent:cancel
-+        {--task-id= : The task UUID returned by subagent:run --background}';
-+
-+    protected $description = 'Cancel a running background sub-agent task';
-+
-+    public function handle(): int
-+    {
-+        $tool = new SubAgentCancelTool();
-+
-+        $input = [
-+            'task_id' => $this->option('task-id') ?? '',
-+        ];
-+
-+        // Note: when called from CLI (not from within a conversation), there is no
-+        // parent conversation UUID — the ownership guard in the tool is skipped.
-+        $context = new ExecutionContext(
-+            getcwd() ?: '/var/www',
-+        );
-+
-+        $result = $tool->execute($input, $context);
-+
-+        $this->outputJson($result->toArray());
-+
-+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
-+    }
-+
-+    private function outputJson(array $data): void
-+    {
-+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
-+    }
-+}
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentCancelTool;
+use Illuminate\Console\Command;
+
+class SubAgentCancelCommand extends Command
+{
+    protected $signature = 'subagent:cancel
+        {--task-id= : The task UUID returned by subagent:run --background}';
+
+    protected $description = 'Cancel a running background sub-agent task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentCancelTool();
+
+        $input = [
+            'task_id' => $this->option('task-id') ?? '',
+        ];
+
+        // Note: when called from CLI (not from within a conversation), there is no
+        // parent conversation UUID — the ownership guard in the tool is skipped.
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Console/Commands/SubAgentCancelCommand.php
+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
@@ -1,0 +1,78 @@
+Author: Claude <noreply@anthropic.com>
+Date:   Tue Apr 7 11:54:28 2026 +0000
+
+    feat(subagents): end parent turn immediately after background dispatch + cancel tool
+    
+    Closes #280.
+    
+    **End-turn signal**
+    - `ToolResult` gains `$endTurn` / `$endTurnMessage` and a `successEndTurn()` factory.
+    - `SubAgentTool` returns `successEndTurn()` in background mode instead of plain `success()`.
+    - `ProcessConversationStream::executeTools()` propagates the flag to its result array.
+    - `ProcessConversationStream::streamWithToolLoop()` checks for the flag after saving
+      tool results; when set, saves a synthetic closing assistant message and returns early
+      without a second AI round-trip. The parent conversation becomes interactive as soon as
+      the child job is dispatched.
+    
+    A synthetic assistant message is required because the last saved message is a ROLE_USER
+    tool-result row; without a closing ROLE_ASSISTANT row the next turn would present two
+    consecutive user messages to the API provider.
+    
+    **SubAgentCancel tool**
+    - `SubAgentCancelTool` (auto-discovered, registers as `SubAgentCancel`).
+    - Sets `StreamManager::setAbortFlag()` on the child conversation UUID — same mechanism
+      used by user-initiated stop; child detects flag within ~1 s and shuts down cleanly.
+    - Ownership guard: only the conversation that spawned the task can cancel it
+      (skipped when called via CLI where no parent UUID is available).
+    - No-op with a clear message if the task is already terminal.
+    - `SubAgentCancelCommand` exposes `pd subagent:cancel --task-id=<uuid>`.
+    
+    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+
+diff --git a/www/app/Console/Commands/SubAgentCancelCommand.php b/www/app/Console/Commands/SubAgentCancelCommand.php
+new file mode 100644
+index 0000000..0851231
+--- /dev/null
++++ b/www/app/Console/Commands/SubAgentCancelCommand.php
+@@ -0,0 +1,41 @@
++<?php
++
++namespace App\Console\Commands;
++
++use App\Tools\ExecutionContext;
++use App\Tools\SubAgentCancelTool;
++use Illuminate\Console\Command;
++
++class SubAgentCancelCommand extends Command
++{
++    protected $signature = 'subagent:cancel
++        {--task-id= : The task UUID returned by subagent:run --background}';
++
++    protected $description = 'Cancel a running background sub-agent task';
++
++    public function handle(): int
++    {
++        $tool = new SubAgentCancelTool();
++
++        $input = [
++            'task_id' => $this->option('task-id') ?? '',
++        ];
++
++        // Note: when called from CLI (not from within a conversation), there is no
++        // parent conversation UUID — the ownership guard in the tool is skipped.
++        $context = new ExecutionContext(
++            getcwd() ?: '/var/www',
++        );
++
++        $result = $tool->execute($input, $context);
++
++        $this->outputJson($result->toArray());
++
++        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
++    }
++
++    private function outputJson(array $data): void
++    {
++        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
++    }
++}

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -11,6 +11,7 @@ use App\Models\Session;
 use App\Models\Workspace;
 use App\Services\ConversationFactory;
 use App\Services\ConversationStreamLogger;
+use App\Services\ModelRepository;
 use App\Services\NativeToolService;
 use App\Services\ProviderFactory;
 use App\Services\RequestFlowLogger;
@@ -31,6 +32,7 @@ class ConversationController extends Controller
         private ProviderFactory $providerFactory,
         private StreamManager $streamManager,
         private ConversationFactory $conversationFactory,
+        private ModelRepository $models,
     ) {}
 
     /**
@@ -248,14 +250,27 @@ class ConversationController extends Controller
 
             // If model changed, update cached context window size
             if (isset($updates['model'])) {
-                $provider = $this->providerFactory->make($conversation->provider_type);
                 try {
-                    $contextWindow = $provider->getContextWindow($updates['model']);
-                    $conversation->updateContextWindowSize($contextWindow);
-                    RequestFlowLogger::log('controller.stream.context_window_updated', 'Context window updated for new model', [
-                        'model' => $updates['model'],
-                        'context_window' => $contextWindow,
-                    ]);
+                    // For 1M context agents, use max_context_window (1M) instead of default (200K)
+                    $conversation->loadMissing('agent');
+                    if ($conversation->agent?->extended_context) {
+                        $maxContextWindow = $this->models->getMaxContextWindow($updates['model']);
+                        if ($maxContextWindow > 0) {
+                            $conversation->updateContextWindowSize($maxContextWindow);
+                            RequestFlowLogger::log('controller.stream.context_window_updated', 'Context window updated (1M agent)', [
+                                'model' => $updates['model'],
+                                'context_window' => $maxContextWindow,
+                            ]);
+                        }
+                    } else {
+                        $provider = $this->providerFactory->make($conversation->provider_type);
+                        $contextWindow = $provider->getContextWindow($updates['model']);
+                        $conversation->updateContextWindowSize($contextWindow);
+                        RequestFlowLogger::log('controller.stream.context_window_updated', 'Context window updated for new model', [
+                            'model' => $updates['model'],
+                            'context_window' => $contextWindow,
+                        ]);
+                    }
                 } catch (\Exception $e) {
                     // Model not found or config error - will be updated when we get actual token data
                     RequestFlowLogger::logError('controller.stream.context_window_error', 'Failed to update context window', $e);
@@ -768,9 +783,17 @@ class ConversationController extends Controller
         // Recalculate context window when model or provider changed
         if (isset($updates['model'])) {
             try {
-                $provider = $this->providerFactory->make($updates['provider_type'] ?? $conversation->provider_type);
-                $contextWindow = $provider->getContextWindow($updates['model']);
-                $conversation->updateContextWindowSize($contextWindow);
+                // For 1M context agents, use max_context_window (1M) instead of default (200K)
+                if ($newAgent->extended_context) {
+                    $maxContextWindow = $this->models->getMaxContextWindow($updates['model']);
+                    if ($maxContextWindow > 0) {
+                        $conversation->updateContextWindowSize($maxContextWindow);
+                    }
+                } else {
+                    $provider = $this->providerFactory->make($updates['provider_type'] ?? $conversation->provider_type);
+                    $contextWindow = $provider->getContextWindow($updates['model']);
+                    $conversation->updateContextWindowSize($contextWindow);
+                }
             } catch (\Exception $e) {
                 \Log::debug('[switchAgent] Failed to update context window', [
                     'error' => $e->getMessage(),

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
@@ -239,6 +240,101 @@ class CodexAuthController extends Controller
         }
 
         return false;
+    }
+
+    /**
+     * Start device auth flow — dispatches a background job that runs codex login.
+     * The job parses the URL/code from codex output and stores them in cache.
+     * Frontend polls deviceStatus() to get the URL and code to show the user.
+     */
+    public function startDeviceAuth(): JsonResponse
+    {
+        // Already authenticated — no need to start a new session
+        if (file_exists($this->credentialsPath)) {
+            return response()->json([
+                'success' => false,
+                'error' => 'Already authenticated. Logout first if you want to switch accounts.',
+            ], 400);
+        }
+
+        // Check if there's already an active session in progress
+        $existing = Cache::get('codex_device_auth');
+        if ($existing && in_array($existing['status'], ['starting', 'ready'], true)) {
+            $expiresAt = $existing['expires_at'] ?? 0;
+            if ($expiresAt > time()) {
+                return response()->json([
+                    'success' => true,
+                    'status' => $existing['status'],
+                    'verification_url' => $existing['verification_url'] ?? null,
+                    'user_code' => $existing['user_code'] ?? null,
+                    'expires_in' => max(0, $expiresAt - time()),
+                ]);
+            }
+        }
+
+        // Store initial "starting" state so the polling endpoint can respond immediately
+        Cache::put('codex_device_auth', [
+            'status' => 'starting',
+            'started_at' => time(),
+            'expires_at' => time() + 960,
+        ], 960);
+
+        // Dispatch the long-running job to the queue container
+        \App\Jobs\StartCodexDeviceAuthJob::dispatch();
+
+        Log::info('[Codex Device Auth] Job dispatched');
+
+        return response()->json([
+            'success' => true,
+            'status' => 'starting',
+        ]);
+    }
+
+    /**
+     * Return the current device auth session status.
+     * Frontend polls this every 2-3 seconds after calling startDeviceAuth().
+     */
+    public function deviceStatus(): JsonResponse
+    {
+        // Auth.json already exists — authentication complete
+        if (file_exists($this->credentialsPath)) {
+            // Clear any leftover session cache
+            Cache::forget('codex_device_auth');
+
+            return response()->json([
+                'success' => true,
+                'status' => 'authenticated',
+            ]);
+        }
+
+        $session = Cache::get('codex_device_auth');
+
+        if (!$session) {
+            return response()->json(['success' => true, 'status' => 'none']);
+        }
+
+        // Check expiry
+        if (($session['expires_at'] ?? 0) <= time()) {
+            Cache::forget('codex_device_auth');
+            return response()->json(['success' => true, 'status' => 'expired']);
+        }
+
+        // Propagate job-reported "authenticated" status even if auth.json isn't visible here
+        if ($session['status'] === 'authenticated') {
+            return response()->json([
+                'success' => true,
+                'status' => 'authenticated',
+            ]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'status' => $session['status'],
+            'verification_url' => $session['verification_url'] ?? null,
+            'user_code' => $session['user_code'] ?? null,
+            'expires_in' => max(0, ($session['expires_at'] ?? 0) - time()),
+            'error' => $session['error'] ?? null,
+        ]);
     }
 
     /**

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
@@ -240,6 +241,30 @@ class CodexAuthController extends Controller
         }
 
         return false;
+    }
+
+    /**
+     * Serve the local upload script with this instance's URL pre-filled.
+     * Users can pipe it directly: bash <(curl -s https://pocketdev/codex/auth/upload-script)
+     */
+    public function downloadScript(): Response
+    {
+        $scriptPath = public_path('scripts/codex-auth.sh');
+        $script = file_get_contents($scriptPath);
+
+        // Pre-fill the PocketDev URL so the user doesn't have to type it
+        $instanceUrl = rtrim(url('/'), '/');
+        $script = str_replace(
+            'PD_URL="${1:-${POCKETDEV_URL:-}}"',
+            'PD_URL="${1:-${POCKETDEV_URL:-' . $instanceUrl . '}}"',
+            $script
+        );
+
+        return response($script, 200, [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Disposition' => 'inline; filename="codex-auth.sh"',
+            'Cache-Control' => 'no-store',
+        ]);
     }
 
     /**

--- a/www/app/Http/Controllers/ConfigController.php
+++ b/www/app/Http/Controllers/ConfigController.php
@@ -473,7 +473,7 @@ class ConfigController extends Controller
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
                     'expose_as_tool' => $validated['expose_as_tool'] ?? false,
-                    'can_call_subagents' => $validated['can_call_subagents'] ?? true,
+                    'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? false),
                     'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 
@@ -591,7 +591,7 @@ class ConfigController extends Controller
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
                     'expose_as_tool' => $validated['expose_as_tool'] ?? false,
-                    'can_call_subagents' => $validated['can_call_subagents'] ?? true,
+                    'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? false),
                     'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 

--- a/www/app/Http/Controllers/ConfigController.php
+++ b/www/app/Http/Controllers/ConfigController.php
@@ -320,15 +320,28 @@ class ConfigController extends Controller
     {
         $request->session()->put('config_last_section', 'agents');
 
+        $selectedWorkspaceId = $request->query('workspace_id');
+
+        // Agents with expose_as_tool = true in the selected workspace (for allowlist multi-select)
+        $exposedAgents = collect();
+        if ($selectedWorkspaceId) {
+            $exposedAgents = Agent::where('workspace_id', $selectedWorkspaceId)
+                ->where('enabled', true)
+                ->where('expose_as_tool', true)
+                ->orderBy('name')
+                ->get(['id', 'name', 'slug']);
+        }
+
         $viewData = [
             'providers' => Agent::getProviders(),
             'modelsPerProvider' => collect(Agent::getProviders())
                 ->mapWithKeys(fn ($p) => [$p => $this->getModelsForProvider($p)])
                 ->toArray(),
             'workspaces' => Workspace::orderBy('name')->get(),
-            'selectedWorkspaceId' => $request->query('workspace_id'),
+            'selectedWorkspaceId' => $selectedWorkspaceId,
             'sourceAgent' => null,
             'cloneWarnings' => null,
+            'exposedAgents' => $exposedAgents,
         ];
 
         // Handle "Create from" (cloning an existing agent)
@@ -415,6 +428,10 @@ class ConfigController extends Controller
                 'system_prompt' => 'nullable|string',
                 'is_default' => 'nullable|boolean',
                 'enabled' => 'nullable|boolean',
+                'expose_as_tool' => 'nullable|boolean',
+                'can_call_subagents' => 'nullable|boolean',
+                'allowed_subagents' => 'nullable|array',
+                'allowed_subagents.*' => 'uuid|exists:agents,id',
             ]);
 
             // Check for duplicate slug within workspace
@@ -455,6 +472,9 @@ class ConfigController extends Controller
                     'system_prompt' => $validated['system_prompt'] ?? null,
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
+                    'expose_as_tool' => $validated['expose_as_tool'] ?? false,
+                    'can_call_subagents' => $validated['can_call_subagents'] ?? true,
+                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)
@@ -481,12 +501,22 @@ class ConfigController extends Controller
     {
         $request->session()->put('config_last_section', 'agents');
 
+        // Load other agents in this workspace that have expose_as_tool enabled
+        // (candidates for the caller-side allowed_subagents multi-select)
+        $exposedAgents = Agent::where('workspace_id', $agent->workspace_id)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true)
+            ->where('id', '!=', $agent->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug']);
+
         return view('config.agents.form', [
             'agent' => $agent,
             'providers' => Agent::getProviders(),
             'modelsPerProvider' => collect(Agent::getProviders())
                 ->mapWithKeys(fn ($p) => [$p => $this->getModelsForProvider($p)])
                 ->toArray(),
+            'exposedAgents' => $exposedAgents,
         ]);
     }
 
@@ -516,6 +546,10 @@ class ConfigController extends Controller
                 'system_prompt' => 'nullable|string',
                 'is_default' => 'nullable|boolean',
                 'enabled' => 'nullable|boolean',
+                'expose_as_tool' => 'nullable|boolean',
+                'can_call_subagents' => 'nullable|boolean',
+                'allowed_subagents' => 'nullable|array',
+                'allowed_subagents.*' => 'uuid|exists:agents,id',
             ]);
 
             // Check for duplicate slug within workspace (excluding current agent)
@@ -556,6 +590,9 @@ class ConfigController extends Controller
                     'system_prompt' => $validated['system_prompt'] ?? null,
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
+                    'expose_as_tool' => $validated['expose_as_tool'] ?? false,
+                    'can_call_subagents' => $validated['can_call_subagents'] ?? true,
+                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -283,7 +283,7 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
 
         // Prepare provider options
         $getToolDefsStart = microtime(true);
-        $toolDefinitions = $toolRegistry->getDefinitions();
+        $toolDefinitions = $toolRegistry->getDefinitions($conversation->agent);
         $getToolDefsTime = (microtime(true) - $getToolDefsStart) * 1000;
         RequestFlowLogger::log('job.loop.tool_definitions', 'Tool definitions retrieved', [
             'duration_ms' => round($getToolDefsTime, 2),
@@ -789,11 +789,12 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
         // Get session from conversation's screen (for panel tools that need to create screens)
         $session = $conversation->screen?->session;
 
-        // Pass workspace, session, and stream context so tools can access workspace-specific credentials,
-        // create panel screens, and emit stream events when needed
+        // Pass workspace, agent, session, and stream context so tools can access workspace-specific
+        // credentials, create panel screens, emit stream events, and enforce sub-agent permissions
         $context = new ExecutionContext(
             $conversation->working_directory,
             workspace: $conversation->workspace,
+            agent: $conversation->agent,
             session: $session,
             streamManager: $streamManager,
             conversationUuid: $this->conversationUuid,

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -666,6 +666,32 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             RequestFlowLogger::log('job.loop.saving_tool_results', 'Saving tool results message');
             $this->saveToolResultMessage($conversation, $toolResults);
 
+            // Check for end-turn signal from a tool (e.g. SubAgent in background mode).
+            // When present, finalize the parent turn immediately without a second AI call,
+            // saving a synthetic assistant message to keep the conversation history well-formed
+            // (avoids two consecutive user messages on the next turn).
+            $endTurnResult = null;
+            foreach ($toolResults as $r) {
+                if ($r['end_turn'] ?? false) {
+                    $endTurnResult = $r;
+                    break;
+                }
+            }
+
+            if ($endTurnResult !== null) {
+                $endTurnMessage = $endTurnResult['end_turn_message'] ?? 'Background agent started.';
+                RequestFlowLogger::log('job.loop.end_turn_signal', 'End-turn signal from tool — ending parent turn early', [
+                    'tool_use_id' => $endTurnResult['tool_use_id'],
+                ]);
+                $this->saveAssistantMessage(
+                    $conversation,
+                    [['type' => 'text', 'text' => $endTurnMessage]],
+                    0, 0, null, null,
+                    'end_turn',
+                );
+                return; // handle() will call completeProcessing()
+            }
+
             // Continue with tool results (recursive)
             // Pass the original user message for abort sync consistency
             RequestFlowLogger::log('job.loop.recursive_call', 'Making recursive call for tool results', [
@@ -819,9 +845,11 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             );
 
             $results[] = [
-                'tool_use_id' => $toolUse['id'],
-                'content' => $result->output,
-                'is_error' => $result->isError,
+                'tool_use_id'      => $toolUse['id'],
+                'content'          => $result->output,
+                'is_error'         => $result->isError,
+                'end_turn'         => $result->endTurn,
+                'end_turn_message' => $result->endTurnMessage,
             ];
         }
 

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -746,10 +746,20 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
 
             // Ensure context_window_size is set (for existing conversations that don't have it)
             if (!$conversation->context_window_size) {
-                $provider = app(\App\Services\ProviderFactory::class)->make($conversation->provider_type);
                 try {
-                    $contextWindow = $provider->getContextWindow($conversation->model);
-                    $conversation->updateContextWindowSize($contextWindow);
+                    // For 1M context agents, use max_context_window (1M) instead of default (200K)
+                    $conversation->loadMissing('agent');
+                    if ($conversation->agent?->extended_context) {
+                        $models = app(\App\Services\ModelRepository::class);
+                        $maxContextWindow = $models->getMaxContextWindow($conversation->model);
+                        if ($maxContextWindow > 0) {
+                            $conversation->updateContextWindowSize($maxContextWindow);
+                        }
+                    } else {
+                        $provider = app(\App\Services\ProviderFactory::class)->make($conversation->provider_type);
+                        $contextWindow = $provider->getContextWindow($conversation->model);
+                        $conversation->updateContextWindowSize($contextWindow);
+                    }
                 } catch (\Exception $e) {
                     // Model not found or provider error - skip (will retry on next turn)
                     Log::debug('ProcessConversationStream: Failed to get context window', [

--- a/www/app/Jobs/StartCodexDeviceAuthJob.php
+++ b/www/app/Jobs/StartCodexDeviceAuthJob.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class StartCodexDeviceAuthJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Allow the job to run for up to 16 minutes (device code window is 15 min).
+     */
+    public int $timeout = 1000;
+
+    /**
+     * Don't retry — device auth is a one-shot flow.
+     */
+    public int $tries = 1;
+
+    public function handle(): void
+    {
+        $home = getenv('HOME') ?: '/home/appuser';
+        $authFile = "{$home}/.codex/auth.json";
+        $logFile = sys_get_temp_dir() . '/codex_device_auth_' . getmypid() . '.log';
+
+        Log::info('[Codex Device Auth] Job started', ['log' => $logFile]);
+
+        // Find codex binary
+        $codexPath = $this->findCodexPath();
+        if (!$codexPath) {
+            $this->failWithError(
+                'Codex is not installed. Install it with: npm install -g @openai/codex'
+            );
+            return;
+        }
+
+        Log::info('[Codex Device Auth] Found codex at: ' . $codexPath);
+
+        // Clean up any old log
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+
+        // Start device auth in background, redirect stdout+stderr to log file
+        $cmd = 'nohup ' . escapeshellarg($codexPath) . ' login --device-auth > '
+            . escapeshellarg($logFile) . ' 2>&1 &';
+        exec($cmd, $execOutput, $exitCode);
+
+        // Poll log file for URL and code (up to 30 seconds)
+        $verificationUrl = null;
+        $userCode = null;
+
+        for ($i = 0; $i < 30; $i++) {
+            sleep(1);
+
+            if (!file_exists($logFile)) {
+                continue;
+            }
+
+            $log = file_get_contents($logFile);
+            if (!$log) {
+                continue;
+            }
+
+            // Strip ANSI color codes
+            $text = preg_replace('/\033\[[0-9;]*[mGKHF]/', '', $log);
+
+            // Look for verification URL (any HTTPS URL from auth.openai.com or similar)
+            if (!$verificationUrl) {
+                if (preg_match('/(https:\/\/\S+device\S*)/i', $text, $m)) {
+                    $verificationUrl = rtrim($m[1], '.,)');
+                } elseif (preg_match('/(https:\/\/auth\.openai\.com\/\S+)/i', $text, $m)) {
+                    $verificationUrl = rtrim($m[1], '.,)');
+                }
+            }
+
+            // Look for user code (e.g. CDB9-2OZPE, or similar alphanumeric-dash patterns)
+            if (!$userCode) {
+                if (preg_match('/\b([A-Z0-9]{4,8}[-–][A-Z0-9]{4,8})\b/', $text, $m)) {
+                    $userCode = $m[1];
+                }
+            }
+
+            if ($verificationUrl && $userCode) {
+                break;
+            }
+        }
+
+        if (!$verificationUrl || !$userCode) {
+            $rawLog = file_exists($logFile) ? file_get_contents($logFile) : '(empty)';
+            Log::error('[Codex Device Auth] Could not parse URL/code', ['log' => $rawLog]);
+            $this->failWithError(
+                'Could not get device code from Codex. Ensure Codex is properly installed and try again.'
+            );
+            return;
+        }
+
+        $expiresAt = time() + 900; // 15 minutes
+
+        Log::info('[Codex Device Auth] Device code ready', [
+            'url' => $verificationUrl,
+            'code' => $userCode,
+        ]);
+
+        Cache::put('codex_device_auth', [
+            'status' => 'ready',
+            'verification_url' => $verificationUrl,
+            'user_code' => $userCode,
+            'expires_at' => $expiresAt,
+        ], 960);
+
+        // Poll for auth.json — codex writes it when the user completes authentication
+        for ($i = 0; $i < 900; $i++) {
+            sleep(1);
+
+            if (file_exists($authFile)) {
+                $content = @file_get_contents($authFile);
+                $data = $content ? @json_decode($content, true) : null;
+
+                if ($data && (isset($data['tokens']['access_token']) || isset($data['OPENAI_API_KEY']))) {
+                    Log::info('[Codex Device Auth] Authentication successful');
+
+                    Cache::put('codex_device_auth', ['status' => 'authenticated'], 120);
+
+                    // Create default Codex agent for all workspaces
+                    $this->createDefaultAgents();
+
+                    // Cleanup log
+                    if (file_exists($logFile)) {
+                        unlink($logFile);
+                    }
+
+                    return;
+                }
+            }
+        }
+
+        // Timed out without authentication
+        Log::warning('[Codex Device Auth] Session expired without authentication');
+        Cache::put('codex_device_auth', ['status' => 'expired'], 120);
+
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+    }
+
+    /**
+     * Find the codex binary on the system.
+     */
+    private function findCodexPath(): ?string
+    {
+        $home = getenv('HOME') ?: '/home/appuser';
+
+        $candidates = [
+            "{$home}/.local/share/npm/bin/codex",
+            "{$home}/.npm-global/bin/codex",
+            "{$home}/.local/bin/codex",
+            '/usr/local/bin/codex',
+            '/usr/bin/codex',
+        ];
+
+        // Check via `which` first (respects PATH)
+        exec('which codex 2>/dev/null', $out, $rc);
+        if ($rc === 0 && !empty($out[0])) {
+            return trim($out[0]);
+        }
+
+        // Check known paths
+        foreach ($candidates as $path) {
+            if (file_exists($path) && is_executable($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Store a failure state in cache so the frontend can display the error.
+     */
+    private function failWithError(string $error): void
+    {
+        Cache::put('codex_device_auth', [
+            'status' => 'failed',
+            'error' => $error,
+        ], 300);
+
+        Log::error('[Codex Device Auth] ' . $error);
+    }
+
+    /**
+     * Create a default Codex agent for all workspaces that don't have one.
+     */
+    private function createDefaultAgents(): void
+    {
+        try {
+            $controller = new \App\Http\Controllers\CodexAuthController();
+            $workspaces = \App\Models\Workspace::all();
+            foreach ($workspaces as $workspace) {
+                $controller->ensureDefaultAgentExists($workspace->id);
+            }
+        } catch (\Exception $e) {
+            Log::error('[Codex Device Auth] Failed to create default agents', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/www/app/Models/Agent.php
+++ b/www/app/Models/Agent.php
@@ -44,6 +44,9 @@ class Agent extends Model
         'system_prompt',
         'is_default',
         'enabled',
+        'expose_as_tool',
+        'can_call_subagents',
+        'allowed_subagents',
     ];
 
     protected $casts = [
@@ -54,6 +57,9 @@ class Agent extends Model
         'enabled' => 'boolean',
         'reasoning_config' => 'array',
         'response_level' => 'integer',
+        'expose_as_tool' => 'boolean',
+        'can_call_subagents' => 'boolean',
+        'allowed_subagents' => 'array',
     ];
 
     protected static function boot(): void

--- a/www/app/Services/ConversationFactory.php
+++ b/www/app/Services/ConversationFactory.php
@@ -7,6 +7,7 @@ use App\Models\Conversation;
 use App\Models\Screen;
 use App\Models\Session;
 use App\Models\Workspace;
+use App\Services\ModelRepository;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
@@ -23,6 +24,7 @@ class ConversationFactory
 {
     public function __construct(
         private ProviderFactory $providerFactory,
+        private ModelRepository $models,
     ) {}
 
     /**
@@ -192,10 +194,22 @@ class ConversationFactory
 
     /**
      * Initialize the context window size from the provider.
+     * For agents with extended_context (1M support), uses max_context_window instead.
      */
     private function initializeContextWindow(Conversation $conversation): void
     {
         try {
+            // For 1M context agents, use max_context_window (e.g. 1,000,000)
+            // instead of the standard context_window (e.g. 200,000)
+            $conversation->loadMissing('agent');
+            if ($conversation->agent?->extended_context) {
+                $maxContextWindow = $this->models->getMaxContextWindow($conversation->model);
+                if ($maxContextWindow > 0) {
+                    $conversation->update(['context_window_size' => $maxContextWindow]);
+                    return;
+                }
+            }
+
             $provider = $this->providerFactory->make($conversation->provider_type);
             $contextWindow = $provider->getContextWindow($conversation->model);
             $conversation->update(['context_window_size' => $contextWindow]);

--- a/www/app/Services/ModelRepository.php
+++ b/www/app/Services/ModelRepository.php
@@ -123,6 +123,23 @@ class ModelRepository
     }
 
     /**
+     * Get the maximum supported context window for a model.
+     * Returns max_context_window if defined, otherwise falls back to context_window.
+     * For models like Claude 4.6, this may be 1M tokens vs the default 200K.
+     * Returns 0 if the model is not found (e.g. custom openai_compatible model IDs).
+     */
+    public function getMaxContextWindow(string $modelId): int
+    {
+        $model = $this->findByModelId($modelId);
+
+        if (!$model) {
+            return 0;
+        }
+
+        return $model['max_context_window'] ?? $model['context_window'];
+    }
+
+    /**
      * Calculate cost for token usage on a model.
      */
     public function calculateCost(

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -187,6 +187,16 @@ class ClaudeCodeProvider extends AbstractCliProvider
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
 
+        // For 1M context agents, bypass the CLI's hard blocking limit (~177K tokens).
+        // Two env vars are required:
+        // 1. DISABLE_AUTO_COMPACT=1 — prevents auto-compact at ~167K tokens
+        // 2. CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE=977000 — bypasses the hard block at ~177K
+        //    (DISABLE_AUTO_COMPACT alone does NOT bypass this — separate code path)
+        if ($conversation->agent?->extended_context) {
+            $env['DISABLE_AUTO_COMPACT'] = '1';
+            $env['CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE'] = '977000';
+        }
+
         return $env;
     }
 

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -114,15 +114,21 @@ class SubAgentRunner
         ]);
 
         if ($isBackground) {
-            return ToolResult::success(json_encode([
+            $jsonOutput = json_encode([
                 'task_id' => $task->id,
                 'conversation_id' => $conversation->uuid,
                 'status' => 'running',
                 'agent' => $agent->slug,
                 'provider' => $agent->provider,
                 'model' => $conversation->model,
-                'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output.",
-            ], JSON_PRETTY_PRINT));
+                'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output. Use SubAgentCancel with task_id '{$task->id}' to cancel.",
+            ], JSON_PRETTY_PRINT);
+
+            $endTurnMessage = "Background sub-agent started (task `{$task->id}`, agent `{$agent->slug}`). "
+                . "Use SubAgentOutput to check status and retrieve results, "
+                . "or SubAgentCancel to stop it.";
+
+            return ToolResult::successEndTurn($jsonOutput, $endTurnMessage);
         }
 
         return $this->waitForCompletion($task, $conversation);

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ProcessConversationStream;
+use App\Models\Agent;
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Tools\ExecutionContext;
+use App\Tools\ToolResult;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Encapsulates the logic for spawning a sub-agent conversation.
+ *
+ * Used by both SubAgentTool (generic slug-based dispatch) and AgentTool
+ * (per-agent native tool calls). Supports foreground and background modes,
+ * as well as resuming an existing conversation.
+ */
+class SubAgentRunner
+{
+    public function __construct(
+        private readonly ConversationFactory $factory,
+        private readonly StreamManager $streamManager,
+    ) {}
+
+    /**
+     * Run an agent with the given prompt.
+     *
+     * @param Agent           $agent          The agent to spawn
+     * @param string          $prompt         The task/prompt to send
+     * @param bool            $isBackground   Return immediately (background) or wait (foreground)
+     * @param ExecutionContext $context        Caller's execution context
+     * @param string|null     $conversationId Existing conversation UUID to resume (optional)
+     */
+    public function run(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        ?string $conversationId = null,
+    ): ToolResult {
+        $workspace = $context->getWorkspace() ?? $agent->workspace;
+        $workspaceId = $workspace?->id;
+        $workingDirectory = $context->workingDirectory;
+
+        try {
+            if ($conversationId !== null) {
+                return $this->resume($agent, $prompt, $isBackground, $context, $conversationId, $workspaceId);
+            }
+
+            return $this->spawn($agent, $prompt, $isBackground, $context, $workspaceId, $workingDirectory);
+        } catch (\Exception $e) {
+            Log::error('SubAgentRunner: failed to start sub-agent', [
+                'agent' => $agent->slug,
+                'error' => $e->getMessage(),
+            ]);
+            return ToolResult::error('Failed to start sub-agent: ' . $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private function spawn(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        ?string $workspaceId,
+        string $workingDirectory,
+    ): ToolResult {
+        [$conversation, $task] = DB::transaction(function () use ($agent, $workingDirectory, $workspaceId, $prompt, $context, $isBackground) {
+            $conversation = $this->factory->createFromAgent(
+                $agent,
+                $workingDirectory,
+                $workspaceId,
+                'Subagent: ' . Str::limit($prompt, 60)
+            );
+
+            $task = SubAgentTask::create([
+                'parent_conversation_uuid' => $context->conversationUuid,
+                'child_conversation_uuid' => $conversation->uuid,
+                'agent_id' => $agent->id,
+                'prompt' => $prompt,
+                'is_background' => $isBackground,
+            ]);
+
+            return [$conversation, $task];
+        });
+
+        // Initialize the Redis stream (outside transaction)
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+            'subagent_task_id' => $task->id,
+        ]);
+
+        ProcessConversationStream::dispatch($conversation->uuid, $prompt);
+
+        Log::info('SubAgentRunner: task started', [
+            'task_id' => $task->id,
+            'parent_conversation' => $context->conversationUuid,
+            'child_conversation' => $conversation->uuid,
+            'agent' => $agent->slug,
+            'background' => $isBackground,
+        ]);
+
+        if ($isBackground) {
+            return ToolResult::success(json_encode([
+                'task_id' => $task->id,
+                'conversation_id' => $conversation->uuid,
+                'status' => 'running',
+                'agent' => $agent->slug,
+                'provider' => $agent->provider,
+                'model' => $conversation->model,
+                'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output.",
+            ], JSON_PRETTY_PRINT));
+        }
+
+        return $this->waitForCompletion($task, $conversation);
+    }
+
+    /**
+     * Resume an existing conversation by adding a new user message.
+     */
+    private function resume(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        string $conversationId,
+        ?string $workspaceId,
+    ): ToolResult {
+        $conversation = Conversation::where('uuid', $conversationId)
+            ->when($workspaceId, fn($q) => $q->where('workspace_id', $workspaceId))
+            ->first();
+
+        if (!$conversation) {
+            return ToolResult::error("Conversation '{$conversationId}' not found or not accessible.");
+        }
+
+        // Create a new task linked to this resumed conversation
+        $task = SubAgentTask::create([
+            'parent_conversation_uuid' => $context->conversationUuid,
+            'child_conversation_uuid' => $conversation->uuid,
+            'agent_id' => $agent->id,
+            'prompt' => $prompt,
+            'is_background' => $isBackground,
+        ]);
+
+        // Re-initialise the stream for this turn
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+            'subagent_task_id' => $task->id,
+        ]);
+
+        ProcessConversationStream::dispatch($conversation->uuid, $prompt);
+
+        Log::info('SubAgentRunner: conversation resumed', [
+            'task_id' => $task->id,
+            'parent_conversation' => $context->conversationUuid,
+            'child_conversation' => $conversation->uuid,
+            'agent' => $agent->slug,
+            'background' => $isBackground,
+        ]);
+
+        if ($isBackground) {
+            return ToolResult::success(json_encode([
+                'task_id' => $task->id,
+                'conversation_id' => $conversation->uuid,
+                'status' => 'running',
+                'agent' => $agent->slug,
+                'message' => "Resumed conversation. Use SubAgentOutput with task_id '{$task->id}' to check status.",
+            ], JSON_PRETTY_PRINT));
+        }
+
+        return $this->waitForCompletion($task, $conversation);
+    }
+
+    /**
+     * Poll the conversation until it reaches a terminal state or times out.
+     */
+    private function waitForCompletion(SubAgentTask $task, Conversation $conversation): ToolResult
+    {
+        $maxWaitSeconds = 600; // 10 minutes
+        $pollIntervalMicroseconds = 1_000_000; // 1 second
+        $startTime = time();
+
+        while (time() - $startTime < $maxWaitSeconds) {
+            $conversation->refresh();
+
+            if (in_array($conversation->status, [Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED], true)) {
+                $task->unsetRelation('childConversation');
+                $output = $task->collectOutput();
+                return ToolResult::success(json_encode([
+                    'task_id' => $task->id,
+                    'conversation_id' => $conversation->uuid,
+                    'status' => 'completed',
+                    'output' => $output,
+                ], JSON_PRETTY_PRINT));
+            }
+
+            if ($conversation->status === Conversation::STATUS_FAILED) {
+                $task->unsetRelation('childConversation');
+                $error = $task->getError();
+                return ToolResult::error("Sub-agent task '{$task->id}' failed: {$error}");
+            }
+
+            usleep($pollIntervalMicroseconds);
+        }
+
+        return ToolResult::success(json_encode([
+            'task_id' => $task->id,
+            'conversation_id' => $conversation->uuid,
+            'status' => 'timeout',
+            'message' => "Sub-agent did not complete within {$maxWaitSeconds} seconds. Use SubAgentOutput with task_id '{$task->id}' to check status later.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -99,6 +99,10 @@ class SubAgentRunner
             'subagent_task_id' => $task->id,
         ]);
 
+        // Mark as processing BEFORE dispatching so waitForCompletion doesn't see
+        // the initial 'idle' status and return prematurely before the job starts.
+        $conversation->startProcessing();
+
         ProcessConversationStream::dispatch($conversation->uuid, $prompt);
 
         Log::info('SubAgentRunner: task started', [
@@ -143,7 +147,7 @@ class SubAgentRunner
             return ToolResult::error("Conversation '{$conversationId}' not found or not accessible.");
         }
 
-        if ($conversation->status === Conversation::STATUS_RUNNING) {
+        if ($conversation->status === Conversation::STATUS_PROCESSING) {
             return ToolResult::error("Conversation '{$conversationId}' is still running. Wait for it to complete before resuming.");
         }
 

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -52,7 +52,7 @@ class SubAgentRunner
             }
 
             return $this->spawn($agent, $prompt, $isBackground, $context, $workspaceId, $workingDirectory);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             Log::error('SubAgentRunner: failed to start sub-agent', [
                 'agent' => $agent->slug,
                 'error' => $e->getMessage(),
@@ -141,6 +141,10 @@ class SubAgentRunner
 
         if (!$conversation) {
             return ToolResult::error("Conversation '{$conversationId}' not found or not accessible.");
+        }
+
+        if ($conversation->status === Conversation::STATUS_RUNNING) {
+            return ToolResult::error("Conversation '{$conversationId}' is still running. Wait for it to complete before resuming.");
         }
 
         // Create a new task linked to this resumed conversation

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -144,7 +144,7 @@ class SystemPromptBuilder
         // 12. Dedicated agent tools — injected last so it's in the recency zone
         // For CLI providers this is the equivalent of API agent_* tool definitions.
         if ($promptType === 'cli' && $agent) {
-            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent)) {
+            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent, $workspace)) {
                 $sections[] = $agentToolsSection;
             }
         }
@@ -531,13 +531,22 @@ PROMPT;
      * For CLI providers (Claude Code, Codex) the equivalent is text in the system prompt
      * describing each exposed agent as a callable tool via `pd subagent:run`.
      */
-    private function buildExposedAgentToolsSection(?Agent $callerAgent): ?string
+    private function buildExposedAgentToolsSection(?Agent $callerAgent, ?Workspace $workspace = null): ?string
     {
         if (!$callerAgent || !$callerAgent->can_call_subagents) {
             return null;
         }
 
-        $query = Agent::where('workspace_id', $callerAgent->workspace_id)
+        // Resolve the workspace to scope agent lookup.
+        // Agents without a workspace_id (global defaults) fall back to the
+        // conversation workspace so they can still see exposed agents.
+        $workspaceId = $callerAgent->workspace_id ?? $workspace?->id;
+
+        if (!$workspaceId) {
+            return null;
+        }
+
+        $query = Agent::where('workspace_id', $workspaceId)
             ->where('enabled', true)
             ->where('expose_as_tool', true)
             ->where('id', '!=', $callerAgent->id);

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -549,30 +549,38 @@ PROMPT;
 
         $agents = $query->orderBy('name')->get();
 
+        $lines = [];
+        $lines[] = "# AGENT ORCHESTRATION — STRICT RULES\n";
+        $lines[] = "## ❌ NEVER do any of these:";
+        $lines[] = "- Use your built-in `Task` tool to spawn subagents";
+        $lines[] = "- Use any native agent/subagent spawning mechanism";
+        $lines[] = "- Look up agents in memory";
+        $lines[] = "- Use the generic SubAgent tool\n";
+        $lines[] = "## ✅ ALWAYS use PocketDev's `pd subagent:run` via Bash for ALL agent calls:\n";
+        $lines[] = "```bash";
+        $lines[] = "pd subagent:run --agent=<slug> --prompt=\"<task>\"";
+        $lines[] = "```\n";
+        $lines[] = "PocketDev manages all agent orchestration, context, and output. Bypassing it breaks tracking and output capture.\n";
+
         if ($agents->isEmpty()) {
-            return null;
+            return implode("\n", $lines);
         }
 
-        $lines = [];
-        $lines[] = "# IMPORTANT: Dedicated Agent Tools Available\n";
-        $lines[] = "You have access to the following dedicated agents as tools. When asked to use one of these";
-        $lines[] = "agents by name (e.g. \"use agent_opus-45-reviewer\"), invoke it immediately using the Bash tool.\n";
-        $lines[] = "**Do NOT look in memory. Do NOT use SubAgent. Just run the Bash command shown below.**\n";
+        $lines[] = "---\n";
+        $lines[] = "## Available PocketDev Agents\n";
 
         foreach ($agents as $agent) {
             $toolName = 'agent_' . $agent->slug;
-            $lines[] = "## {$toolName}";
+            $lines[] = "### `{$toolName}`";
             if ($agent->description) {
                 $lines[] = trim($agent->description);
             }
-            $lines[] = "When asked to use `{$toolName}`, run this Bash command:";
+            $lines[] = "**Run via Bash (the ONLY correct way):**";
             $lines[] = "```bash";
             $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<task>\"";
             $lines[] = "```";
-            $lines[] = "Example: User says \"use agent_{$agent->slug} to review this code\" → you run:";
-            $lines[] = "```bash";
-            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"Review this code: ...\"";
-            $lines[] = "```\n";
+            $lines[] = "❌ Wrong: using Task tool with `{$toolName}`";
+            $lines[] = "✅ Right: `pd subagent:run --agent={$agent->slug} --prompt=\"...\"`\n";
         }
 
         return implode("\n", $lines);

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -100,6 +100,13 @@ class SystemPromptBuilder
             $sections[] = $agentsSection;
         }
 
+        // 3c. Dedicated agent tools section (CLI equivalent of API agent_* tool definitions)
+        if ($promptType === 'cli' && $agent) {
+            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent)) {
+                $sections[] = $agentToolsSection;
+            }
+        }
+
         // 4. Skills section (slash commands)
         if ($skillsSection = $this->toolSelector->buildSkillsSection($agent)) {
             $sections[] = $skillsSection;
@@ -511,6 +518,52 @@ PROMPT;
                 $escapeCell($agent->model),
                 $escapeCell($desc),
             );
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Build a section describing exposed agents as dedicated named tools for CLI providers.
+     *
+     * For API providers this is handled via getDefinitions() injecting agent_* tool schemas.
+     * For CLI providers (Claude Code, Codex) the equivalent is text in the system prompt
+     * describing each exposed agent as a callable tool via `pd subagent:run`.
+     */
+    private function buildExposedAgentToolsSection(?Agent $callerAgent): ?string
+    {
+        if (!$callerAgent || !$callerAgent->can_call_subagents) {
+            return null;
+        }
+
+        $query = Agent::where('workspace_id', $callerAgent->workspace_id)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true)
+            ->where('id', '!=', $callerAgent->id);
+
+        $allowlist = $callerAgent->allowed_subagents;
+        if (!empty($allowlist)) {
+            $query->whereIn('id', $allowlist);
+        }
+
+        $agents = $query->orderBy('name')->get();
+
+        if ($agents->isEmpty()) {
+            return null;
+        }
+
+        $lines = ["# Dedicated Agent Tools\n"];
+        $lines[] = "These agents are exposed as dedicated tools. Call them by name instead of using the generic SubAgent tool.\n";
+
+        foreach ($agents as $agent) {
+            $toolName = 'agent_' . $agent->slug;
+            $lines[] = "#### {$toolName}";
+            if ($agent->description) {
+                $lines[] = trim($agent->description);
+            }
+            $lines[] = "```bash";
+            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<your task>\"";
+            $lines[] = "```\n";
         }
 
         return implode("\n", $lines);

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -100,13 +100,6 @@ class SystemPromptBuilder
             $sections[] = $agentsSection;
         }
 
-        // 3c. Dedicated agent tools section (CLI equivalent of API agent_* tool definitions)
-        if ($promptType === 'cli' && $agent) {
-            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent)) {
-                $sections[] = $agentToolsSection;
-            }
-        }
-
         // 4. Skills section (slash commands)
         if ($skillsSection = $this->toolSelector->buildSkillsSection($agent)) {
             $sections[] = $skillsSection;
@@ -146,6 +139,14 @@ class SystemPromptBuilder
         // 11. Environment (credentials and packages)
         if ($envSection = $this->buildEnvironmentSection($workspace)) {
             $sections[] = $envSection;
+        }
+
+        // 12. Dedicated agent tools — injected last so it's in the recency zone
+        // For CLI providers this is the equivalent of API agent_* tool definitions.
+        if ($promptType === 'cli' && $agent) {
+            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent)) {
+                $sections[] = $agentToolsSection;
+            }
         }
 
         // Note: Context usage section removed to improve prompt caching.
@@ -552,17 +553,20 @@ PROMPT;
             return null;
         }
 
-        $lines = ["# Dedicated Agent Tools\n"];
-        $lines[] = "These agents are exposed as dedicated tools. Call them by name instead of using the generic SubAgent tool.\n";
+        $lines = [];
+        $lines[] = "# IMPORTANT: You Have Dedicated Sub-Agent Tools\n";
+        $lines[] = "The following agents are available as **dedicated tools** you MUST use via the Bash tool.";
+        $lines[] = "When a task matches one of these agents, call it directly — do NOT use the generic SubAgent tool.\n";
 
         foreach ($agents as $agent) {
             $toolName = 'agent_' . $agent->slug;
-            $lines[] = "#### {$toolName}";
+            $lines[] = "## {$toolName}";
             if ($agent->description) {
-                $lines[] = trim($agent->description);
+                $lines[] = '> ' . trim($agent->description);
             }
+            $lines[] = "Call via Bash:";
             $lines[] = "```bash";
-            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<your task>\"";
+            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<your task here>\"";
             $lines[] = "```\n";
         }
 

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -554,19 +554,24 @@ PROMPT;
         }
 
         $lines = [];
-        $lines[] = "# IMPORTANT: You Have Dedicated Sub-Agent Tools\n";
-        $lines[] = "The following agents are available as **dedicated tools** you MUST use via the Bash tool.";
-        $lines[] = "When a task matches one of these agents, call it directly — do NOT use the generic SubAgent tool.\n";
+        $lines[] = "# IMPORTANT: Dedicated Agent Tools Available\n";
+        $lines[] = "You have access to the following dedicated agents as tools. When asked to use one of these";
+        $lines[] = "agents by name (e.g. \"use agent_opus-45-reviewer\"), invoke it immediately using the Bash tool.\n";
+        $lines[] = "**Do NOT look in memory. Do NOT use SubAgent. Just run the Bash command shown below.**\n";
 
         foreach ($agents as $agent) {
             $toolName = 'agent_' . $agent->slug;
             $lines[] = "## {$toolName}";
             if ($agent->description) {
-                $lines[] = '> ' . trim($agent->description);
+                $lines[] = trim($agent->description);
             }
-            $lines[] = "Call via Bash:";
+            $lines[] = "When asked to use `{$toolName}`, run this Bash command:";
             $lines[] = "```bash";
-            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<your task here>\"";
+            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<task>\"";
+            $lines[] = "```";
+            $lines[] = "Example: User says \"use agent_{$agent->slug} to review this code\" → you run:";
+            $lines[] = "```bash";
+            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"Review this code: ...\"";
             $lines[] = "```\n";
         }
 

--- a/www/app/Services/ToolRegistry.php
+++ b/www/app/Services/ToolRegistry.php
@@ -2,13 +2,16 @@
 
 namespace App\Services;
 
+use App\Models\Agent;
 use App\Models\PocketTool;
 use App\Models\Workspace;
+use App\Tools\AgentTool;
 use App\Tools\ExecutionContext;
 use App\Tools\Tool;
 use App\Tools\ToolResult;
 use App\Tools\UserTool;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
  * Registry for available tools.
@@ -17,6 +20,10 @@ use Illuminate\Support\Facades\Log;
  * Built-in tools (from app/Tools) are cached in the singleton.
  * User tools (from database) are always fetched fresh to ensure
  * newly created tools are available without restarting the queue worker.
+ *
+ * Agent tools (agents with expose_as_tool = true) are always fetched fresh
+ * and injected per-caller based on the caller agent's can_call_subagents
+ * and allowed_subagents settings.
  *
  * Tool filtering follows a three-tier hierarchy:
  * 1. Global enablement (PocketTool.enabled) - tool exists and is globally enabled
@@ -63,8 +70,64 @@ class ToolRegistry
     }
 
     /**
+     * Get AgentTools for agents that are opted-in (expose_as_tool = true)
+     * and permitted for the given caller.
+     *
+     * Rules:
+     * - If no caller: inject all opted-in agents across all workspaces (e.g. CLI context)
+     * - If caller has can_call_subagents = false: inject nothing
+     * - If caller has allowed_subagents (non-null array): inject only those agent IDs
+     * - Otherwise: inject all opted-in agents in the same workspace as the caller
+     *
+     * @return array<string, AgentTool>
+     */
+    private function getAgentTools(?Agent $callerAgent = null): array
+    {
+        $agentTools = [];
+
+        try {
+            // Caller has explicitly disabled sub-agent calling
+            if ($callerAgent !== null && ! $callerAgent->can_call_subagents) {
+                return [];
+            }
+
+            $query = Agent::query()
+                ->where('enabled', true)
+                ->where('expose_as_tool', true);
+
+            if ($callerAgent !== null) {
+                // Scope to caller's workspace
+                $query->where('workspace_id', $callerAgent->workspace_id);
+
+                // Apply allowlist if set
+                $allowlist = $callerAgent->allowed_subagents;
+                if (!empty($allowlist)) {
+                    $query->whereIn('id', $allowlist);
+                }
+
+                // Never inject the caller itself as its own sub-agent tool
+                $query->where('id', '!=', $callerAgent->id);
+            }
+
+            $agents = $query->get();
+
+            foreach ($agents as $agent) {
+                $tool = new AgentTool($agent);
+                $agentTools[$tool->name] = $tool;
+            }
+        } catch (\Throwable $e) {
+            Log::debug('ToolRegistry: Could not load agent tools', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $agentTools;
+    }
+
+    /**
      * Get a tool by name.
      * Checks built-in tools first, then user tools.
+     * Does not include agent tools (use execute() which handles agent_* prefix).
      */
     public function get(string $name): ?Tool
     {
@@ -88,6 +151,7 @@ class ToolRegistry
 
     /**
      * Get all registered tools (built-in + fresh user tools).
+     * Does not include agent tools (context-dependent).
      *
      * @return array<string, Tool>
      */
@@ -144,15 +208,20 @@ class ToolRegistry
 
     /**
      * Get tool definitions for the API.
-     * Returns array of tool definition objects.
      *
+     * Merges built-in tools, user tools, and per-caller agent tools.
+     * Agent tools are filtered based on the caller's sub-agent settings.
+     *
+     * @param Agent|null $callerAgent The agent making the request (null = no per-agent filtering)
      * @return array<array{name: string, description: string, input_schema: array}>
      */
-    public function getDefinitions(): array
+    public function getDefinitions(?Agent $callerAgent = null): array
     {
+        $tools = array_merge($this->all(), $this->getAgentTools($callerAgent));
+
         return array_map(
             fn(Tool $tool) => $tool->toDefinition(),
-            array_values($this->all())
+            array_values($tools)
         );
     }
 
@@ -184,9 +253,17 @@ class ToolRegistry
 
     /**
      * Execute a tool by name.
+     *
+     * Handles the agent_* prefix for native per-agent tool calls.
+     * Agent resolution is scoped to the context workspace for security.
      */
     public function execute(string $name, array $input, ExecutionContext $context): ToolResult
     {
+        // Handle native agent tool calls (agent_<slug> prefix)
+        if (Str::startsWith($name, 'agent_')) {
+            return $this->executeAgentTool($name, $input, $context);
+        }
+
         $tool = $this->get($name);
 
         if ($tool === null) {
@@ -197,6 +274,59 @@ class ToolRegistry
             return $tool->execute($input, $context);
         } catch (\Throwable $e) {
             return ToolResult::error("Tool execution failed: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Dispatch an agent_* tool call.
+     *
+     * Resolves the target agent by slug, verifies it has expose_as_tool = true,
+     * and checks that the caller's sub-agent settings permit the call.
+     */
+    private function executeAgentTool(string $name, array $input, ExecutionContext $context): ToolResult
+    {
+        $slug = Str::after($name, 'agent_');
+        $workspace = $context->getWorkspace();
+        $callerAgent = $context->getAgent();
+
+        // Security: caller must have sub-agent calling enabled
+        if ($callerAgent !== null && ! $callerAgent->can_call_subagents) {
+            return ToolResult::error("This agent is not permitted to call other agents.");
+        }
+
+        $query = Agent::query()
+            ->where('slug', $slug)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true);
+
+        if ($workspace) {
+            $query->where('workspace_id', $workspace->id);
+        }
+
+        $agent = $query->first();
+
+        if (!$agent) {
+            return ToolResult::error("Agent tool '{$name}' not found or not available. The agent may not exist, be disabled, or not have expose_as_tool enabled.");
+        }
+
+        // Check allowlist
+        if ($callerAgent !== null) {
+            $allowlist = $callerAgent->allowed_subagents;
+            if (!empty($allowlist) && !in_array($agent->id, $allowlist, true)) {
+                return ToolResult::error("Agent '{$agent->name}' is not in this agent's allowed sub-agents list.");
+            }
+
+            // Prevent self-call
+            if ($callerAgent->id === $agent->id) {
+                return ToolResult::error("An agent cannot call itself as a sub-agent.");
+            }
+        }
+
+        try {
+            $agentTool = new AgentTool($agent);
+            return $agentTool->execute($input, $context);
+        } catch (\Throwable $e) {
+            return ToolResult::error("Agent tool execution failed: {$e->getMessage()}");
         }
     }
 

--- a/www/app/Services/ToolRegistry.php
+++ b/www/app/Services/ToolRegistry.php
@@ -86,27 +86,26 @@ class ToolRegistry
         $agentTools = [];
 
         try {
+            // No caller context (e.g. CLI) — do not inject any agent tools
+            if ($callerAgent === null) {
+                return [];
+            }
+
             // Caller has explicitly disabled sub-agent calling
-            if ($callerAgent !== null && ! $callerAgent->can_call_subagents) {
+            if (! $callerAgent->can_call_subagents) {
                 return [];
             }
 
             $query = Agent::query()
                 ->where('enabled', true)
-                ->where('expose_as_tool', true);
+                ->where('expose_as_tool', true)
+                ->where('workspace_id', $callerAgent->workspace_id)
+                ->where('id', '!=', $callerAgent->id);
 
-            if ($callerAgent !== null) {
-                // Scope to caller's workspace
-                $query->where('workspace_id', $callerAgent->workspace_id);
-
-                // Apply allowlist if set
-                $allowlist = $callerAgent->allowed_subagents;
-                if (!empty($allowlist)) {
-                    $query->whereIn('id', $allowlist);
-                }
-
-                // Never inject the caller itself as its own sub-agent tool
-                $query->where('id', '!=', $callerAgent->id);
+            // Apply allowlist if set
+            $allowlist = $callerAgent->allowed_subagents;
+            if (!empty($allowlist)) {
+                $query->whereIn('id', $allowlist);
             }
 
             $agents = $query->get();

--- a/www/app/Tools/AgentTool.php
+++ b/www/app/Tools/AgentTool.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Agent;
+use App\Services\SubAgentRunner;
+
+/**
+ * A per-agent tool wrapper that exposes a PocketDev agent as a native tool call.
+ *
+ * Only created for agents with expose_as_tool = true. Each instance wraps one
+ * agent and generates a dedicated tool definition named `agent_<slug>`.
+ *
+ * The AI calls it like any other tool — no slug lookup, no generic SubAgent
+ * dispatch. This follows Anthropic's recommended "agents as tools" pattern.
+ */
+class AgentTool extends Tool
+{
+    public string $category = 'agents';
+
+    public function __construct(private readonly Agent $agent)
+    {
+        $this->name = 'agent_' . $agent->slug;
+
+        $providerLabel = match ($agent->provider) {
+            'claude_code' => 'Claude Code',
+            'codex'       => 'Codex',
+            'anthropic'   => 'Anthropic',
+            'openai'      => 'OpenAI',
+            default       => ucfirst($agent->provider),
+        };
+
+        $this->description = $agent->description
+            ?? "Delegate to the {$agent->name} agent ({$providerLabel} / {$agent->model}).";
+
+        $this->inputSchema = [
+            'type' => 'object',
+            'properties' => [
+                'prompt' => [
+                    'type' => 'string',
+                    'description' => "Task for {$agent->name}. Be self-contained — the agent has no context from your conversation.",
+                ],
+                'background' => [
+                    'type' => 'boolean',
+                    'description' => 'Run in background and return task_id immediately. Poll with SubAgentOutput. Default: false.',
+                ],
+                'conversation_id' => [
+                    'type' => 'string',
+                    'description' => 'Optional: UUID of a previous conversation with this agent to resume. When provided, prompt is appended as the next user message.',
+                ],
+            ],
+            'required' => ['prompt'],
+        ];
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $prompt = trim($input['prompt'] ?? '');
+        $isBackground = (bool) ($input['background'] ?? false);
+        $conversationId = isset($input['conversation_id']) ? trim($input['conversation_id']) : null;
+
+        if (empty($prompt)) {
+            return ToolResult::error('prompt is required');
+        }
+
+        return app(SubAgentRunner::class)->run(
+            $this->agent,
+            $prompt,
+            $isBackground,
+            $context,
+            $conversationId ?: null,
+        );
+    }
+
+    /**
+     * Get the underlying agent model.
+     */
+    public function getAgent(): Agent
+    {
+        return $this->agent;
+    }
+}

--- a/www/app/Tools/SubAgentCancelTool.php
+++ b/www/app/Tools/SubAgentCancelTool.php
@@ -1,0 +1,167 @@
+Author: Claude <noreply@anthropic.com>
+Date:   Tue Apr 7 11:54:28 2026 +0000
+
+    feat(subagents): end parent turn immediately after background dispatch + cancel tool
+    
+    Closes #280.
+    
+    **End-turn signal**
+    - `ToolResult` gains `$endTurn` / `$endTurnMessage` and a `successEndTurn()` factory.
+    - `SubAgentTool` returns `successEndTurn()` in background mode instead of plain `success()`.
+    - `ProcessConversationStream::executeTools()` propagates the flag to its result array.
+    - `ProcessConversationStream::streamWithToolLoop()` checks for the flag after saving
+      tool results; when set, saves a synthetic closing assistant message and returns early
+      without a second AI round-trip. The parent conversation becomes interactive as soon as
+      the child job is dispatched.
+    
+    A synthetic assistant message is required because the last saved message is a ROLE_USER
+    tool-result row; without a closing ROLE_ASSISTANT row the next turn would present two
+    consecutive user messages to the API provider.
+    
+    **SubAgentCancel tool**
+    - `SubAgentCancelTool` (auto-discovered, registers as `SubAgentCancel`).
+    - Sets `StreamManager::setAbortFlag()` on the child conversation UUID — same mechanism
+      used by user-initiated stop; child detects flag within ~1 s and shuts down cleanly.
+    - Ownership guard: only the conversation that spawned the task can cancel it
+      (skipped when called via CLI where no parent UUID is available).
+    - No-op with a clear message if the task is already terminal.
+    - `SubAgentCancelCommand` exposes `pd subagent:cancel --task-id=<uuid>`.
+    
+    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+
+diff --git a/www/app/Tools/SubAgentCancelTool.php b/www/app/Tools/SubAgentCancelTool.php
+new file mode 100644
+index 0000000..4cc75ac
+--- /dev/null
++++ b/www/app/Tools/SubAgentCancelTool.php
+@@ -0,0 +1,130 @@
++<?php
++
++namespace App\Tools;
++
++use App\Models\Conversation;
++use App\Models\SubAgentTask;
++use App\Services\StreamManager;
++
++class SubAgentCancelTool extends Tool
++{
++    public string $name = 'SubAgentCancel';
++
++    public string $description = 'Cancel a running background sub-agent task.';
++
++    public string $category = 'custom';
++
++    public array $inputSchema = [
++        'type' => 'object',
++        'properties' => [
++            'task_id' => [
++                'type' => 'string',
++                'description' => 'The task UUID returned by SubAgent when launched with background=true.',
++            ],
++        ],
++        'required' => ['task_id'],
++    ];
++
++    public ?string $instructions = <<<'INSTRUCTIONS'
++Cancel a running background sub-agent task by its task ID.
++
++## When to Use
++- After launching a sub-agent with background=true and deciding to stop it
++- When a background task is no longer needed
++
++## How It Works
++Sets an abort flag on the child conversation. The running sub-agent detects the flag
++within ~1 second on its next event-loop tick and shuts down cleanly.
++Cancellation is non-blocking — this tool returns immediately.
++
++## Notes
++- Only tasks you spawned (from this conversation) can be cancelled
++- If the task has already completed or failed, cancellation is a no-op
++- After cancellation the task status becomes "failed" (same as a user-initiated stop)
++
++## Parameters
++- task_id: The UUID returned by SubAgent when background=true
++INSTRUCTIONS;
++
++    public ?string $cliExamples = <<<'CLI'
++## CLI Example
++
++```bash
++pd subagent:cancel --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
++```
++CLI;
++
++    public ?string $apiExamples = <<<'API'
++## API Example (JSON input)
++
++```json
++{
++  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
++}
++```
++API;
++
++    public function getArtisanCommand(): ?string
++    {
++        return 'subagent:cancel';
++    }
++
++    public function execute(array $input, ExecutionContext $context): ToolResult
++    {
++        $taskId = trim($input['task_id'] ?? '');
++
++        if (empty($taskId)) {
++            return ToolResult::error('task_id is required');
++        }
++
++        $task = SubAgentTask::with('childConversation')->find($taskId);
++
++        if (!$task) {
++            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
++        }
++
++        // Guard: only allow cancellation of tasks spawned by this conversation.
++        // Prevents one conversation from aborting another conversation's subagents.
++        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
++            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
++        }
++
++        $conversation = $task->childConversation;
++
++        if (!$conversation) {
++            return ToolResult::error("Sub-agent task '{$taskId}' has no associated conversation.");
++        }
++
++        // If already terminal, nothing to cancel
++        $terminalStatuses = [
++            Conversation::STATUS_IDLE,
++            Conversation::STATUS_ARCHIVED,
++            Conversation::STATUS_FAILED,
++        ];
++
++        if (in_array($conversation->status, $terminalStatuses, true)) {
++            $status = $task->getStatus();
++            return ToolResult::success(json_encode([
++                'task_id'   => $task->id,
++                'cancelled' => false,
++                'status'    => $status,
++                'message'   => "Task is already {$status} — nothing to cancel.",
++            ], JSON_PRETTY_PRINT));
++        }
++
++        // Set the abort flag on the child conversation's stream.
++        // ProcessConversationStream checks this flag in its event loop and will
++        // shut down the child cleanly within ~1 second.
++        $streamManager = app(StreamManager::class);
++        $streamManager->setAbortFlag($conversation->uuid);
++
++        return ToolResult::success(json_encode([
++            'task_id'   => $task->id,
++            'cancelled' => true,
++            'status'    => 'cancelling',
++            'message'   => "Abort signal sent to sub-agent task '{$task->id}'. "
++                . 'The task will stop within ~1 second. '
++                . "Use SubAgentOutput with task_id '{$task->id}' to confirm.",
++        ], JSON_PRETTY_PRINT));
++    }
++}

--- a/www/app/Tools/SubAgentCancelTool.php
+++ b/www/app/Tools/SubAgentCancelTool.php
@@ -1,167 +1,130 @@
-Author: Claude <noreply@anthropic.com>
-Date:   Tue Apr 7 11:54:28 2026 +0000
+<?php
 
-    feat(subagents): end parent turn immediately after background dispatch + cancel tool
-    
-    Closes #280.
-    
-    **End-turn signal**
-    - `ToolResult` gains `$endTurn` / `$endTurnMessage` and a `successEndTurn()` factory.
-    - `SubAgentTool` returns `successEndTurn()` in background mode instead of plain `success()`.
-    - `ProcessConversationStream::executeTools()` propagates the flag to its result array.
-    - `ProcessConversationStream::streamWithToolLoop()` checks for the flag after saving
-      tool results; when set, saves a synthetic closing assistant message and returns early
-      without a second AI round-trip. The parent conversation becomes interactive as soon as
-      the child job is dispatched.
-    
-    A synthetic assistant message is required because the last saved message is a ROLE_USER
-    tool-result row; without a closing ROLE_ASSISTANT row the next turn would present two
-    consecutive user messages to the API provider.
-    
-    **SubAgentCancel tool**
-    - `SubAgentCancelTool` (auto-discovered, registers as `SubAgentCancel`).
-    - Sets `StreamManager::setAbortFlag()` on the child conversation UUID — same mechanism
-      used by user-initiated stop; child detects flag within ~1 s and shuts down cleanly.
-    - Ownership guard: only the conversation that spawned the task can cancel it
-      (skipped when called via CLI where no parent UUID is available).
-    - No-op with a clear message if the task is already terminal.
-    - `SubAgentCancelCommand` exposes `pd subagent:cancel --task-id=<uuid>`.
-    
-    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+namespace App\Tools;
 
-diff --git a/www/app/Tools/SubAgentCancelTool.php b/www/app/Tools/SubAgentCancelTool.php
-new file mode 100644
-index 0000000..4cc75ac
---- /dev/null
-+++ b/www/app/Tools/SubAgentCancelTool.php
-@@ -0,0 +1,130 @@
-+<?php
-+
-+namespace App\Tools;
-+
-+use App\Models\Conversation;
-+use App\Models\SubAgentTask;
-+use App\Services\StreamManager;
-+
-+class SubAgentCancelTool extends Tool
-+{
-+    public string $name = 'SubAgentCancel';
-+
-+    public string $description = 'Cancel a running background sub-agent task.';
-+
-+    public string $category = 'custom';
-+
-+    public array $inputSchema = [
-+        'type' => 'object',
-+        'properties' => [
-+            'task_id' => [
-+                'type' => 'string',
-+                'description' => 'The task UUID returned by SubAgent when launched with background=true.',
-+            ],
-+        ],
-+        'required' => ['task_id'],
-+    ];
-+
-+    public ?string $instructions = <<<'INSTRUCTIONS'
-+Cancel a running background sub-agent task by its task ID.
-+
-+## When to Use
-+- After launching a sub-agent with background=true and deciding to stop it
-+- When a background task is no longer needed
-+
-+## How It Works
-+Sets an abort flag on the child conversation. The running sub-agent detects the flag
-+within ~1 second on its next event-loop tick and shuts down cleanly.
-+Cancellation is non-blocking — this tool returns immediately.
-+
-+## Notes
-+- Only tasks you spawned (from this conversation) can be cancelled
-+- If the task has already completed or failed, cancellation is a no-op
-+- After cancellation the task status becomes "failed" (same as a user-initiated stop)
-+
-+## Parameters
-+- task_id: The UUID returned by SubAgent when background=true
-+INSTRUCTIONS;
-+
-+    public ?string $cliExamples = <<<'CLI'
-+## CLI Example
-+
-+```bash
-+pd subagent:cancel --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
-+```
-+CLI;
-+
-+    public ?string $apiExamples = <<<'API'
-+## API Example (JSON input)
-+
-+```json
-+{
-+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-+}
-+```
-+API;
-+
-+    public function getArtisanCommand(): ?string
-+    {
-+        return 'subagent:cancel';
-+    }
-+
-+    public function execute(array $input, ExecutionContext $context): ToolResult
-+    {
-+        $taskId = trim($input['task_id'] ?? '');
-+
-+        if (empty($taskId)) {
-+            return ToolResult::error('task_id is required');
-+        }
-+
-+        $task = SubAgentTask::with('childConversation')->find($taskId);
-+
-+        if (!$task) {
-+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
-+        }
-+
-+        // Guard: only allow cancellation of tasks spawned by this conversation.
-+        // Prevents one conversation from aborting another conversation's subagents.
-+        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
-+            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
-+        }
-+
-+        $conversation = $task->childConversation;
-+
-+        if (!$conversation) {
-+            return ToolResult::error("Sub-agent task '{$taskId}' has no associated conversation.");
-+        }
-+
-+        // If already terminal, nothing to cancel
-+        $terminalStatuses = [
-+            Conversation::STATUS_IDLE,
-+            Conversation::STATUS_ARCHIVED,
-+            Conversation::STATUS_FAILED,
-+        ];
-+
-+        if (in_array($conversation->status, $terminalStatuses, true)) {
-+            $status = $task->getStatus();
-+            return ToolResult::success(json_encode([
-+                'task_id'   => $task->id,
-+                'cancelled' => false,
-+                'status'    => $status,
-+                'message'   => "Task is already {$status} — nothing to cancel.",
-+            ], JSON_PRETTY_PRINT));
-+        }
-+
-+        // Set the abort flag on the child conversation's stream.
-+        // ProcessConversationStream checks this flag in its event loop and will
-+        // shut down the child cleanly within ~1 second.
-+        $streamManager = app(StreamManager::class);
-+        $streamManager->setAbortFlag($conversation->uuid);
-+
-+        return ToolResult::success(json_encode([
-+            'task_id'   => $task->id,
-+            'cancelled' => true,
-+            'status'    => 'cancelling',
-+            'message'   => "Abort signal sent to sub-agent task '{$task->id}'. "
-+                . 'The task will stop within ~1 second. '
-+                . "Use SubAgentOutput with task_id '{$task->id}' to confirm.",
-+        ], JSON_PRETTY_PRINT));
-+    }
-+}
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Services\StreamManager;
+
+class SubAgentCancelTool extends Tool
+{
+    public string $name = 'SubAgentCancel';
+
+    public string $description = 'Cancel a running background sub-agent task.';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'task_id' => [
+                'type' => 'string',
+                'description' => 'The task UUID returned by SubAgent when launched with background=true.',
+            ],
+        ],
+        'required' => ['task_id'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Cancel a running background sub-agent task by its task ID.
+
+## When to Use
+- After launching a sub-agent with background=true and deciding to stop it
+- When a background task is no longer needed
+
+## How It Works
+Sets an abort flag on the child conversation. The running sub-agent detects the flag
+within ~1 second on its next event-loop tick and shuts down cleanly.
+Cancellation is non-blocking — this tool returns immediately.
+
+## Notes
+- Only tasks you spawned (from this conversation) can be cancelled
+- If the task has already completed or failed, cancellation is a no-op
+- After cancellation the task status becomes "failed" (same as a user-initiated stop)
+
+## Parameters
+- task_id: The UUID returned by SubAgent when background=true
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+pd subagent:cancel --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:cancel';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $taskId = trim($input['task_id'] ?? '');
+
+        if (empty($taskId)) {
+            return ToolResult::error('task_id is required');
+        }
+
+        $task = SubAgentTask::with('childConversation')->find($taskId);
+
+        if (!$task) {
+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
+        }
+
+        // Guard: only allow cancellation of tasks spawned by this conversation.
+        // Prevents one conversation from aborting another conversation's subagents.
+        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
+            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
+        }
+
+        $conversation = $task->childConversation;
+
+        if (!$conversation) {
+            return ToolResult::error("Sub-agent task '{$taskId}' has no associated conversation.");
+        }
+
+        // If already terminal, nothing to cancel
+        $terminalStatuses = [
+            Conversation::STATUS_IDLE,
+            Conversation::STATUS_ARCHIVED,
+            Conversation::STATUS_FAILED,
+        ];
+
+        if (in_array($conversation->status, $terminalStatuses, true)) {
+            $status = $task->getStatus();
+            return ToolResult::success(json_encode([
+                'task_id'   => $task->id,
+                'cancelled' => false,
+                'status'    => $status,
+                'message'   => "Task is already {$status} — nothing to cancel.",
+            ], JSON_PRETTY_PRINT));
+        }
+
+        // Set the abort flag on the child conversation's stream.
+        // ProcessConversationStream checks this flag in its event loop and will
+        // shut down the child cleanly within ~1 second.
+        $streamManager = app(StreamManager::class);
+        $streamManager->setAbortFlag($conversation->uuid);
+
+        return ToolResult::success(json_encode([
+            'task_id'   => $task->id,
+            'cancelled' => true,
+            'status'    => 'cancelling',
+            'message'   => "Abort signal sent to sub-agent task '{$task->id}'. "
+                . 'The task will stop within ~1 second. '
+                . "Use SubAgentOutput with task_id '{$task->id}' to confirm.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -2,15 +2,8 @@
 
 namespace App\Tools;
 
-use App\Jobs\ProcessConversationStream;
 use App\Models\Agent;
-use App\Models\Conversation;
-use App\Models\SubAgentTask;
-use App\Models\Workspace;
-use App\Services\ConversationFactory;
-use App\Services\StreamManager;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
+use App\Services\SubAgentRunner;
 use Illuminate\Support\Str;
 
 class SubAgentTool extends Tool
@@ -36,6 +29,10 @@ class SubAgentTool extends Tool
                 'type' => 'boolean',
                 'description' => 'If true, return immediately with a task_id. If false (default), wait for the sub-agent to complete and return its output.',
             ],
+            'conversation_id' => [
+                'type' => 'string',
+                'description' => 'Optional: UUID of a previous conversation with this agent to resume. When provided, prompt is appended as the next user message.',
+            ],
         ],
         'required' => ['agent', 'prompt'],
     ];
@@ -47,6 +44,7 @@ Spawn a child PocketDev agent to handle a task using any configured provider. Th
 - Delegate specialized tasks to a different AI model or provider
 - Run multiple tasks in parallel using background mode
 - Break complex work into sub-tasks handled by purpose-built agents
+- For agents with `expose_as_tool = true`, prefer calling them directly by name (e.g. `agent_code_reviewer`) instead of using SubAgent
 
 ## Foreground Mode (default)
 Blocks until the sub-agent completes and returns its full output. Use for tasks where you need the result before continuing.
@@ -54,13 +52,17 @@ Blocks until the sub-agent completes and returns its full output. Use for tasks 
 ## Background Mode
 Returns immediately with a task_id. Use SubAgentOutput to check status and retrieve results later. Ideal for parallelism.
 
+## Resuming a Conversation
+Pass `conversation_id` from a previous response to continue from where you left off. The sub-agent will see the full conversation history.
+
 ## Parameters
 - agent: Agent slug or UUID (see "Available Agents" section in this prompt)
 - prompt: The task/prompt to send. Be specific and self-contained — the sub-agent has no context from your conversation
 - background: Optional boolean (default: false). Set to true for background execution
+- conversation_id: Optional UUID to resume an existing sub-agent conversation
 
 ## Important Notes
-- The sub-agent starts a fresh conversation — it does NOT see your conversation history
+- The sub-agent starts a fresh conversation (unless conversation_id is provided)
 - Write self-contained prompts with all necessary context
 - The sub-agent shares your working directory and workspace
 - Foreground mode has a 10-minute timeout
@@ -104,6 +106,7 @@ API;
         $agentIdentifier = trim($input['agent'] ?? '');
         $prompt = trim($input['prompt'] ?? '');
         $isBackground = (bool) ($input['background'] ?? false);
+        $conversationId = isset($input['conversation_id']) ? trim($input['conversation_id']) : null;
 
         if (empty($agentIdentifier)) {
             return ToolResult::error('agent is required. See "Available Agents" in the system prompt.');
@@ -128,117 +131,12 @@ API;
             return ToolResult::error("Agent '{$agentIdentifier}' not found. Use an agent slug or UUID from the Available Agents list.");
         }
 
-        // Determine workspace (fall back to agent's workspace if context has none)
-        $workspace = $workspace ?? $agent->workspace;
-        $workspaceId = $workspace?->id;
-        $workingDirectory = $context->workingDirectory;
-
-        try {
-            // Create child conversation + task atomically
-            [$conversation, $task] = DB::transaction(function () use ($agent, $workingDirectory, $workspaceId, $prompt, $context, $isBackground) {
-                $factory = app(ConversationFactory::class);
-                $conversation = $factory->createFromAgent(
-                    $agent,
-                    $workingDirectory,
-                    $workspaceId,
-                    'Subagent: ' . Str::limit($prompt, 60)
-                );
-
-                $task = SubAgentTask::create([
-                    'parent_conversation_uuid' => $context->conversationUuid,
-                    'child_conversation_uuid' => $conversation->uuid,
-                    'agent_id' => $agent->id,
-                    'prompt' => $prompt,
-                    'is_background' => $isBackground,
-                ]);
-
-                return [$conversation, $task];
-            });
-
-            // Initialize the Redis stream (outside transaction — not DB state)
-            $streamManager = app(StreamManager::class);
-            $streamManager->startStream($conversation->uuid, [
-                'model' => $conversation->model,
-                'provider' => $conversation->provider_type,
-                'subagent_task_id' => $task->id,
-            ]);
-
-            // Dispatch the streaming job
-            ProcessConversationStream::dispatch(
-                $conversation->uuid,
-                $prompt,
-            );
-
-            Log::info('SubAgent task started', [
-                'task_id' => $task->id,
-                'parent_conversation' => $context->conversationUuid,
-                'child_conversation' => $conversation->uuid,
-                'agent' => $agent->slug,
-                'background' => $isBackground,
-            ]);
-
-            // Background mode: return immediately
-            if ($isBackground) {
-                return ToolResult::success(json_encode([
-                    'task_id' => $task->id,
-                    'status' => 'running',
-                    'agent' => $agent->slug,
-                    'provider' => $agent->provider,
-                    'model' => $conversation->model,
-                    'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output.",
-                ], JSON_PRETTY_PRINT));
-            }
-
-            // Foreground mode: poll until complete
-            return $this->waitForCompletion($task, $conversation);
-
-        } catch (\Exception $e) {
-            Log::error('SubAgent failed to start', [
-                'agent' => $agentIdentifier,
-                'error' => $e->getMessage(),
-            ]);
-            return ToolResult::error('Failed to start sub-agent: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Poll the conversation until it completes or times out.
-     */
-    private function waitForCompletion(SubAgentTask $task, Conversation $conversation): ToolResult
-    {
-        $maxWaitSeconds = 600; // 10 minutes
-        $pollIntervalMicroseconds = 1_000_000; // 1 second
-        $startTime = time();
-
-        while (time() - $startTime < $maxWaitSeconds) {
-            $conversation->refresh();
-
-            if (in_array($conversation->status, [Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED], true)) {
-                // Reload task's relationship so collectOutput sees the final messages
-                $task->unsetRelation('childConversation');
-                $output = $task->collectOutput();
-                return ToolResult::success(json_encode([
-                    'task_id' => $task->id,
-                    'status' => 'completed',
-                    'output' => $output,
-                ], JSON_PRETTY_PRINT));
-            }
-
-            if ($conversation->status === Conversation::STATUS_FAILED) {
-                $task->unsetRelation('childConversation');
-                $error = $task->getError();
-                return ToolResult::error("Sub-agent task '{$task->id}' failed: {$error}");
-            }
-
-            usleep($pollIntervalMicroseconds);
-        }
-
-        // Timed out — returned as success because the task is still running
-        // and the caller can poll via SubAgentOutput later.
-        return ToolResult::success(json_encode([
-            'task_id' => $task->id,
-            'status' => 'timeout',
-            'message' => "Sub-agent did not complete within {$maxWaitSeconds} seconds. Use SubAgentOutput with task_id '{$task->id}' to check status later.",
-        ], JSON_PRETTY_PRINT));
+        return app(SubAgentRunner::class)->run(
+            $agent,
+            $prompt,
+            $isBackground,
+            $context,
+            $conversationId ?: null,
+        );
     }
 }

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -67,6 +67,7 @@ Pass `conversation_id` from a previous response to continue from where you left 
 - The sub-agent shares your working directory and workspace
 - Foreground mode has a 10-minute timeout
 - For background tasks, use SubAgentOutput to poll for completion
+- To stop a running background task, use SubAgentCancel with its task_id
 INSTRUCTIONS;
 
     public ?string $cliExamples = <<<'CLI'

--- a/www/app/Tools/ToolResult.php
+++ b/www/app/Tools/ToolResult.php
@@ -4,6 +4,21 @@ namespace App\Tools;
 
 class ToolResult
 {
+    /**
+     * When true, the stream loop should end the parent turn immediately after
+     * this tool result is saved — without making another AI round-trip.
+     * Used by SubAgentTool in background mode so the parent conversation
+     * becomes interactive again as soon as the child job is dispatched.
+     */
+    public bool $endTurn = false;
+
+    /**
+     * Human-readable text saved as a synthetic closing assistant message
+     * when $endTurn is true. Keeps the conversation history well-formed
+     * (prevents two consecutive user messages on the next turn).
+     */
+    public ?string $endTurnMessage = null;
+
     public function __construct(
         public string $output,
         public bool $isError = false,
@@ -12,6 +27,21 @@ class ToolResult
     public static function success(string $output): self
     {
         return new self($output, false);
+    }
+
+    /**
+     * Like success(), but signals the stream loop to end the parent turn
+     * immediately without a second AI call.
+     *
+     * @param string $output       JSON output returned as the tool result content
+     * @param string $endTurnMessage  Text for the synthetic closing assistant message
+     */
+    public static function successEndTurn(string $output, string $endTurnMessage): self
+    {
+        $result = new self($output, false);
+        $result->endTurn = true;
+        $result->endTurnMessage = $endTurnMessage;
+        return $result;
     }
 
     public static function error(string $message): self

--- a/www/config/ai.php
+++ b/www/config/ai.php
@@ -289,11 +289,13 @@ return [
 
         // Claude Code models (aliases supported by CLI)
         // Pricing is null since Claude Code uses subscription credits
+        // max_context_window: opus/sonnet support 1M for Max subscribers via context-1m-2025-08-07 beta
         'claude_code' => [
             [
                 'model_id' => 'opus',
                 'display_name' => 'Claude Opus (via CLI)',
                 'context_window' => 200000,
+                'max_context_window' => 1000000,
                 'max_output_tokens' => 64000,
                 'input_price_per_million' => null,
                 'output_price_per_million' => null,
@@ -304,6 +306,7 @@ return [
                 'model_id' => 'sonnet',
                 'display_name' => 'Claude Sonnet (via CLI)',
                 'context_window' => 200000,
+                'max_context_window' => 1000000,
                 'max_output_tokens' => 64000,
                 'input_price_per_million' => null,
                 'output_price_per_million' => null,
@@ -314,6 +317,7 @@ return [
                 'model_id' => 'haiku',
                 'display_name' => 'Claude Haiku (via CLI)',
                 'context_window' => 200000,
+                'max_context_window' => 200000,
                 'max_output_tokens' => 64000,
                 'input_price_per_million' => null,
                 'output_price_per_million' => null,

--- a/www/database/migrations/2026_04_10_000001_add_expose_as_tool_to_agents.php
+++ b/www/database/migrations/2026_04_10_000001_add_expose_as_tool_to_agents.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            // Opt-in: expose this agent as a dedicated native tool call
+            $table->boolean('expose_as_tool')->default(false)->after('enabled');
+
+            // Caller-side: can this agent call other agents as sub-agents?
+            $table->boolean('can_call_subagents')->default(true)->after('expose_as_tool');
+
+            // Caller-side allowlist: if set, only these agent UUIDs are injected as tools
+            // null = all opted-in agents; [] = (not used — toggle off can_call_subagents instead)
+            $table->jsonb('allowed_subagents')->nullable()->after('can_call_subagents');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropColumn(['expose_as_tool', 'can_call_subagents', 'allowed_subagents']);
+        });
+    }
+};

--- a/www/public/scripts/codex-auth.sh
+++ b/www/public/scripts/codex-auth.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# PocketDev — Codex Auth Upload Script
+#
+# Runs `codex login` on your local machine (no org restrictions, uses your
+# browser), then automatically uploads the resulting auth.json to PocketDev.
+#
+# Usage:
+#   bash <(curl -s https://YOUR-POCKETDEV/scripts/codex-auth.sh) https://YOUR-POCKETDEV
+#
+# Or download and run manually:
+#   curl -O https://YOUR-POCKETDEV/scripts/codex-auth.sh
+#   bash codex-auth.sh https://YOUR-POCKETDEV
+#   bash codex-auth.sh https://user:pass@YOUR-POCKETDEV   # with Basic Auth
+# ─────────────────────────────────────────────────────────────────────────────
+set -e
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { echo -e "${CYAN}→${RESET} $*"; }
+success() { echo -e "${GREEN}✓${RESET} $*"; }
+warn()    { echo -e "${YELLOW}!${RESET} $*"; }
+error()   { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+header()  { echo -e "\n${BOLD}$*${RESET}"; }
+
+# ── Argument / env parsing ────────────────────────────────────────────────────
+PD_URL="${1:-${POCKETDEV_URL:-}}"
+
+if [ -z "$PD_URL" ]; then
+    echo -e "${BOLD}PocketDev Codex Auth Upload${RESET}"
+    echo ""
+    echo "Usage:"
+    echo "  $0 <pocketdev-url>"
+    echo "  $0 https://user:pass@pocketdev.example.com   # with Basic Auth"
+    echo ""
+    echo "Or set the POCKETDEV_URL environment variable:"
+    echo "  POCKETDEV_URL=https://pocketdev.example.com $0"
+    exit 1
+fi
+
+# Strip trailing slash
+PD_URL="${PD_URL%/}"
+
+header "PocketDev Codex Auth Upload"
+echo "Target: ${PD_URL}"
+echo ""
+
+# ── Step 1: Check for Node / npm ─────────────────────────────────────────────
+if ! command -v npm > /dev/null 2>&1; then
+    error "npm is not installed. Install Node.js from https://nodejs.org and try again."
+fi
+
+# ── Step 2: Install codex if missing ─────────────────────────────────────────
+if ! command -v codex > /dev/null 2>&1; then
+    warn "Codex is not installed. Installing now..."
+    npm install -g @openai/codex
+    success "Codex installed."
+else
+    success "Codex is already installed ($(codex --version 2>/dev/null || echo 'version unknown'))."
+fi
+
+# ── Step 3: Run codex login ───────────────────────────────────────────────────
+AUTH_FILE="$HOME/.codex/auth.json"
+
+info "Running 'codex login'..."
+echo "    A browser will open. Sign in with your ChatGPT account."
+echo ""
+
+codex login
+
+if [ ! -f "$AUTH_FILE" ]; then
+    error "auth.json not found at $AUTH_FILE. Did the login succeed?"
+fi
+
+success "Login complete. auth.json found."
+
+# ── Step 4: Build the JSON payload ───────────────────────────────────────────
+# We need to embed the auth.json content as a JSON string value.
+# Use Python3 (available on macOS & most Linux) or jq as fallback.
+
+AUTH_CONTENT=$(cat "$AUTH_FILE")
+
+if command -v python3 > /dev/null 2>&1; then
+    PAYLOAD=$(python3 -c "
+import json, sys
+content = sys.stdin.read()
+print(json.dumps({'json': content}))
+" <<< "$AUTH_CONTENT")
+elif command -v jq > /dev/null 2>&1; then
+    PAYLOAD=$(jq -n --arg content "$AUTH_CONTENT" '{"json": $content}')
+else
+    # Last resort: manual escaping (works for standard auth.json)
+    ESCAPED=$(printf '%s' "$AUTH_CONTENT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
+    PAYLOAD="{\"json\": \"${ESCAPED}\"}"
+fi
+
+# ── Step 5: Upload to PocketDev ───────────────────────────────────────────────
+info "Uploading auth.json to PocketDev..."
+
+HTTP_CODE=$(curl -s -o /tmp/pd_codex_response.json -w "%{http_code}" \
+    -X POST \
+    "${PD_URL}/api/codex/auth/upload" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD")
+
+RESPONSE=$(cat /tmp/pd_codex_response.json 2>/dev/null || echo '{}')
+rm -f /tmp/pd_codex_response.json
+
+# ── Step 6: Check result ──────────────────────────────────────────────────────
+if echo "$RESPONSE" | grep -q '"success":true'; then
+    echo ""
+    success "${BOLD}Codex is nu gekoppeld aan PocketDev!${RESET}"
+    echo ""
+    echo "  Je kunt nu Codex gebruiken in PocketDev."
+    echo "  Ga naar ${PD_URL} om te beginnen."
+    echo ""
+elif [ "$HTTP_CODE" = "400" ] && echo "$RESPONSE" | grep -q '"message"'; then
+    MSG=$(echo "$RESPONSE" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
+    error "Server error: $MSG"
+elif [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+    error "Toegang geweigerd (HTTP $HTTP_CODE). Voeg je Basic Auth credentials toe aan de URL:\n    $0 https://user:wachtwoord@jouw-pocketdev.com"
+elif [ "$HTTP_CODE" = "000" ]; then
+    error "Kon PocketDev niet bereiken. Controleer de URL en je internetverbinding:\n    ${PD_URL}"
+else
+    error "Upload mislukt (HTTP $HTTP_CODE):\n$RESPONSE"
+fi

--- a/www/resources/defaults/system-prompt.md
+++ b/www/resources/defaults/system-prompt.md
@@ -46,6 +46,25 @@ If a PocketDev tool returns an unexpected error or response:
 3. Explain what you expected vs. what happened
 4. Wait for confirmation before trying workarounds
 
+## Subagents — Gebruik Ze Proactief
+
+Als er agents beschikbaar zijn (zie **AGENT ORCHESTRATION** sectie verderop), gebruik ze dan **uit jezelf** zonder dat de gebruiker er om vraagt:
+
+- **Code review** → delegeer naar een reviewer agent
+- **Cross-provider** → Codex voor OpenAI/GPT taken, Claude Code voor Anthropic taken
+- **Parallelle taken** → meerdere onafhankelijke taken tegelijk via `--background`
+- **Specialisatie** → als een ander model beter geschikt is voor de taak
+
+```bash
+# Foreground — wacht op resultaat
+pd subagent:run --agent=<slug> --prompt="<zelfstandige taak>"
+
+# Background — parallel uitvoeren
+pd subagent:run --agent=<slug> --prompt="<taak>" --background
+```
+
+Beschikbare agents en hun slugs staan in de **AGENT ORCHESTRATION** sectie. Raadpleeg de `subagents` skill voor alle opties (`--background`, `--conversation-id`, etc.).
+
 ## Hooks (File Protection)
 
 Claude Code CLI loads settings from `~/.claude/settings.json`. Users can view and configure settings via Settings → Hooks in the PocketDev UI. You can also edit this file on the user's request. See docs.anthropic.com/en/docs/claude-code/settings for available options.

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -4771,17 +4771,21 @@
                     }
 
                     // Block unmatched /commands - if prompt starts with / but no skill is active
+                    // Native Claude Code commands are passed through directly (compact, clear, etc.)
+                    const nativeClaudeCommands = ['compact', 'clear', 'help', 'review', 'init', 'vim', 'config'];
                     if (this.prompt.trim().startsWith('/') && !this.activeSkill) {
                         const potentialSkillName = this.prompt.trim().slice(1).split(/\s+/)[0];
-                        const matchedSkill = this.findSkillByName(potentialSkillName);
-                        if (!matchedSkill) {
-                            this.showError(`Unknown skill: /${potentialSkillName}. Type / to see available skills.`);
-                            return;
+                        if (!nativeClaudeCommands.includes(potentialSkillName.toLowerCase())) {
+                            const matchedSkill = this.findSkillByName(potentialSkillName);
+                            if (!matchedSkill) {
+                                this.showError(`Unknown skill: /${potentialSkillName}. Type / to see available skills.`);
+                                return;
+                            }
+                            // If it matches, activate it and continue
+                            this.activeSkill = matchedSkill;
+                            // Remove the /command from prompt, keep any text after it
+                            this.prompt = this.prompt.trim().slice(1 + potentialSkillName.length).trim();
                         }
-                        // If it matches, activate it and continue
-                        this.activeSkill = matchedSkill;
-                        // Remove the /command from prompt, keep any text after it
-                        this.prompt = this.prompt.trim().slice(1 + potentialSkillName.length).trim();
                     }
 
                     // Block if uploads still in progress

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -66,7 +66,10 @@
                 <!-- Tabs -->
                 <div class="flex space-x-2 mb-6 border-b border-gray-700">
                     <button onclick="switchTab('device')" id="tab-device" class="tab-btn px-4 py-2 -mb-px border-b-2 border-blue-500 text-blue-400">
-                        Subscription (Recommended)
+                        Via PocketDev UI
+                    </button>
+                    <button onclick="switchTab('laptop')" id="tab-laptop" class="tab-btn px-4 py-2 -mb-px border-b-2 border-transparent text-gray-400 hover:text-gray-300">
+                        Via laptop / SSH
                     </button>
                     <button onclick="switchTab('json')" id="tab-json" class="tab-btn px-4 py-2 -mb-px border-b-2 border-transparent text-gray-400 hover:text-gray-300">
                         API Key
@@ -191,19 +194,64 @@
                         </div>
                         <!-- Org restriction help -->
                         <div class="bg-yellow-900/20 border border-yellow-700/50 rounded-lg p-4 text-sm">
-                            <p class="text-yellow-400 font-semibold mb-1">💡 Is your organisation blocking device auth?</p>
-                            <p class="text-yellow-200/70 mb-2">
-                                If you see <em>"Contact your workspace administrator to enable device code authentication"</em> on the OpenAI page,
-                                your organisation has disabled this flow. Use the <strong class="text-white">API Key tab</strong> instead:
+                            <p class="text-yellow-400 font-semibold mb-1">💡 Ziet je de fout "neem contact op met je werkruimtebeheerder"?</p>
+                            <p class="text-yellow-200/70 mb-3">
+                                Jouw OpenAI-organisatie heeft device-auth uitgeschakeld. Gebruik dan de <strong class="text-white">Via laptop / SSH</strong> tab —
+                                twee copy-paste commando's die werken zonder die beperking.
                             </p>
-                            <ol class="list-decimal list-inside text-yellow-200/70 space-y-1 mb-3">
-                                <li>On a machine with a browser, run: <code class="bg-black/30 px-1.5 py-0.5 rounded text-xs">codex login</code></li>
-                                <li>Copy the resulting <code class="bg-black/30 px-1.5 py-0.5 rounded text-xs">~/.codex/auth.json</code> file contents</li>
-                                <li>Paste it in the <strong class="text-white">API Key tab</strong> below</li>
-                            </ol>
-                            <button onclick="switchTab('json')" class="px-4 py-1.5 bg-yellow-700/60 hover:bg-yellow-700 rounded text-xs font-medium text-yellow-100 transition-colors">
-                                Switch to API Key tab →
+                            <button onclick="switchTab('laptop')" class="px-4 py-1.5 bg-yellow-700/60 hover:bg-yellow-700 rounded text-xs font-medium text-yellow-100 transition-colors">
+                                Naar "Via laptop / SSH" →
                             </button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Via laptop / SSH tab -->
+                <div id="content-laptop" class="tab-content hidden">
+                    <p class="text-gray-300 mb-1">Draai deze twee commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
+                    <p class="text-sm text-gray-400 mb-6">Werkt altijd — geen org-restricties, geen device-auth nodig. Vereist alleen Node.js en Python3.</p>
+
+                    <!-- Stap 1 -->
+                    <div class="mb-5">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 1 — Installeer Codex en log in</p>
+                        <div class="flex items-center gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 select-all">npm install -g @openai/codex && codex login</code>
+                            <button
+                                onclick="copyCmd(this, 'npm install -g @openai/codex && codex login')"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all"
+                            >📋 Copy</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1.5">Dit opent een browser om in te loggen met je ChatGPT-account.</p>
+                    </div>
+
+                    <!-- Stap 2 -->
+                    <div class="mb-5">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 2 — Upload auth.json naar PocketDev</p>
+                        @php
+                            $uploadCmd = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '" . url('/') . "/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                        @endphp
+                        <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 break-all select-all">{{ $uploadCmd }}</code>
+                            <button
+                                onclick="copyCmd(this, {{ json_encode($uploadCmd) }})"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
+                            >📋 Copy</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1.5">Voert stap 2 pas uit nadat je bent ingelogd in stap 1.</p>
+                    </div>
+
+                    <!-- Of alles in één -->
+                    <div class="border-t border-gray-700 pt-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Of alles in één commando</p>
+                        @php
+                            $oneCmd = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '" . url('/') . "/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                        @endphp
+                        <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 break-all select-all">{{ $oneCmd }}</code>
+                            <button
+                                onclick="copyCmd(this, {{ json_encode($oneCmd) }})"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
+                            >📋 Copy</button>
                         </div>
                     </div>
                 </div>
@@ -289,13 +337,25 @@
 
     <script>
         // ── Copy script command ────────────────────────────────────────────────────
+        // Generic copy-with-feedback for any button
+        function copyCmd(btn, text) {
+            navigator.clipboard.writeText(text).then(() => {
+                const orig = btn.textContent;
+                btn.textContent = '✓ Gekopieerd!';
+                btn.classList.add('bg-green-700', 'text-green-200');
+                btn.classList.remove('bg-gray-700', 'text-gray-300');
+                setTimeout(() => {
+                    btn.textContent = orig;
+                    btn.classList.remove('bg-green-700', 'text-green-200');
+                    btn.classList.add('bg-gray-700', 'text-gray-300');
+                }, 2000);
+            });
+        }
+
         function copyScriptCmd(btn) {
             const text = btn.previousElementSibling.textContent.trim()
                 .replace(/&lt;/g, '<').replace(/&gt;/g, '>');
-            navigator.clipboard.writeText(text).then(() => {
-                btn.textContent = '✓ Copied!';
-                setTimeout(() => { btn.textContent = '📋 Copy'; }, 2000);
-            });
+            copyCmd(btn, text);
         }
 
         // ── Tab switching ──────────────────────────────────────────────────────────

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -112,6 +112,13 @@
                             <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 1 — Open this link</p>
                             <div class="flex items-center gap-3 bg-gray-900 rounded-lg p-3 border border-gray-700">
                                 <span class="text-blue-400 text-sm font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                                <a
+                                    :href="verificationUrl"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="flex-shrink-0 px-3 py-1.5 rounded text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 transition-all"
+                                    title="Open in new tab"
+                                >↗ Open</a>
                                 <button
                                     @click="copyUrl()"
                                     class="flex-shrink-0 px-3 py-1.5 rounded text-sm transition-all"
@@ -174,19 +181,40 @@
                             </p>
                             <p class="text-red-300 text-sm" x-text="error || (state === 'expired' ? 'The code expired before authentication completed.' : 'Please try again.')"></p>
                         </div>
-                        <button
-                            @click="reset(); startAuth()"
-                            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
-                        >
-                            Try again
-                        </button>
+                        <div class="flex gap-3 flex-wrap mb-6">
+                            <button
+                                @click="reset(); startAuth()"
+                                class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors text-sm"
+                            >
+                                Try again
+                            </button>
+                        </div>
+                        <!-- Org restriction help -->
+                        <div class="bg-yellow-900/20 border border-yellow-700/50 rounded-lg p-4 text-sm">
+                            <p class="text-yellow-400 font-semibold mb-1">💡 Is your organisation blocking device auth?</p>
+                            <p class="text-yellow-200/70 mb-2">
+                                If you see <em>"Contact your workspace administrator to enable device code authentication"</em> on the OpenAI page,
+                                your organisation has disabled this flow. Use the <strong class="text-white">API Key tab</strong> instead:
+                            </p>
+                            <ol class="list-decimal list-inside text-yellow-200/70 space-y-1 mb-3">
+                                <li>On a machine with a browser, run: <code class="bg-black/30 px-1.5 py-0.5 rounded text-xs">codex login</code></li>
+                                <li>Copy the resulting <code class="bg-black/30 px-1.5 py-0.5 rounded text-xs">~/.codex/auth.json</code> file contents</li>
+                                <li>Paste it in the <strong class="text-white">API Key tab</strong> below</li>
+                            </ol>
+                            <button onclick="switchTab('json')" class="px-4 py-1.5 bg-yellow-700/60 hover:bg-yellow-700 rounded text-xs font-medium text-yellow-100 transition-colors">
+                                Switch to API Key tab →
+                            </button>
+                        </div>
                     </div>
                 </div>
 
-                <!-- API Key Tab -->
+                <!-- API Key / Manual Upload Tab -->
                 <div id="content-json" class="tab-content hidden">
-                    <p class="text-gray-300 mb-4">Use an OpenAI API key for pay-per-use access:</p>
-
+                    <p class="text-gray-300 mb-1">Paste your <code class="text-blue-400 text-sm">~/.codex/auth.json</code> file contents below.</p>
+                    <p class="text-sm text-gray-500 mb-4">
+                        Works for both API keys (<code>{"OPENAI_API_KEY": "sk-..."}</code>) and
+                        subscription tokens obtained via <code>codex login</code> on another machine.
+                    </p>
                     <p class="text-gray-400 mb-2"><strong>Paste auth.json content below</strong></p>
                     <form id="json-form" class="space-y-4">
                         <div>

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -213,8 +213,8 @@
                     $linux2 = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
                     $linuxAll = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
                     $win1 = 'npm install -g @openai/codex; codex login';
-                    $win2 = "Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body (@{json=(Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw)} | ConvertTo-Json); Write-Host '✓ Klaar!'";
-                    $winAll = "npm install -g @openai/codex; codex login; Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body (@{json=(Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw)} | ConvertTo-Json); Write-Host '✓ Klaar!'";
+                    $win2 = "\$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
+                    $winAll = "npm install -g @openai/codex; codex login; \$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
                 @endphp
                 <div id="content-laptop" class="tab-content hidden" x-data="{ os: 'linux' }">
                     <p class="text-gray-300 mb-1">Draai deze commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
@@ -306,19 +306,29 @@
                         <div class="flex-1 border-t border-gray-700"></div>
                     </div>
 
-                    <!-- Option B: manual paste -->
+                    <!-- Option B: file upload or manual paste -->
                     <div>
-                        <p class="text-gray-300 font-medium mb-1">Optie B — Handmatig plakken</p>
+                        <p class="text-gray-300 font-medium mb-1">Optie B — Bestand uploaden of plakken</p>
                         <p class="text-sm text-gray-400 mb-3">
-                            Draai <code class="text-green-400">codex login</code> op een machine met browser,
-                            kopieer <code class="text-green-400">~/.codex/auth.json</code> en plak de inhoud hieronder.
-                            Werkt voor zowel API keys als subscription tokens.
+                            Draai <code class="text-green-400">codex login</code> op een machine met browser.
+                            Selecteer daarna het <code class="text-green-400">auth.json</code> bestand, of plak de inhoud hieronder.
                         </p>
                         <form id="json-form" class="space-y-3">
+                            <!-- File picker -->
+                            <div class="flex items-center gap-3">
+                                <label class="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded cursor-pointer text-sm text-gray-200 transition-colors">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+                                    Selecteer auth.json
+                                    <input type="file" id="json-file" accept=".json,application/json" class="hidden">
+                                </label>
+                                <span id="file-name" class="text-xs text-gray-500">Geen bestand geselecteerd</span>
+                            </div>
+                            <p class="text-xs text-gray-600">Pad op Windows: <code class="text-gray-500">%USERPROFILE%\.codex\auth.json</code> &nbsp;|&nbsp; macOS/Linux: <code class="text-gray-500">~/.codex/auth.json</code></p>
+                            <!-- Textarea (filled by file picker, or paste manually) -->
                             <textarea id="json-input" rows="4" placeholder='{"OPENAI_API_KEY": "sk-proj-..."}'
                                 class="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm font-mono focus:outline-none focus:border-blue-500"></textarea>
                             <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                                Save Credentials
+                                Opslaan
                             </button>
                         </form>
                         <div id="json-result" class="mt-4"></div>
@@ -387,6 +397,18 @@
             activeTab.classList.remove('border-transparent', 'text-gray-400');
             activeTab.classList.add('border-blue-500', 'text-blue-400');
         }
+
+        // ── File picker → textarea ────────────────────────────────────────────────
+        document.getElementById('json-file')?.addEventListener('change', function (e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            document.getElementById('file-name').textContent = file.name;
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+                document.getElementById('json-input').value = ev.target.result;
+            };
+            reader.readAsText(file, 'UTF-8');
+        });
 
         // ── Device auth Alpine component ───────────────────────────────────────────
         function codexDeviceAuth() {

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -6,6 +6,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Codex Authentication</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
 </head>
 <body class="antialiased bg-gray-900 text-gray-100">
     <div class="min-h-screen flex items-center justify-center p-4">
@@ -64,7 +65,7 @@
 
                 <!-- Tabs -->
                 <div class="flex space-x-2 mb-6 border-b border-gray-700">
-                    <button onclick="switchTab('docker')" id="tab-docker" class="tab-btn px-4 py-2 -mb-px border-b-2 border-blue-500 text-blue-400">
+                    <button onclick="switchTab('device')" id="tab-device" class="tab-btn px-4 py-2 -mb-px border-b-2 border-blue-500 text-blue-400">
                         Subscription (Recommended)
                     </button>
                     <button onclick="switchTab('json')" id="tab-json" class="tab-btn px-4 py-2 -mb-px border-b-2 border-transparent text-gray-400 hover:text-gray-300">
@@ -72,30 +73,114 @@
                     </button>
                 </div>
 
-                <!-- Host Login Tab (Subscription) -->
-                <div id="content-docker" class="tab-content">
-                    <p class="text-gray-300 mb-4">Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise).</p>
-                    <p class="text-sm text-gray-400 mb-4">
-                        Run this command on your <strong class="text-white">host machine</strong> (not in Docker) to authenticate:
-                    </p>
-                    @if(config('backup.user_id') !== null && config('backup.group_id') !== null)
-                        <div class="bg-gray-900 rounded p-4 mb-4 overflow-x-auto">
-                            <code class="text-sm text-green-400">sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json pocket-dev-queue:/home/appuser/.codex/auth.json && docker exec -u root pocket-dev-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec pocket-dev-queue chmod 660 /home/appuser/.codex/auth.json</code>
+                <!-- Inline Device Auth Tab (Subscription) -->
+                <div id="content-device" class="tab-content" x-data="codexDeviceAuth()">
+
+                    <!-- Idle state: show start button -->
+                    <div x-show="state === 'idle'">
+                        <p class="text-gray-300 mb-2">
+                            Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise).
+                        </p>
+                        <p class="text-sm text-gray-400 mb-6">
+                            Works on any device — no terminal, no Docker commands needed.
+                        </p>
+                        <button
+                            @click="startAuth()"
+                            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
+                        >
+                            Login met ChatGPT
+                        </button>
+                    </div>
+
+                    <!-- Starting state: spinner -->
+                    <div x-show="state === 'starting'" class="text-center py-8">
+                        <svg class="animate-spin w-8 h-8 mx-auto text-blue-400 mb-3" fill="none" viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                        </svg>
+                        <p class="text-gray-400">Connecting to OpenAI...</p>
+                    </div>
+
+                    <!-- Ready state: show URL and code -->
+                    <div x-show="state === 'ready'" style="display:none">
+                        <p class="text-gray-300 mb-6 text-sm">
+                            Open the link below on your phone or another browser window, then enter the code when prompted.
+                        </p>
+
+                        <!-- Step 1: URL -->
+                        <div class="mb-6">
+                            <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 1 — Open this link</p>
+                            <div class="flex items-center gap-3 bg-gray-900 rounded-lg p-3 border border-gray-700">
+                                <span class="text-blue-400 text-sm font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                                <button
+                                    @click="copyUrl()"
+                                    class="flex-shrink-0 px-3 py-1.5 rounded text-sm transition-all"
+                                    :class="urlCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                >
+                                    <span x-show="!urlCopied">📋 Copy</span>
+                                    <span x-show="urlCopied">✓ Copied!</span>
+                                </button>
+                            </div>
                         </div>
-                        <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300 mb-4">
-                            <li>Copy the command above and run it in your terminal</li>
-                            <li>This installs Codex locally, opens a browser login, then copies credentials to the container</li>
-                            <li>After completion, come back here and refresh the page</li>
-                        </ol>
-                    @else
-                        <div class="bg-red-900/50 border border-red-500 rounded p-4 mb-4 text-red-300 text-sm">
-                            <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">PD_USER_ID</code> and <code class="bg-red-900 px-1 rounded">PD_GROUP_ID</code> in your .env file.
-                            <span class="text-red-400 text-xs block mt-1">Run <code>id -u</code> and <code>id -g</code> on your host to get the values. Then reload this page to see the login command.</span>
+
+                        <!-- Step 2: Code -->
+                        <div class="mb-6">
+                            <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 2 — Enter this code</p>
+                            <div class="flex items-center gap-4">
+                                <div class="bg-gray-900 border border-gray-600 rounded-lg px-6 py-4">
+                                    <span class="text-3xl font-mono font-bold tracking-widest text-white" x-text="userCode"></span>
+                                </div>
+                                <button
+                                    @click="copyCode()"
+                                    class="px-4 py-2 rounded-lg text-sm font-medium transition-all"
+                                    :class="codeCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                >
+                                    <span x-show="!codeCopied">📋 Copy code</span>
+                                    <span x-show="codeCopied">✓ Copied!</span>
+                                </button>
+                            </div>
                         </div>
-                    @endif
-                    <button onclick="window.location.reload()" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                        Refresh Page
-                    </button>
+
+                        <!-- Waiting indicator + countdown -->
+                        <div class="flex items-center gap-3 text-sm text-gray-400">
+                            <svg class="animate-spin w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24">
+                                <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                            </svg>
+                            <span>Waiting for authentication…</span>
+                            <span class="text-gray-500">(expires in <span class="font-mono" x-text="countdown"></span>)</span>
+                        </div>
+                    </div>
+
+                    <!-- Authenticated! -->
+                    <div x-show="state === 'authenticated'" style="display:none" class="text-center py-8">
+                        <div class="text-5xl mb-4">✅</div>
+                        <p class="text-green-400 font-semibold text-lg mb-2">Successfully authenticated!</p>
+                        <p class="text-gray-400 text-sm mb-6">Your ChatGPT subscription is now connected to PocketDev.</p>
+                        <button
+                            onclick="window.location.reload()"
+                            class="px-6 py-3 bg-green-600 hover:bg-green-700 rounded-lg font-semibold transition-colors"
+                        >
+                            Reload Page
+                        </button>
+                    </div>
+
+                    <!-- Expired or failed -->
+                    <div x-show="state === 'expired' || state === 'failed'" style="display:none">
+                        <div class="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-4">
+                            <p class="text-red-400 font-semibold mb-1">
+                                <span x-show="state === 'expired'">Code expired</span>
+                                <span x-show="state === 'failed'">Authentication failed</span>
+                            </p>
+                            <p class="text-red-300 text-sm" x-text="error || (state === 'expired' ? 'The code expired before authentication completed.' : 'Please try again.')"></p>
+                        </div>
+                        <button
+                            @click="reset(); startAuth()"
+                            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
+                        >
+                            Try again
+                        </button>
+                    </div>
                 </div>
 
                 <!-- API Key Tab -->
@@ -116,7 +201,7 @@
                 </div>
             </div>
 
-            <!-- Instructions -->
+            <!-- Info block -->
             <div class="bg-gray-800 rounded-lg p-6 border border-gray-700 text-sm">
                 <h3 class="font-semibold mb-2">About Codex Authentication:</h3>
                 <ul class="list-disc list-inside space-y-1 text-gray-300">
@@ -143,23 +228,163 @@
     </div>
 
     <script>
+        // ── Tab switching ──────────────────────────────────────────────────────────
         function switchTab(tab) {
-            // Hide all content
             document.querySelectorAll('.tab-content').forEach(el => el.classList.add('hidden'));
-            // Reset all tabs
             document.querySelectorAll('.tab-btn').forEach(el => {
                 el.classList.remove('border-blue-500', 'text-blue-400');
                 el.classList.add('border-transparent', 'text-gray-400');
             });
-            // Show selected content
             document.getElementById('content-' + tab).classList.remove('hidden');
-            // Highlight selected tab
             const activeTab = document.getElementById('tab-' + tab);
             activeTab.classList.remove('border-transparent', 'text-gray-400');
             activeTab.classList.add('border-blue-500', 'text-blue-400');
         }
 
-        // JSON form
+        // ── Device auth Alpine component ───────────────────────────────────────────
+        function codexDeviceAuth() {
+            return {
+                state: 'idle',   // idle | starting | ready | authenticated | expired | failed
+                verificationUrl: '',
+                userCode: '',
+                expiresIn: 900,
+                urlCopied: false,
+                codeCopied: false,
+                error: '',
+                _pollTimer: null,
+                _countdownTimer: null,
+
+                get countdown() {
+                    const m = Math.floor(this.expiresIn / 60);
+                    const s = this.expiresIn % 60;
+                    return `${m}:${String(s).padStart(2, '0')}`;
+                },
+
+                async init() {
+                    // Resume any session already in progress (e.g. after page reload)
+                    await this.checkStatus();
+                },
+
+                async startAuth() {
+                    this.state = 'starting';
+                    this.error = '';
+
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStart') }}', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            }
+                        });
+                        const data = await res.json();
+
+                        if (!data.success) {
+                            this.state = 'failed';
+                            this.error = data.error || 'Unknown error';
+                            return;
+                        }
+
+                        this._applyStatus(data);
+                        this._startPolling();
+                    } catch (e) {
+                        this.state = 'failed';
+                        this.error = e.message;
+                    }
+                },
+
+                _startPolling() {
+                    if (this._pollTimer) clearInterval(this._pollTimer);
+                    this._pollTimer = setInterval(() => this.checkStatus(), 2500);
+                },
+
+                async checkStatus() {
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStatus') }}');
+                        const data = await res.json();
+                        this._applyStatus(data);
+                    } catch (e) {
+                        // Network error — keep polling silently
+                    }
+                },
+
+                _applyStatus(data) {
+                    const status = data.status;
+
+                    if (status === 'ready' && this.state !== 'ready') {
+                        this.state = 'ready';
+                        this.verificationUrl = data.verification_url || '';
+                        this.userCode = data.user_code || '';
+                        this.expiresIn = data.expires_in ?? 900;
+                        this._startCountdown();
+                        if (!this._pollTimer) this._startPolling();
+                    } else if (status === 'ready') {
+                        // Already showing — sync expiry
+                        if (data.expires_in !== undefined) this.expiresIn = data.expires_in;
+                    } else if (status === 'authenticated') {
+                        this.state = 'authenticated';
+                        this._stopTimers();
+                    } else if (status === 'failed') {
+                        this.state = 'failed';
+                        this.error = data.error || 'Authentication failed';
+                        this._stopTimers();
+                    } else if (status === 'expired') {
+                        this.state = 'expired';
+                        this._stopTimers();
+                    } else if (status === 'starting' && this.state === 'idle') {
+                        this.state = 'starting';
+                        this._startPolling();
+                    }
+                    // 'none': nothing to do (still idle)
+                },
+
+                _startCountdown() {
+                    if (this._countdownTimer) clearInterval(this._countdownTimer);
+                    this._countdownTimer = setInterval(() => {
+                        if (this.expiresIn > 0) {
+                            this.expiresIn--;
+                        } else {
+                            this.state = 'expired';
+                            this._stopTimers();
+                        }
+                    }, 1000);
+                },
+
+                _stopTimers() {
+                    if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+                    if (this._countdownTimer) { clearInterval(this._countdownTimer); this._countdownTimer = null; }
+                },
+
+                reset() {
+                    this._stopTimers();
+                    this.state = 'idle';
+                    this.verificationUrl = '';
+                    this.userCode = '';
+                    this.expiresIn = 900;
+                    this.error = '';
+                    this.urlCopied = false;
+                    this.codeCopied = false;
+                },
+
+                async copyUrl() {
+                    try {
+                        await navigator.clipboard.writeText(this.verificationUrl);
+                        this.urlCopied = true;
+                        setTimeout(() => { this.urlCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+
+                async copyCode() {
+                    try {
+                        await navigator.clipboard.writeText(this.userCode);
+                        this.codeCopied = true;
+                        setTimeout(() => { this.codeCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+            };
+        }
+
+        // ── JSON (API Key) form ────────────────────────────────────────────────────
         document.getElementById('json-form')?.addEventListener('submit', async (e) => {
             e.preventDefault();
             const jsonInput = document.getElementById('json-input').value;
@@ -192,7 +417,7 @@
             }
         });
 
-        // Logout
+        // ── Logout ─────────────────────────────────────────────────────────────────
         async function logout() {
             if (!confirm('Are you sure you want to clear your credentials?')) {
                 return;
@@ -219,10 +444,12 @@
             }
         }
 
-        // Helper function
+        // ── Helper ─────────────────────────────────────────────────────────────────
         function showResult(elementId, type, message) {
             const element = document.getElementById(elementId);
-            const bgColor = type === 'success' ? 'bg-green-900/30 border-green-700 text-green-400' : 'bg-red-900/30 border-red-700 text-red-400';
+            const bgColor = type === 'success'
+                ? 'bg-green-900/30 border-green-700 text-green-400'
+                : 'bg-red-900/30 border-red-700 text-red-400';
             const div = document.createElement('div');
             div.className = `border rounded p-3 ${bgColor}`;
             div.textContent = message;

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -323,7 +323,20 @@
                                 </label>
                                 <span id="file-name" class="text-xs text-gray-500">Geen bestand geselecteerd</span>
                             </div>
-                            <p class="text-xs text-gray-600">Pad op Windows: <code class="text-gray-500">%USERPROFILE%\.codex\auth.json</code> &nbsp;|&nbsp; macOS/Linux: <code class="text-gray-500">~/.codex/auth.json</code></p>
+                            <!-- Path hints with copy buttons -->
+                            <div class="bg-gray-900/60 rounded-lg border border-gray-700/50 p-3 space-y-2">
+                                <p class="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">Bestandslocatie</p>
+                                <div class="flex items-center gap-2">
+                                    <span class="text-xs text-gray-500 w-24 shrink-0">🪟 Windows</span>
+                                    <code class="text-xs text-gray-300 flex-1">%USERPROFILE%\.codex\auth.json</code>
+                                    <button type="button" onclick="copyCmd(this, '%USERPROFILE%\\.codex\\auth.json')" class="text-xs px-2 py-0.5 bg-gray-700 hover:bg-gray-600 text-gray-400 rounded transition-all">📋</button>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="text-xs text-gray-500 w-24 shrink-0">🐧 macOS/Linux</span>
+                                    <code class="text-xs text-gray-300 flex-1">~/.codex/auth.json</code>
+                                    <button type="button" onclick="copyCmd(this, '~/.codex/auth.json')" class="text-xs px-2 py-0.5 bg-gray-700 hover:bg-gray-600 text-gray-400 rounded transition-all">📋</button>
+                                </div>
+                            </div>
                             <!-- Textarea (filled by file picker, or paste manually) -->
                             <textarea id="json-input" rows="4" placeholder='{"OPENAI_API_KEY": "sk-proj-..."}'
                                 class="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm font-mono focus:outline-none focus:border-blue-500"></textarea>

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -207,17 +207,40 @@
                 </div>
 
                 <!-- Via laptop / SSH tab -->
-                <div id="content-laptop" class="tab-content hidden">
-                    <p class="text-gray-300 mb-1">Draai deze twee commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
-                    <p class="text-sm text-gray-400 mb-6">Werkt altijd — geen org-restricties, geen device-auth nodig. Vereist alleen Node.js en Python3.</p>
+                @php
+                    $pdUrl = url('/');
+                    $linux1 = 'npm install -g @openai/codex && codex login';
+                    $linux2 = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                    $linuxAll = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                    $win1 = 'npm install -g @openai/codex; codex login';
+                    $win2 = "Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body (@{json=(Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw)} | ConvertTo-Json); Write-Host '✓ Klaar!'";
+                    $winAll = "npm install -g @openai/codex; codex login; Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body (@{json=(Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw)} | ConvertTo-Json); Write-Host '✓ Klaar!'";
+                @endphp
+                <div id="content-laptop" class="tab-content hidden" x-data="{ os: 'linux' }">
+                    <p class="text-gray-300 mb-1">Draai deze commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
+                    <p class="text-sm text-gray-400 mb-4">Werkt altijd — geen org-restricties, geen device-auth nodig.</p>
+
+                    <!-- OS toggle -->
+                    <div class="flex gap-2 mb-6">
+                        <button
+                            @click="os = 'linux'"
+                            :class="os === 'linux' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-400 hover:bg-gray-600'"
+                            class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
+                        >🐧 Linux / macOS</button>
+                        <button
+                            @click="os = 'windows'"
+                            :class="os === 'windows' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-400 hover:bg-gray-600'"
+                            class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
+                        >🪟 Windows (PowerShell)</button>
+                    </div>
 
                     <!-- Stap 1 -->
                     <div class="mb-5">
                         <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 1 — Installeer Codex en log in</p>
                         <div class="flex items-center gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
-                            <code class="text-green-400 text-sm flex-1 select-all">npm install -g @openai/codex && codex login</code>
+                            <code class="text-green-400 text-sm flex-1 select-all" x-text="os === 'linux' ? {{ json_encode($linux1) }} : {{ json_encode($win1) }}"></code>
                             <button
-                                onclick="copyCmd(this, 'npm install -g @openai/codex && codex login')"
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linux1) }} : {{ json_encode($win1) }})"
                                 class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all"
                             >📋 Copy</button>
                         </div>
@@ -227,29 +250,23 @@
                     <!-- Stap 2 -->
                     <div class="mb-5">
                         <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 2 — Upload auth.json naar PocketDev</p>
-                        @php
-                            $uploadCmd = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '" . url('/') . "/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
-                        @endphp
                         <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
-                            <code class="text-green-400 text-sm flex-1 break-all select-all">{{ $uploadCmd }}</code>
+                            <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linux2) }} : {{ json_encode($win2) }}"></code>
                             <button
-                                onclick="copyCmd(this, {{ json_encode($uploadCmd) }})"
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linux2) }} : {{ json_encode($win2) }})"
                                 class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
                             >📋 Copy</button>
                         </div>
                         <p class="text-xs text-gray-500 mt-1.5">Voert stap 2 pas uit nadat je bent ingelogd in stap 1.</p>
                     </div>
 
-                    <!-- Of alles in één -->
+                    <!-- Alles in één -->
                     <div class="border-t border-gray-700 pt-4">
                         <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Of alles in één commando</p>
-                        @php
-                            $oneCmd = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '" . url('/') . "/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
-                        @endphp
                         <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
-                            <code class="text-green-400 text-sm flex-1 break-all select-all">{{ $oneCmd }}</code>
+                            <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linuxAll) }} : {{ json_encode($winAll) }}"></code>
                             <button
-                                onclick="copyCmd(this, {{ json_encode($oneCmd) }})"
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linuxAll) }} : {{ json_encode($winAll) }})"
                                 class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
                             >📋 Copy</button>
                         </div>

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -208,24 +208,56 @@
                     </div>
                 </div>
 
-                <!-- API Key / Manual Upload Tab -->
+                <!-- Upload script / Manual tab -->
                 <div id="content-json" class="tab-content hidden">
-                    <p class="text-gray-300 mb-1">Paste your <code class="text-blue-400 text-sm">~/.codex/auth.json</code> file contents below.</p>
-                    <p class="text-sm text-gray-500 mb-4">
-                        Works for both API keys (<code>{"OPENAI_API_KEY": "sk-..."}</code>) and
-                        subscription tokens obtained via <code>codex login</code> on another machine.
-                    </p>
-                    <p class="text-gray-400 mb-2"><strong>Paste auth.json content below</strong></p>
-                    <form id="json-form" class="space-y-4">
-                        <div>
+
+                    <!-- Option A: one-liner script (recommended) -->
+                    <div class="mb-6">
+                        <p class="text-gray-300 font-medium mb-1">Optie A — Automatisch (aanbevolen)</p>
+                        <p class="text-sm text-gray-400 mb-3">
+                            Draai dit commando op je <strong class="text-white">laptop of desktop</strong> met een browser.
+                            Het script installeert Codex, doet <code class="text-green-400">codex login</code> en
+                            uploadt <code class="text-green-400">auth.json</code> automatisch naar PocketDev.
+                        </p>
+                        <div class="relative group">
+                            <div class="bg-gray-900 rounded-lg border border-gray-700 p-3 font-mono text-sm text-green-400 overflow-x-auto pr-24">
+                                bash &lt;(curl -sL {{ route('codex.auth.downloadScript') }})
+                            </div>
+                            <button
+                                onclick="copyScriptCmd(this)"
+                                class="absolute right-2 top-2 px-2.5 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs text-gray-300 transition-all"
+                            >📋 Copy</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-2">
+                            Werkt op macOS en Linux. Vereist Node.js/npm.
+                            Voeg je Basic Auth credentials toe als je die hebt:
+                            <code class="text-gray-400">bash &lt;(curl ...) https://user:pass@{{ request()->getHost() }}</code>
+                        </p>
+                    </div>
+
+                    <div class="flex items-center gap-3 my-4">
+                        <div class="flex-1 border-t border-gray-700"></div>
+                        <span class="text-xs text-gray-500">of handmatig</span>
+                        <div class="flex-1 border-t border-gray-700"></div>
+                    </div>
+
+                    <!-- Option B: manual paste -->
+                    <div>
+                        <p class="text-gray-300 font-medium mb-1">Optie B — Handmatig plakken</p>
+                        <p class="text-sm text-gray-400 mb-3">
+                            Draai <code class="text-green-400">codex login</code> op een machine met browser,
+                            kopieer <code class="text-green-400">~/.codex/auth.json</code> en plak de inhoud hieronder.
+                            Werkt voor zowel API keys als subscription tokens.
+                        </p>
+                        <form id="json-form" class="space-y-3">
                             <textarea id="json-input" rows="4" placeholder='{"OPENAI_API_KEY": "sk-proj-..."}'
                                 class="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm font-mono focus:outline-none focus:border-blue-500"></textarea>
-                        </div>
-                        <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                            Save Credentials
-                        </button>
-                    </form>
-                    <div id="json-result" class="mt-4"></div>
+                            <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
+                                Save Credentials
+                            </button>
+                        </form>
+                        <div id="json-result" class="mt-4"></div>
+                    </div>
                 </div>
             </div>
 
@@ -256,6 +288,16 @@
     </div>
 
     <script>
+        // ── Copy script command ────────────────────────────────────────────────────
+        function copyScriptCmd(btn) {
+            const text = btn.previousElementSibling.textContent.trim()
+                .replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+            navigator.clipboard.writeText(text).then(() => {
+                btn.textContent = '✓ Copied!';
+                setTimeout(() => { btn.textContent = '📋 Copy'; }, 2000);
+            });
+        }
+
         // ── Tab switching ──────────────────────────────────────────────────────────
         function switchTab(tab) {
             document.querySelectorAll('.tab-content').forEach(el => el.classList.add('hidden'));

--- a/www/resources/views/config/agents/form.blade.php
+++ b/www/resources/views/config/agents/form.blade.php
@@ -237,7 +237,8 @@
                             type="checkbox"
                             name="expose_as_tool"
                             value="1"
-                            x-model="exposeAsTool"
+                            :checked="exposeAsTool"
+                            @change="exposeAsTool = $event.target.checked"
                             class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
                         >
                         <div>
@@ -254,7 +255,8 @@
                             type="checkbox"
                             name="can_call_subagents"
                             value="1"
-                            x-model="canCallSubagents"
+                            :checked="canCallSubagents"
+                            @change="canCallSubagents = $event.target.checked"
                             class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
                         >
                         <div>

--- a/www/resources/views/config/agents/form.blade.php
+++ b/www/resources/views/config/agents/form.blade.php
@@ -219,6 +219,77 @@
                         <span class="text-sm">Default for provider</span>
                     </label>
                 </div>
+
+                <!-- Sub-agent Settings -->
+                <div
+                    x-data="{
+                        exposeAsTool: {{ old('expose_as_tool', ($agent->expose_as_tool ?? ($sourceAgent->expose_as_tool ?? false)) ? 'true' : 'false') }},
+                        canCallSubagents: {{ old('can_call_subagents', ($agent->can_call_subagents ?? ($sourceAgent->can_call_subagents ?? true)) ? 'true' : 'false') }},
+                        allowedSubagents: @js(old('allowed_subagents', $agent->allowed_subagents ?? [])),
+                    }"
+                    class="space-y-4 pt-2 border-t border-gray-700/50"
+                >
+                    <h4 class="text-sm font-semibold text-gray-300">Sub-agent Settings</h4>
+
+                    <!-- Expose as tool -->
+                    <label class="flex items-start gap-3 cursor-pointer group">
+                        <input
+                            type="checkbox"
+                            name="expose_as_tool"
+                            value="1"
+                            x-model="exposeAsTool"
+                            class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                        >
+                        <div>
+                            <span class="text-sm text-white group-hover:text-blue-300">Expose as native tool</span>
+                            <p class="text-xs text-gray-400 mt-0.5">
+                                Adds this agent as a dedicated tool call (e.g. <code class="text-blue-400">agent_{{ Illuminate\Support\Str::slug($agent->name ?? 'my-agent') }}</code>) for other agents. Only enable for agents designed to be called as sub-agents.
+                            </p>
+                        </div>
+                    </label>
+
+                    <!-- Can call subagents -->
+                    <label class="flex items-start gap-3 cursor-pointer group">
+                        <input
+                            type="checkbox"
+                            name="can_call_subagents"
+                            value="1"
+                            x-model="canCallSubagents"
+                            class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                        >
+                        <div>
+                            <span class="text-sm text-white group-hover:text-blue-300">Can call other agents</span>
+                            <p class="text-xs text-gray-400 mt-0.5">
+                                Allow this agent to spawn sub-agents via SubAgent tool or native agent tool calls. Disable to prevent any outbound sub-agent calls.
+                            </p>
+                        </div>
+                    </label>
+
+                    <!-- Allowed subagents allowlist -->
+                    @php $exposedAgents = $exposedAgents ?? collect(); @endphp
+                    <div x-show="canCallSubagents && {{ $exposedAgents->isNotEmpty() ? 'true' : 'false' }}" x-cloak class="ml-7">
+                        <label class="block text-xs font-medium text-gray-400 mb-2">
+                            Limit to specific agents
+                            <span class="text-gray-500 font-normal">(leave empty to allow all)</span>
+                        </label>
+                        <div class="flex flex-wrap gap-2">
+                            @foreach ($exposedAgents as $exposedAgent)
+                                <label class="flex items-center gap-1.5 px-2 py-1 bg-gray-800 border border-gray-700 rounded cursor-pointer hover:border-gray-600 text-xs">
+                                    <input
+                                        type="checkbox"
+                                        name="allowed_subagents[]"
+                                        value="{{ $exposedAgent->id }}"
+                                        {{ in_array($exposedAgent->id, old('allowed_subagents', $agent->allowed_subagents ?? [])) ? 'checked' : '' }}
+                                        class="w-3.5 h-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500"
+                                    >
+                                    <span class="text-gray-300">{{ $exposedAgent->name }}</span>
+                                    <span class="text-gray-500 font-mono">{{ $exposedAgent->slug }}</span>
+                                </label>
+                            @endforeach
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">Only agents with "Expose as native tool" enabled are listed here.</p>
+                    </div>
+                </div>
             </div>
 
             <!-- Right Column: Reasoning Settings -->

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -171,6 +171,7 @@
                     </button>
                     <p class="text-xs text-gray-500 mt-3">
                         If you prefer to use an API key instead, select "OpenAI API" above.
+                        You can also skip this and authenticate later via <strong class="text-gray-400">Settings → Codex Auth</strong>.
                     </p>
                 </div>
 
@@ -193,6 +194,13 @@
                         <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Step 1 — Open this link</p>
                         <div class="flex items-center gap-2 bg-gray-900 rounded p-2 border border-gray-700">
                             <span class="text-blue-400 text-xs font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                            <a
+                                :href="verificationUrl"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="flex-shrink-0 px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 transition-all"
+                                title="Open in new tab"
+                            >↗</a>
                             <button
                                 type="button"
                                 @click="copyUrl()"
@@ -239,13 +247,28 @@
                         </p>
                         <p class="text-red-300 text-xs mt-1" x-text="error || 'Please try again.'"></p>
                     </div>
-                    <button
-                        type="button"
-                        @click="reset(); startAuth()"
-                        class="px-5 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm font-medium"
-                    >
-                        Try again
-                    </button>
+                    <div class="flex gap-2 mb-4">
+                        <button
+                            type="button"
+                            @click="reset(); startAuth()"
+                            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm font-medium"
+                        >
+                            Try again
+                        </button>
+                        <button
+                            type="button"
+                            @click="reset()"
+                            class="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm text-gray-300"
+                        >
+                            Skip — auth later
+                        </button>
+                    </div>
+                    <!-- Org restriction hint -->
+                    <p class="text-xs text-yellow-400/80">
+                        💡 If your organisation blocks device auth, run <code class="bg-black/20 px-1 rounded">codex login</code> on another machine,
+                        then upload <code class="bg-black/20 px-1 rounded">~/.codex/auth.json</code> via
+                        <a href="{{ route('codex.auth') }}" target="_blank" class="underline">Settings → Codex Auth</a>.
+                    </p>
                 </div>
             </div>
             @endif

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -153,45 +153,100 @@
 
             {{-- Codex Setup (conditional) --}}
             @if(!$hasCodex)
-            <div x-show="provider === 'codex'" x-cloak class="bg-gray-800 rounded-lg p-6">
+            <div x-show="provider === 'codex'" x-cloak class="bg-gray-800 rounded-lg p-6" x-data="wizardCodexDeviceAuth()">
                 <h3 class="text-lg font-semibold mb-3">Codex Setup</h3>
-                <p class="text-sm text-gray-400 mb-4">
-                    Run this command on your <strong class="text-white">host machine</strong> (not in Docker) to authenticate:
-                </p>
-                @if(config('backup.user_id') !== null && config('backup.group_id') !== null)
-                    <div class="relative">
-                        <div
-                            @click="copyCommand('sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json pocket-dev-queue:/home/appuser/.codex/auth.json && docker exec -u root pocket-dev-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec pocket-dev-queue chmod 600 /home/appuser/.codex/auth.json', 'codex')"
-                            class="bg-gray-900 rounded p-3 font-mono text-xs text-green-400 cursor-pointer hover:bg-gray-800 transition-colors mb-3 overflow-x-auto"
-                            title="Click to copy"
-                        >
-                            sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json pocket-dev-queue:/home/appuser/.codex/auth.json && docker exec -u root pocket-dev-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec pocket-dev-queue chmod 600 /home/appuser/.codex/auth.json
-                        </div>
-                        <div
-                            x-show="copiedCommand === 'codex'"
-                            x-transition:enter="transition ease-out duration-200"
-                            x-transition:enter-start="opacity-0 translate-y-1"
-                            x-transition:enter-end="opacity-100 translate-y-0"
-                            x-transition:leave="transition ease-in duration-150"
-                            x-transition:leave-start="opacity-100 translate-y-0"
-                            x-transition:leave-end="opacity-0 translate-y-1"
-                            class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded shadow-lg"
-                        >
-                            Copied!
+
+                <!-- Idle: show start button -->
+                <div x-show="state === 'idle'">
+                    <p class="text-sm text-gray-400 mb-4">
+                        Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise).
+                        No terminal or Docker commands needed.
+                    </p>
+                    <button
+                        type="button"
+                        @click="startAuth()"
+                        class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-semibold transition-colors"
+                    >
+                        Login met ChatGPT
+                    </button>
+                    <p class="text-xs text-gray-500 mt-3">
+                        If you prefer to use an API key instead, select "OpenAI API" above.
+                    </p>
+                </div>
+
+                <!-- Starting: spinner -->
+                <div x-show="state === 'starting'" class="text-center py-4">
+                    <svg class="animate-spin w-6 h-6 mx-auto text-blue-400 mb-2" fill="none" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                        <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                    </svg>
+                    <p class="text-sm text-gray-400">Connecting to OpenAI...</p>
+                </div>
+
+                <!-- Ready: show URL and code -->
+                <div x-show="state === 'ready'" style="display:none">
+                    <p class="text-sm text-gray-400 mb-4">
+                        Open the link on your phone or another browser, then enter the code when prompted.
+                    </p>
+                    <!-- URL -->
+                    <div class="mb-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Step 1 — Open this link</p>
+                        <div class="flex items-center gap-2 bg-gray-900 rounded p-2 border border-gray-700">
+                            <span class="text-blue-400 text-xs font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                            <button
+                                type="button"
+                                @click="copyUrl()"
+                                class="flex-shrink-0 px-2 py-1 rounded text-xs transition-all"
+                                :class="urlCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                x-text="urlCopied ? '✓' : '📋'"
+                            ></button>
                         </div>
                     </div>
-                @else
-                    <div class="bg-red-900/50 border border-red-500/50 rounded p-3 text-red-300 text-sm mb-3">
-                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">PD_USER_ID</code> and <code class="bg-red-900 px-1 rounded">PD_GROUP_ID</code> in your .env file.
-                        <span class="text-red-400 text-xs block mt-1">Run <code>id -u</code> and <code>id -g</code> on your host to get the values.</span>
+                    <!-- Code -->
+                    <div class="mb-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Step 2 — Enter this code</p>
+                        <div class="flex items-center gap-3">
+                            <div class="bg-gray-900 border border-gray-600 rounded px-4 py-2">
+                                <span class="text-xl font-mono font-bold tracking-widest" x-text="userCode"></span>
+                            </div>
+                            <button
+                                type="button"
+                                @click="copyCode()"
+                                class="px-3 py-1.5 rounded text-xs font-medium transition-all"
+                                :class="codeCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                x-text="codeCopied ? '✓ Copied' : '📋 Copy'"
+                            ></button>
+                        </div>
                     </div>
-                @endif
-                <p class="text-sm text-gray-400 mb-2">
-                    This installs Codex locally, opens a browser login, then copies credentials to the container. After completion, click <strong class="text-white">Verify & Continue</strong>.
-                </p>
-                <p class="text-xs text-gray-500">
-                    If you prefer to use an API key instead, select "OpenAI API" above.
-                </p>
+                    <p class="text-xs text-gray-500">
+                        Waiting for login… expires in <span class="font-mono" x-text="countdown"></span>
+                    </p>
+                </div>
+
+                <!-- Authenticated -->
+                <div x-show="state === 'authenticated'" style="display:none" class="text-center py-4">
+                    <div class="text-3xl mb-2">✅</div>
+                    <p class="text-green-400 font-semibold mb-1">Authenticated!</p>
+                    <p class="text-sm text-gray-400">Click <strong class="text-white">Verify &amp; Continue</strong> below to proceed.</p>
+                </div>
+
+                <!-- Failed / expired -->
+                <div x-show="state === 'expired' || state === 'failed'" style="display:none">
+                    <div class="bg-red-900/30 border border-red-700 rounded p-3 mb-3">
+                        <p class="text-red-400 text-sm font-semibold">
+                            <span x-show="state === 'expired'">Code expired</span>
+                            <span x-show="state === 'failed'">Failed</span>
+                        </p>
+                        <p class="text-red-300 text-xs mt-1" x-text="error || 'Please try again.'"></p>
+                    </div>
+                    <button
+                        type="button"
+                        @click="reset(); startAuth()"
+                        class="px-5 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm font-medium"
+                    >
+                        Try again
+                    </button>
+                </div>
             </div>
             @endif
 
@@ -337,6 +392,140 @@
                     });
                 }
             }
+        }
+
+        // Inline device auth component reused in the wizard's Codex step
+        function wizardCodexDeviceAuth() {
+            return {
+                state: 'idle',
+                verificationUrl: '',
+                userCode: '',
+                expiresIn: 900,
+                urlCopied: false,
+                codeCopied: false,
+                error: '',
+                _pollTimer: null,
+                _countdownTimer: null,
+
+                get countdown() {
+                    const m = Math.floor(this.expiresIn / 60);
+                    const s = this.expiresIn % 60;
+                    return `${m}:${String(s).padStart(2, '0')}`;
+                },
+
+                async init() {
+                    await this.checkStatus();
+                },
+
+                async startAuth() {
+                    this.state = 'starting';
+                    this.error = '';
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStart') }}', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            }
+                        });
+                        const data = await res.json();
+                        if (!data.success) {
+                            this.state = 'failed';
+                            this.error = data.error || 'Unknown error';
+                            return;
+                        }
+                        this._applyStatus(data);
+                        this._startPolling();
+                    } catch (e) {
+                        this.state = 'failed';
+                        this.error = e.message;
+                    }
+                },
+
+                _startPolling() {
+                    if (this._pollTimer) clearInterval(this._pollTimer);
+                    this._pollTimer = setInterval(() => this.checkStatus(), 2500);
+                },
+
+                async checkStatus() {
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStatus') }}');
+                        const data = await res.json();
+                        this._applyStatus(data);
+                    } catch (e) {}
+                },
+
+                _applyStatus(data) {
+                    const status = data.status;
+                    if (status === 'ready' && this.state !== 'ready') {
+                        this.state = 'ready';
+                        this.verificationUrl = data.verification_url || '';
+                        this.userCode = data.user_code || '';
+                        this.expiresIn = data.expires_in ?? 900;
+                        this._startCountdown();
+                        if (!this._pollTimer) this._startPolling();
+                    } else if (status === 'ready') {
+                        if (data.expires_in !== undefined) this.expiresIn = data.expires_in;
+                    } else if (status === 'authenticated') {
+                        this.state = 'authenticated';
+                        this._stopTimers();
+                    } else if (status === 'failed') {
+                        this.state = 'failed';
+                        this.error = data.error || 'Authentication failed';
+                        this._stopTimers();
+                    } else if (status === 'expired') {
+                        this.state = 'expired';
+                        this._stopTimers();
+                    } else if (status === 'starting' && this.state === 'idle') {
+                        this.state = 'starting';
+                        this._startPolling();
+                    }
+                },
+
+                _startCountdown() {
+                    if (this._countdownTimer) clearInterval(this._countdownTimer);
+                    this._countdownTimer = setInterval(() => {
+                        if (this.expiresIn > 0) {
+                            this.expiresIn--;
+                        } else {
+                            this.state = 'expired';
+                            this._stopTimers();
+                        }
+                    }, 1000);
+                },
+
+                _stopTimers() {
+                    if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+                    if (this._countdownTimer) { clearInterval(this._countdownTimer); this._countdownTimer = null; }
+                },
+
+                reset() {
+                    this._stopTimers();
+                    this.state = 'idle';
+                    this.verificationUrl = '';
+                    this.userCode = '';
+                    this.expiresIn = 900;
+                    this.error = '';
+                    this.urlCopied = false;
+                    this.codeCopied = false;
+                },
+
+                async copyUrl() {
+                    try {
+                        await navigator.clipboard.writeText(this.verificationUrl);
+                        this.urlCopied = true;
+                        setTimeout(() => { this.urlCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+
+                async copyCode() {
+                    try {
+                        await navigator.clipboard.writeText(this.userCode);
+                        this.codeCopied = true;
+                        setTimeout(() => { this.codeCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+            };
         }
     </script>
 

--- a/www/routes/api.php
+++ b/www/routes/api.php
@@ -218,6 +218,13 @@ Route::prefix('screens')->group(function () {
 
 Route::get('panels', [\App\Http\Controllers\Api\PanelController::class, 'availablePanels']);
 
+/*
+|--------------------------------------------------------------------------
+| Codex Auth (script upload — no CSRF required for CLI tools)
+|--------------------------------------------------------------------------
+*/
+Route::post('codex/auth/upload', [\App\Http\Controllers\CodexAuthController::class, 'uploadJson']);
+
 Route::prefix('panel/{panelState}')->group(function () {
     Route::get('render', [\App\Http\Controllers\Api\PanelController::class, 'render']);
     Route::get('state', [\App\Http\Controllers\Api\PanelController::class, 'getState']);

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -26,6 +26,9 @@ Route::get("/codex/auth", [CodexAuthController::class, "index"])->name("codex.au
 Route::get("/codex/auth/status", [CodexAuthController::class, "status"])->name("codex.auth.status");
 Route::post("/codex/auth/upload-json", [CodexAuthController::class, "uploadJson"])->name("codex.auth.uploadJson");
 Route::delete("/codex/auth/logout", [CodexAuthController::class, "logout"])->name("codex.auth.logout");
+// Inline device auth flow (no terminal/sudo required)
+Route::post("/codex/auth/device-start", [CodexAuthController::class, "startDeviceAuth"])->name("codex.auth.deviceStart");
+Route::get("/codex/auth/device-status", [CodexAuthController::class, "deviceStatus"])->name("codex.auth.deviceStatus");
 
 // Chat - Multi-provider conversation interface
 Route::get("/", [ChatController::class, "index"])->name("chat.index");

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -29,6 +29,8 @@ Route::delete("/codex/auth/logout", [CodexAuthController::class, "logout"])->nam
 // Inline device auth flow (no terminal/sudo required)
 Route::post("/codex/auth/device-start", [CodexAuthController::class, "startDeviceAuth"])->name("codex.auth.deviceStart");
 Route::get("/codex/auth/device-status", [CodexAuthController::class, "deviceStatus"])->name("codex.auth.deviceStatus");
+// Serve the local-run upload script (pre-filled with this instance's URL)
+Route::get("/codex/auth/upload-script", [CodexAuthController::class, "downloadScript"])->name("codex.auth.downloadScript");
 
 // Chat - Multi-provider conversation interface
 Route::get("/", [ChatController::class, "index"])->name("chat.index");


### PR DESCRIPTION
## Summary

Implements issue #245 — each PocketDev agent can now be exposed as a **dedicated native tool call** following Anthropic's recommended "agents as tools" pattern.

- **Target-side opt-in**: agents with `expose_as_tool = true` appear as `agent_<slug>` in the AI's tool schema
- **Caller-side access control**: `can_call_subagents` toggle + `allowed_subagents` allowlist per agent
- **Resumable conversations**: both SubAgent and AgentTool now accept `conversation_id` to continue a previous sub-agent conversation
- **SubAgentRunner service**: shared execution logic extracted from SubAgentTool so both tools stay DRY

Depends on: #248 (native cross-provider subagents — base branch for this PR)
Closes #245

## What changed

| File | Change |
|------|--------|
| `migration: add_expose_as_tool_to_agents` | **New** — 3 new columns on agents table |
| `Agent.php` | Add `expose_as_tool`, `can_call_subagents`, `allowed_subagents` to fillable + casts |
| `SubAgentRunner.php` | **New service** — extracted spawn/resume/poll logic; supports `conversation_id` |
| `AgentTool.php` | **New tool** — per-agent wrapper; delegates to SubAgentRunner |
| `SubAgentTool.php` | Refactored to use SubAgentRunner; added `conversation_id` param |
| `ToolRegistry.php` | `getDefinitions(?Agent $callerAgent)` + `agent_*` dispatch in `execute()` |
| `ProcessConversationStream.php` | Pass `$conversation->agent` to `getDefinitions()` and `ExecutionContext` |
| `ConfigController.php` | Validate + save new fields; pass `$exposedAgents` to form view |
| `agents/form.blade.php` | Sub-agent settings section: expose toggle, can-call toggle, allowlist checkboxes |

## How it works

**Target-side (expose_as_tool)**
```
agent_code_reviewer({"prompt": "Review AuthController for security issues"})
```
The AI calls the agent directly — no slug lookup needed.

**Caller-side controls**
- Toggle OFF `can_call_subagents` → no `agent_*` tools injected for this agent at all
- Set `allowed_subagents` → restrict to only specific agents
- Both at defaults → all opted-in workspace agents available

**Resumable**
```json
{ "prompt": "Elaborate on issue #2", "conversation_id": "conv_abc123" }
```

## Test plan

- [ ] Agent with `expose_as_tool = true` appears in tool schema as `agent_<slug>`
- [ ] Agent with `expose_as_tool = false` does NOT appear as a tool
- [ ] `can_call_subagents = false` → no `agent_*` tools injected for that caller
- [ ] Allowlist set → only listed agents injected
- [ ] Foreground call returns output inline
- [ ] Background call returns task_id
- [ ] `conversation_id` provided → prompt appended to existing conversation
- [ ] Agent cannot call itself
- [ ] Cross-workspace: agent tools scoped to caller's workspace only
- [ ] Migration on existing DB: existing agents default to `expose_as_tool = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\n---\n**Bevat ook PR #248** (native cross-provider subagents) — die branch is volledig opgenomen in deze.