### PR TITLE
feat(codex): inline device auth — no terminal or sudo required | READY TO MERGE!

### DIFF
--- a/docs/plans/codex-inline-device-auth.md
+++ b/docs/plans/codex-inline-device-auth.md
@@ -1,0 +1,136 @@
+# Plan: Codex Inline Device Auth
+
+## Probleem
+
+De huidige Codex authenticatie flows werken niet goed op een VPS:
+
+| Flow | Probleem |
+|------|---------|
+| Wizard | Vereist `sudo` + browser op host machine |
+| Settings (device-auth) | Vereist terminal toegang + interactieve TTY |
+
+## Oplossing
+
+Device auth flow volledig ingebouwd in de PocketDev UI. Gebruiker hoeft
+alleen een link te openen op een ander apparaat (telefoon/laptop).
+
+### User flow
+
+1. Gebruiker klikt **"Login met ChatGPT"** in PocketDev UI
+2. PocketDev start `codex login --device-auth` als background process in de queue container
+3. PocketDev parseert stdout/stderr → toont **URL + code groot in de UI**
+4. Gebruiker opent `https://auth.openai.com/codex/device` op telefoon/laptop
+5. Voert de code in → logt in met ChatGPT account
+6. PocketDev pollt `~/.codex/auth.json` → detecteert success → toont ✅
+
+Geen sudo, geen terminal, geen docker commando's.
+
+---
+
+## Implementatie
+
+### 1. Backend: `CodexAuthController`
+
+**Nieuwe endpoints:**
+
+#### `POST /codex/auth/device-start`
+- Start `codex login --device-auth` als background process in de queue container via `docker exec`
+- Parseert output voor URL en user code
+- Slaat process PID op in cache (voor cleanup)
+- Returnt: `{ verification_url, user_code, expires_in: 900 }`
+
+```php
+public function startDeviceAuth(): JsonResponse
+{
+    // Run in queue container where codex is installed
+    $process = Process::start([
+        'docker', 'exec', '-u', 'appuser',
+        config('pocketdev.queue_container', 'pocket-dev-queue'),
+        'codex', 'login', '--device-auth'
+    ]);
+
+    // Parse URL and code from stderr output
+    // Output format:
+    //   1. Open: https://auth.openai.com/codex/device
+    //   2. Enter code: CDB9-2OZPE
+    ...
+}
+```
+
+#### `GET /codex/auth/device-status`
+- Pollt of `~/.codex/auth.json` aangemaakt is in de queue container
+- Returnt: `{ authenticated: bool, auth_type: string }`
+
+---
+
+### 2. Frontend: `codex-auth.blade.php`
+
+**Nieuwe "Subscription" tab UI:**
+
+```
+┌─────────────────────────────────────────┐
+│  Login met ChatGPT Subscription         │
+│                                         │
+│  [Start Login]                          │
+│                                         │
+│  ── na klik ──                          │
+│                                         │
+│  1. Open deze link op je telefoon       │
+│     of laptop:                          │
+│                                         │
+│  https://auth.openai.com/codex/device   │
+│  [📋 Kopieer link]                      │
+│                                         │
+│  2. Voer deze code in:                  │
+│                                         │
+│  ┌──────────────┐                       │
+│  │  CDB9-2OZPE  │  [📋 Kopieer]        │
+│  └──────────────┘                       │
+│                                         │
+│  ⏳ Wachten op authenticatie...         │
+│     (verloopt over 14:32)               │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Copy knoppen:**
+- Kopieer URL → `navigator.clipboard.writeText(url)`
+- Kopieer code → `navigator.clipboard.writeText(code)`
+- Beide tonen ✓ bevestiging na kopiëren
+
+**Polling:**
+- Frontend pollt `GET /codex/auth/device-status` elke 3 seconden
+- Bij success: toont ✅ "Authenticated!" + herlaadt status
+
+**Countdown timer:**
+- 15 minuten aftellen via `setInterval`
+- Bij 0: toont melding "Code verlopen, probeer opnieuw"
+
+---
+
+### 3. Wizard: `setup/wizard.blade.php`
+
+Zelfde inline device auth component hergebruiken in de wizard stap voor Codex.
+
+---
+
+## Bestanden om aan te passen
+
+| Bestand | Wijziging |
+|---------|-----------|
+| `CodexAuthController.php` | `startDeviceAuth()` + `deviceStatus()` endpoints |
+| `routes/web.php` | `POST /codex/auth/device-start` + `GET /codex/auth/device-status` |
+| `codex-auth.blade.php` | Nieuwe subscription tab UI met copy knoppen + polling |
+| `setup/wizard.blade.php` | Inline device auth component |
+| `EnsureSetupComplete.php` | Nieuwe routes whitelisten |
+
+---
+
+## Open vragen
+
+- [ ] Hoe parsen we de URL + code uit `codex login --device-auth` output?
+  - Output gaat naar stderr met ANSI color codes
+  - Regex: `https://auth\.openai\.com/codex/device` + `[A-Z0-9]{4}-[A-Z0-9]{5}`
+- [ ] Timeout afhandeling: process killen als 15 min verstreken zijn
+- [ ] Wat als Docker niet beschikbaar is (non-Docker deployment)?
+  - Fallback: run `codex login --device-auth` direct (niet via docker exec)

--- a/docs/plans/codex-inline-device-auth.md
+++ b/docs/plans/codex-inline-device-auth.md
@@ -67,7 +67,7 @@ public function startDeviceAuth(): JsonResponse
 
 **Nieuwe "Subscription" tab UI:**
 
-```
+```text
 ┌─────────────────────────────────────────┐
 │  Login met ChatGPT Subscription         │
 │                                         │

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\CodexAgentService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -12,9 +13,12 @@ use Illuminate\Support\Facades\Validator;
 class CodexAuthController extends Controller
 {
     protected string $credentialsPath;
+    protected CodexAgentService $codexAgentService;
 
-    public function __construct()
+    public function __construct(CodexAgentService $codexAgentService)
     {
+        $this->codexAgentService = $codexAgentService;
+
         // Credentials path - use HOME environment variable from PHP-FPM process
         $home = getenv('HOME') ?: '/home/appuser';
         $this->credentialsPath = "{$home}/.codex/auth.json";
@@ -88,7 +92,7 @@ class CodexAuthController extends Controller
             // Create default agent for all workspaces that don't have one
             $workspaces = \App\Models\Workspace::all();
             foreach ($workspaces as $workspace) {
-                $this->ensureDefaultAgentExists($workspace->id);
+                $this->codexAgentService->ensureDefaultAgentExists($workspace->id);
             }
 
             return response()->json([
@@ -250,7 +254,16 @@ class CodexAuthController extends Controller
     public function downloadScript(): Response
     {
         $scriptPath = public_path('scripts/codex-auth.sh');
+        if (!file_exists($scriptPath) || !is_readable($scriptPath)) {
+            Log::error('[Codex Auth] Upload script missing or unreadable', ['path' => $scriptPath]);
+            return response('Upload script not found', 404);
+        }
+
         $script = file_get_contents($scriptPath);
+        if ($script === false) {
+            Log::error('[Codex Auth] Failed to read upload script', ['path' => $scriptPath]);
+            return response('Failed to read upload script', 500);
+        }
 
         // Pre-fill the PocketDev URL so the user doesn't have to type it
         $instanceUrl = rtrim(url('/'), '/');
@@ -373,46 +386,6 @@ class CodexAuthController extends Controller
      */
     public function ensureDefaultAgentExists(string $workspaceId): ?\App\Models\Agent
     {
-        // Check if a default Codex agent already exists
-        $existing = \App\Models\Agent::where('workspace_id', $workspaceId)
-            ->where('provider', 'codex')
-            ->where('is_default', true)
-            ->first();
-
-        if ($existing) {
-            return $existing;
-        }
-
-        // Check if ANY Codex agent exists
-        $anyCodex = \App\Models\Agent::where('workspace_id', $workspaceId)
-            ->where('provider', 'codex')
-            ->first();
-
-        if ($anyCodex) {
-            return $anyCodex;
-        }
-
-        // Create default agent
-        try {
-            return \App\Models\Agent::create([
-                'workspace_id' => $workspaceId,
-                'name' => 'Codex',
-                'slug' => 'codex-default',
-                'description' => 'Default Codex agent',
-                'provider' => 'codex',
-                'model' => config('ai.providers.codex.default_model', 'gpt-5.3-codex'),
-                'reasoning_config' => ['effort' => 'medium'],
-                'response_level' => 1,
-                'enabled' => true,
-                'is_default' => true,
-                'inherit_workspace_tools' => true,
-            ]);
-        } catch (\Exception $e) {
-            Log::error('[Codex Auth] Failed to create default agent', [
-                'workspace_id' => $workspaceId,
-                'error' => $e->getMessage(),
-            ]);
-            return null;
-        }
+        return $this->codexAgentService->ensureDefaultAgentExists($workspaceId);
     }
 }

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 
@@ -79,7 +81,7 @@ class CodexAuthController extends Controller
 
             // Save the file
             file_put_contents($this->credentialsPath, json_encode($data, JSON_PRETTY_PRINT));
-            chmod($this->credentialsPath, 0600);
+            chmod($this->credentialsPath, 0660);
 
             Log::info("[Codex Auth] Credentials saved from JSON input");
 
@@ -168,24 +170,40 @@ class CodexAuthController extends Controller
                 ];
             }
 
-            // Check for OAuth format (accessToken indicates OAuth login)
-            if (isset($data["accessToken"])) {
-                $expiresAt = $data["expiresAt"] ?? null;
-                $now = time() * 1000; // Convert to milliseconds
+            // Check for OAuth format (tokens.access_token indicates OAuth login)
+            if (isset($data["tokens"]["access_token"])) {
+                $lastRefresh = $data["last_refresh"] ?? null;
+                // Codex source uses TOKEN_REFRESH_INTERVAL = 8 days (codex-rs/core/src/auth.rs)
+                $refreshIntervalDays = (int) config('ai.providers.codex.token_refresh_days', 8);
 
-                if ($expiresAt && $expiresAt < $now) {
+                if ($lastRefresh) {
+                    $refreshDate = new \DateTime($lastRefresh);
+                    $now = new \DateTime();
+                    $expiryDate = (clone $refreshDate)->modify("+{$refreshIntervalDays} days");
+
+                    if ($now > $expiryDate) {
+                        return [
+                            "authenticated" => false,
+                            "message" => "Token expired",
+                            "expired_at" => $expiryDate->format("Y-m-d H:i:s"),
+                        ];
+                    }
+
+                    $daysUntilExpiry = round(($expiryDate->getTimestamp() - $now->getTimestamp()) / 86400, 1);
+
                     return [
-                        "authenticated" => false,
-                        "message" => "Token expired",
-                        "expired_at" => date("Y-m-d H:i:s", $expiresAt / 1000),
+                        "authenticated" => true,
+                        "auth_type" => "subscription",
+                        "expires_at" => $expiryDate->format("Y-m-d H:i:s"),
+                        "days_until_expiry" => $daysUntilExpiry,
                     ];
                 }
 
                 return [
                     "authenticated" => true,
                     "auth_type" => "subscription",
-                    "expires_at" => $expiresAt ? date("Y-m-d H:i:s", $expiresAt / 1000) : null,
-                    "days_until_expiry" => $expiresAt ? round(($expiresAt - $now) / (1000 * 60 * 60 * 24), 1) : null,
+                    "expires_at" => null,
+                    "days_until_expiry" => null,
                 ];
             }
 
@@ -217,12 +235,131 @@ class CodexAuthController extends Controller
             return true;
         }
 
-        // Valid if has accessToken (OAuth format)
-        if (isset($data["accessToken"]) && !empty($data["accessToken"])) {
+        // Valid if has tokens.access_token (OAuth format)
+        if (isset($data["tokens"]["access_token"]) && !empty($data["tokens"]["access_token"])) {
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Serve the local upload script with this instance's URL pre-filled.
+     * Users can pipe it directly: bash <(curl -s https://pocketdev/codex/auth/upload-script)
+     */
+    public function downloadScript(): Response
+    {
+        $scriptPath = public_path('scripts/codex-auth.sh');
+        $script = file_get_contents($scriptPath);
+
+        // Pre-fill the PocketDev URL so the user doesn't have to type it
+        $instanceUrl = rtrim(url('/'), '/');
+        $script = str_replace(
+            'PD_URL="${1:-${POCKETDEV_URL:-}}"',
+            'PD_URL="${1:-${POCKETDEV_URL:-' . $instanceUrl . '}}"',
+            $script
+        );
+
+        return response($script, 200, [
+            'Content-Type' => 'text/plain; charset=utf-8',
+            'Content-Disposition' => 'inline; filename="codex-auth.sh"',
+            'Cache-Control' => 'no-store',
+        ]);
+    }
+
+    /**
+     * Start device auth flow — dispatches a background job that runs codex login.
+     * The job parses the URL/code from codex output and stores them in cache.
+     * Frontend polls deviceStatus() to get the URL and code to show the user.
+     */
+    public function startDeviceAuth(): JsonResponse
+    {
+        // Already authenticated — no need to start a new session
+        if (file_exists($this->credentialsPath)) {
+            return response()->json([
+                'success' => false,
+                'error' => 'Already authenticated. Logout first if you want to switch accounts.',
+            ], 400);
+        }
+
+        // Check if there's already an active session in progress
+        $existing = Cache::get('codex_device_auth');
+        if ($existing && in_array($existing['status'], ['starting', 'ready'], true)) {
+            $expiresAt = $existing['expires_at'] ?? 0;
+            if ($expiresAt > time()) {
+                return response()->json([
+                    'success' => true,
+                    'status' => $existing['status'],
+                    'verification_url' => $existing['verification_url'] ?? null,
+                    'user_code' => $existing['user_code'] ?? null,
+                    'expires_in' => max(0, $expiresAt - time()),
+                ]);
+            }
+        }
+
+        // Store initial "starting" state so the polling endpoint can respond immediately
+        Cache::put('codex_device_auth', [
+            'status' => 'starting',
+            'started_at' => time(),
+            'expires_at' => time() + 960,
+        ], 960);
+
+        // Dispatch the long-running job to the queue container
+        \App\Jobs\StartCodexDeviceAuthJob::dispatch();
+
+        Log::info('[Codex Device Auth] Job dispatched');
+
+        return response()->json([
+            'success' => true,
+            'status' => 'starting',
+        ]);
+    }
+
+    /**
+     * Return the current device auth session status.
+     * Frontend polls this every 2-3 seconds after calling startDeviceAuth().
+     */
+    public function deviceStatus(): JsonResponse
+    {
+        // Auth.json already exists — authentication complete
+        if (file_exists($this->credentialsPath)) {
+            // Clear any leftover session cache
+            Cache::forget('codex_device_auth');
+
+            return response()->json([
+                'success' => true,
+                'status' => 'authenticated',
+            ]);
+        }
+
+        $session = Cache::get('codex_device_auth');
+
+        if (!$session) {
+            return response()->json(['success' => true, 'status' => 'none']);
+        }
+
+        // Check expiry
+        if (($session['expires_at'] ?? 0) <= time()) {
+            Cache::forget('codex_device_auth');
+            return response()->json(['success' => true, 'status' => 'expired']);
+        }
+
+        // Propagate job-reported "authenticated" status even if auth.json isn't visible here
+        if ($session['status'] === 'authenticated') {
+            return response()->json([
+                'success' => true,
+                'status' => 'authenticated',
+            ]);
+        }
+
+        return response()->json([
+            'success' => true,
+            'status' => $session['status'],
+            'verification_url' => $session['verification_url'] ?? null,
+            'user_code' => $session['user_code'] ?? null,
+            'expires_in' => max(0, ($session['expires_at'] ?? 0) - time()),
+            'error' => $session['error'] ?? null,
+        ]);
     }
 
     /**
@@ -264,7 +401,7 @@ class CodexAuthController extends Controller
                 'description' => 'Default Codex agent',
                 'provider' => 'codex',
                 'model' => config('ai.providers.codex.default_model', 'gpt-5.3-codex'),
-                'reasoning_config' => ['effort' => 'minimal'],
+                'reasoning_config' => ['effort' => 'medium'],
                 'response_level' => 1,
                 'enabled' => true,
                 'is_default' => true,

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -265,11 +265,18 @@ class CodexAuthController extends Controller
             return response('Failed to read upload script', 500);
         }
 
-        // Pre-fill the PocketDev URL so the user doesn't have to type it
+        // Pre-fill the PocketDev URL so the user doesn't have to type it.
+        // Use escapeshellarg() to neutralise any special shell characters in the URL
+        // before embedding it as the default value in the shell variable assignment.
         $instanceUrl = rtrim(url('/'), '/');
+        $escapedUrl = escapeshellarg($instanceUrl);
+        // Strip the outer single-quotes added by escapeshellarg — the URL will be
+        // placed inside double-quotes in the shell script, so we only need the
+        // inner content with single-quotes escaped (i.e. ' → '\'').
+        $safeUrl = substr($escapedUrl, 1, -1);
         $script = str_replace(
             'PD_URL="${1:-${POCKETDEV_URL:-}}"',
-            'PD_URL="${1:-${POCKETDEV_URL:-' . $instanceUrl . '}}"',
+            'PD_URL="${1:-${POCKETDEV_URL:-' . $safeUrl . '}}"',
             $script
         );
 
@@ -287,8 +294,11 @@ class CodexAuthController extends Controller
      */
     public function startDeviceAuth(): JsonResponse
     {
-        // Already authenticated — no need to start a new session
-        if (file_exists($this->credentialsPath)) {
+        // Already authenticated with valid, non-expired credentials — no need to start a new session.
+        // We check getAuthenticationStatus() rather than mere file existence so that users with
+        // stale/expired/malformed auth.json can still trigger device auth to re-authenticate.
+        $currentStatus = $this->getAuthenticationStatus();
+        if ($currentStatus['authenticated'] ?? false) {
             return response()->json([
                 'success' => false,
                 'error' => 'Already authenticated. Logout first if you want to switch accounts.',

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -85,7 +85,7 @@ class CodexAuthController extends Controller
 
             // Save the file
             file_put_contents($this->credentialsPath, json_encode($data, JSON_PRETTY_PRINT));
-            chmod($this->credentialsPath, 0660);
+            chmod($this->credentialsPath, 0600);
 
             Log::info("[Codex Auth] Credentials saved from JSON input");
 

--- a/www/app/Http/Controllers/CodexAuthController.php
+++ b/www/app/Http/Controllers/CodexAuthController.php
@@ -305,6 +305,13 @@ class CodexAuthController extends Controller
             ], 400);
         }
 
+        // Remove stale/expired/malformed auth.json before starting a new device-auth flow.
+        // Without this, the job and deviceStatus() would see the leftover file and
+        // immediately report "authenticated" with the old (invalid) credentials.
+        if (file_exists($this->credentialsPath)) {
+            @unlink($this->credentialsPath);
+        }
+
         // Check if there's already an active session in progress
         $existing = Cache::get('codex_device_auth');
         if ($existing && in_array($existing['status'], ['starting', 'ready'], true)) {

--- a/www/app/Jobs/StartCodexDeviceAuthJob.php
+++ b/www/app/Jobs/StartCodexDeviceAuthJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Services\CodexAgentService;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -51,7 +52,7 @@ class StartCodexDeviceAuthJob implements ShouldQueue
         // Start device auth in background, redirect stdout+stderr to log file
         $cmd = 'nohup ' . escapeshellarg($codexPath) . ' login --device-auth > '
             . escapeshellarg($logFile) . ' 2>&1 &';
-        exec($cmd, $execOutput, $exitCode);
+        exec($cmd);
 
         // Poll log file for URL and code (up to 30 seconds)
         $verificationUrl = null;
@@ -201,10 +202,10 @@ class StartCodexDeviceAuthJob implements ShouldQueue
     private function createDefaultAgents(): void
     {
         try {
-            $controller = new \App\Http\Controllers\CodexAuthController();
+            $agentService = app(CodexAgentService::class);
             $workspaces = \App\Models\Workspace::all();
             foreach ($workspaces as $workspace) {
-                $controller->ensureDefaultAgentExists($workspace->id);
+                $agentService->ensureDefaultAgentExists($workspace->id);
             }
         } catch (\Exception $e) {
             Log::error('[Codex Device Auth] Failed to create default agents', [

--- a/www/app/Jobs/StartCodexDeviceAuthJob.php
+++ b/www/app/Jobs/StartCodexDeviceAuthJob.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class StartCodexDeviceAuthJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Allow the job to run for up to 16 minutes (device code window is 15 min).
+     */
+    public int $timeout = 1000;
+
+    /**
+     * Don't retry — device auth is a one-shot flow.
+     */
+    public int $tries = 1;
+
+    public function handle(): void
+    {
+        $home = getenv('HOME') ?: '/home/appuser';
+        $authFile = "{$home}/.codex/auth.json";
+        $logFile = sys_get_temp_dir() . '/codex_device_auth_' . getmypid() . '.log';
+
+        Log::info('[Codex Device Auth] Job started', ['log' => $logFile]);
+
+        // Find codex binary
+        $codexPath = $this->findCodexPath();
+        if (!$codexPath) {
+            $this->failWithError(
+                'Codex is not installed. Install it with: npm install -g @openai/codex'
+            );
+            return;
+        }
+
+        Log::info('[Codex Device Auth] Found codex at: ' . $codexPath);
+
+        // Clean up any old log
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+
+        // Start device auth in background, redirect stdout+stderr to log file
+        $cmd = 'nohup ' . escapeshellarg($codexPath) . ' login --device-auth > '
+            . escapeshellarg($logFile) . ' 2>&1 &';
+        exec($cmd, $execOutput, $exitCode);
+
+        // Poll log file for URL and code (up to 30 seconds)
+        $verificationUrl = null;
+        $userCode = null;
+
+        for ($i = 0; $i < 30; $i++) {
+            sleep(1);
+
+            if (!file_exists($logFile)) {
+                continue;
+            }
+
+            $log = file_get_contents($logFile);
+            if (!$log) {
+                continue;
+            }
+
+            // Strip ANSI color codes
+            $text = preg_replace('/\033\[[0-9;]*[mGKHF]/', '', $log);
+
+            // Look for verification URL (any HTTPS URL from auth.openai.com or similar)
+            if (!$verificationUrl) {
+                if (preg_match('/(https:\/\/\S+device\S*)/i', $text, $m)) {
+                    $verificationUrl = rtrim($m[1], '.,)');
+                } elseif (preg_match('/(https:\/\/auth\.openai\.com\/\S+)/i', $text, $m)) {
+                    $verificationUrl = rtrim($m[1], '.,)');
+                }
+            }
+
+            // Look for user code (e.g. CDB9-2OZPE, or similar alphanumeric-dash patterns)
+            if (!$userCode) {
+                if (preg_match('/\b([A-Z0-9]{4,8}[-–][A-Z0-9]{4,8})\b/', $text, $m)) {
+                    $userCode = $m[1];
+                }
+            }
+
+            if ($verificationUrl && $userCode) {
+                break;
+            }
+        }
+
+        if (!$verificationUrl || !$userCode) {
+            $rawLog = file_exists($logFile) ? file_get_contents($logFile) : '(empty)';
+            Log::error('[Codex Device Auth] Could not parse URL/code', ['log' => $rawLog]);
+            $this->failWithError(
+                'Could not get device code from Codex. Ensure Codex is properly installed and try again.'
+            );
+            return;
+        }
+
+        $expiresAt = time() + 900; // 15 minutes
+
+        Log::info('[Codex Device Auth] Device code ready', [
+            'url' => $verificationUrl,
+            'code' => $userCode,
+        ]);
+
+        Cache::put('codex_device_auth', [
+            'status' => 'ready',
+            'verification_url' => $verificationUrl,
+            'user_code' => $userCode,
+            'expires_at' => $expiresAt,
+        ], 960);
+
+        // Poll for auth.json — codex writes it when the user completes authentication
+        for ($i = 0; $i < 900; $i++) {
+            sleep(1);
+
+            if (file_exists($authFile)) {
+                $content = @file_get_contents($authFile);
+                $data = $content ? @json_decode($content, true) : null;
+
+                if ($data && (isset($data['tokens']['access_token']) || isset($data['OPENAI_API_KEY']))) {
+                    Log::info('[Codex Device Auth] Authentication successful');
+
+                    Cache::put('codex_device_auth', ['status' => 'authenticated'], 120);
+
+                    // Create default Codex agent for all workspaces
+                    $this->createDefaultAgents();
+
+                    // Cleanup log
+                    if (file_exists($logFile)) {
+                        unlink($logFile);
+                    }
+
+                    return;
+                }
+            }
+        }
+
+        // Timed out without authentication
+        Log::warning('[Codex Device Auth] Session expired without authentication');
+        Cache::put('codex_device_auth', ['status' => 'expired'], 120);
+
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+    }
+
+    /**
+     * Find the codex binary on the system.
+     */
+    private function findCodexPath(): ?string
+    {
+        $home = getenv('HOME') ?: '/home/appuser';
+
+        $candidates = [
+            "{$home}/.local/share/npm/bin/codex",
+            "{$home}/.npm-global/bin/codex",
+            "{$home}/.local/bin/codex",
+            '/usr/local/bin/codex',
+            '/usr/bin/codex',
+        ];
+
+        // Check via `which` first (respects PATH)
+        exec('which codex 2>/dev/null', $out, $rc);
+        if ($rc === 0 && !empty($out[0])) {
+            return trim($out[0]);
+        }
+
+        // Check known paths
+        foreach ($candidates as $path) {
+            if (file_exists($path) && is_executable($path)) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Store a failure state in cache so the frontend can display the error.
+     */
+    private function failWithError(string $error): void
+    {
+        Cache::put('codex_device_auth', [
+            'status' => 'failed',
+            'error' => $error,
+        ], 300);
+
+        Log::error('[Codex Device Auth] ' . $error);
+    }
+
+    /**
+     * Create a default Codex agent for all workspaces that don't have one.
+     */
+    private function createDefaultAgents(): void
+    {
+        try {
+            $controller = new \App\Http\Controllers\CodexAuthController();
+            $workspaces = \App\Models\Workspace::all();
+            foreach ($workspaces as $workspace) {
+                $controller->ensureDefaultAgentExists($workspace->id);
+            }
+        } catch (\Exception $e) {
+            Log::error('[Codex Device Auth] Failed to create default agents', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/www/app/Jobs/StartCodexDeviceAuthJob.php
+++ b/www/app/Jobs/StartCodexDeviceAuthJob.php
@@ -49,10 +49,18 @@ class StartCodexDeviceAuthJob implements ShouldQueue
             unlink($logFile);
         }
 
-        // Start device auth in background, redirect stdout+stderr to log file
+        // Start device auth in background, redirect stdout+stderr to log file.
+        // Capture the PID so we can kill the process on failure/timeout.
         $cmd = 'nohup ' . escapeshellarg($codexPath) . ' login --device-auth > '
-            . escapeshellarg($logFile) . ' 2>&1 &';
-        exec($cmd);
+            . escapeshellarg($logFile) . ' 2>&1 & echo $!';
+        $pidOutput = [];
+        exec($cmd, $pidOutput);
+        $pid = isset($pidOutput[0]) ? (int) trim($pidOutput[0]) : null;
+
+        if ($pid) {
+            // Store PID alongside the initial starting state so cleanup paths can kill it
+            Cache::put('codex_device_auth_pid', $pid, 1020);
+        }
 
         // Poll log file for URL and code (up to 30 seconds)
         $verificationUrl = null;
@@ -97,6 +105,7 @@ class StartCodexDeviceAuthJob implements ShouldQueue
         if (!$verificationUrl || !$userCode) {
             $rawLog = file_exists($logFile) ? file_get_contents($logFile) : '(empty)';
             Log::error('[Codex Device Auth] Could not parse URL/code', ['log' => $rawLog]);
+            $this->killBackgroundProcess();
             $this->failWithError(
                 'Could not get device code from Codex. Ensure Codex is properly installed and try again.'
             );
@@ -129,6 +138,7 @@ class StartCodexDeviceAuthJob implements ShouldQueue
                     Log::info('[Codex Device Auth] Authentication successful');
 
                     Cache::put('codex_device_auth', ['status' => 'authenticated'], 120);
+                    Cache::forget('codex_device_auth_pid');
 
                     // Create default Codex agent for all workspaces
                     $this->createDefaultAgents();
@@ -145,6 +155,7 @@ class StartCodexDeviceAuthJob implements ShouldQueue
 
         // Timed out without authentication
         Log::warning('[Codex Device Auth] Session expired without authentication');
+        $this->killBackgroundProcess();
         Cache::put('codex_device_auth', ['status' => 'expired'], 120);
 
         if (file_exists($logFile)) {
@@ -181,6 +192,27 @@ class StartCodexDeviceAuthJob implements ShouldQueue
         }
 
         return null;
+    }
+
+    /**
+     * Kill the background codex process started by this job, if a PID was recorded.
+     * Attempts POSIX process-group kill first, falls back to shell kill.
+     */
+    private function killBackgroundProcess(): void
+    {
+        $pid = Cache::pull('codex_device_auth_pid');
+        if (!$pid) {
+            return;
+        }
+
+        Log::info('[Codex Device Auth] Killing background process', ['pid' => $pid]);
+
+        if (function_exists('posix_kill')) {
+            // Send SIGTERM to the process group so child processes are also terminated
+            posix_kill(-$pid, SIGTERM);
+        } else {
+            exec('kill -TERM -- -' . (int) $pid . ' 2>/dev/null || kill -TERM ' . (int) $pid . ' 2>/dev/null');
+        }
     }
 
     /**

--- a/www/app/Services/CodexAgentService.php
+++ b/www/app/Services/CodexAgentService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Agent;
+use Illuminate\Support\Facades\Log;
+
+class CodexAgentService
+{
+    /**
+     * Ensure a default Codex agent exists for the given workspace.
+     */
+    public function ensureDefaultAgentExists(string $workspaceId): ?Agent
+    {
+        $existing = Agent::where('workspace_id', $workspaceId)
+            ->where('provider', 'codex')
+            ->where('is_default', true)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        $anyCodex = Agent::where('workspace_id', $workspaceId)
+            ->where('provider', 'codex')
+            ->first();
+
+        if ($anyCodex) {
+            return $anyCodex;
+        }
+
+        try {
+            return Agent::create([
+                'workspace_id' => $workspaceId,
+                'name' => 'Codex',
+                'slug' => 'codex-default',
+                'description' => 'Default Codex agent',
+                'provider' => 'codex',
+                'model' => config('ai.providers.codex.default_model', 'gpt-5.3-codex'),
+                'reasoning_config' => ['effort' => 'medium'],
+                'response_level' => 1,
+                'enabled' => true,
+                'is_default' => true,
+                'inherit_workspace_tools' => true,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('[Codex Auth] Failed to create default agent', [
+                'workspace_id' => $workspaceId,
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+    }
+}
+

--- a/www/public/scripts/codex-auth.sh
+++ b/www/public/scripts/codex-auth.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────────
+# PocketDev — Codex Auth Upload Script
+#
+# Runs `codex login` on your local machine (no org restrictions, uses your
+# browser), then automatically uploads the resulting auth.json to PocketDev.
+#
+# Usage:
+#   bash <(curl -s https://YOUR-POCKETDEV/scripts/codex-auth.sh) https://YOUR-POCKETDEV
+#
+# Or download and run manually:
+#   curl -O https://YOUR-POCKETDEV/scripts/codex-auth.sh
+#   bash codex-auth.sh https://YOUR-POCKETDEV
+#   bash codex-auth.sh https://user:pass@YOUR-POCKETDEV   # with Basic Auth
+# ─────────────────────────────────────────────────────────────────────────────
+set -e
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { echo -e "${CYAN}→${RESET} $*"; }
+success() { echo -e "${GREEN}✓${RESET} $*"; }
+warn()    { echo -e "${YELLOW}!${RESET} $*"; }
+error()   { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+header()  { echo -e "\n${BOLD}$*${RESET}"; }
+
+# ── Argument / env parsing ────────────────────────────────────────────────────
+PD_URL="${1:-${POCKETDEV_URL:-}}"
+
+if [ -z "$PD_URL" ]; then
+    echo -e "${BOLD}PocketDev Codex Auth Upload${RESET}"
+    echo ""
+    echo "Usage:"
+    echo "  $0 <pocketdev-url>"
+    echo "  $0 https://user:pass@pocketdev.example.com   # with Basic Auth"
+    echo ""
+    echo "Or set the POCKETDEV_URL environment variable:"
+    echo "  POCKETDEV_URL=https://pocketdev.example.com $0"
+    exit 1
+fi
+
+# Strip trailing slash
+PD_URL="${PD_URL%/}"
+
+header "PocketDev Codex Auth Upload"
+echo "Target: ${PD_URL}"
+echo ""
+
+# ── Step 1: Check for Node / npm ─────────────────────────────────────────────
+if ! command -v npm > /dev/null 2>&1; then
+    error "npm is not installed. Install Node.js from https://nodejs.org and try again."
+fi
+
+# ── Step 2: Install codex if missing ─────────────────────────────────────────
+if ! command -v codex > /dev/null 2>&1; then
+    warn "Codex is not installed. Installing now..."
+    npm install -g @openai/codex
+    success "Codex installed."
+else
+    success "Codex is already installed ($(codex --version 2>/dev/null || echo 'version unknown'))."
+fi
+
+# ── Step 3: Run codex login ───────────────────────────────────────────────────
+AUTH_FILE="$HOME/.codex/auth.json"
+
+info "Running 'codex login'..."
+echo "    A browser will open. Sign in with your ChatGPT account."
+echo ""
+
+codex login
+
+if [ ! -f "$AUTH_FILE" ]; then
+    error "auth.json not found at $AUTH_FILE. Did the login succeed?"
+fi
+
+success "Login complete. auth.json found."
+
+# ── Step 4: Build the JSON payload ───────────────────────────────────────────
+# We need to embed the auth.json content as a JSON string value.
+# Use Python3 (available on macOS & most Linux) or jq as fallback.
+
+AUTH_CONTENT=$(cat "$AUTH_FILE")
+
+if command -v python3 > /dev/null 2>&1; then
+    PAYLOAD=$(python3 -c "
+import json, sys
+content = sys.stdin.read()
+print(json.dumps({'json': content}))
+" <<< "$AUTH_CONTENT")
+elif command -v jq > /dev/null 2>&1; then
+    PAYLOAD=$(jq -n --arg content "$AUTH_CONTENT" '{"json": $content}')
+else
+    # Last resort: manual escaping (works for standard auth.json)
+    ESCAPED=$(printf '%s' "$AUTH_CONTENT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
+    PAYLOAD="{\"json\": \"${ESCAPED}\"}"
+fi
+
+# ── Step 5: Upload to PocketDev ───────────────────────────────────────────────
+info "Uploading auth.json to PocketDev..."
+
+HTTP_CODE=$(curl -s -o /tmp/pd_codex_response.json -w "%{http_code}" \
+    -X POST \
+    "${PD_URL}/api/codex/auth/upload" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD")
+
+RESPONSE=$(cat /tmp/pd_codex_response.json 2>/dev/null || echo '{}')
+rm -f /tmp/pd_codex_response.json
+
+# ── Step 6: Check result ──────────────────────────────────────────────────────
+if echo "$RESPONSE" | grep -q '"success":true'; then
+    echo ""
+    success "${BOLD}Codex is nu gekoppeld aan PocketDev!${RESET}"
+    echo ""
+    echo "  Je kunt nu Codex gebruiken in PocketDev."
+    echo "  Ga naar ${PD_URL} om te beginnen."
+    echo ""
+elif [ "$HTTP_CODE" = "400" ] && echo "$RESPONSE" | grep -q '"message"'; then
+    MSG=$(echo "$RESPONSE" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
+    error "Server error: $MSG"
+elif [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+    error "Toegang geweigerd (HTTP $HTTP_CODE). Voeg je Basic Auth credentials toe aan de URL:\n    $0 https://user:wachtwoord@jouw-pocketdev.com"
+elif [ "$HTTP_CODE" = "000" ]; then
+    error "Kon PocketDev niet bereiken. Controleer de URL en je internetverbinding:\n    ${PD_URL}"
+else
+    error "Upload mislukt (HTTP $HTTP_CODE):\n$RESPONSE"
+fi

--- a/www/public/scripts/codex-auth.sh
+++ b/www/public/scripts/codex-auth.sh
@@ -91,9 +91,7 @@ print(json.dumps({'json': content}))
 elif command -v jq > /dev/null 2>&1; then
     PAYLOAD=$(jq -n --arg content "$AUTH_CONTENT" '{"json": $content}')
 else
-    # Last resort: manual escaping (works for standard auth.json)
-    ESCAPED=$(printf '%s' "$AUTH_CONTENT" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$/\\n/g' | tr -d '\n')
-    PAYLOAD="{\"json\": \"${ESCAPED}\"}"
+    error "Could not build JSON payload safely. Please install python3 or jq and try again."
 fi
 
 # ── Step 5: Upload to PocketDev ───────────────────────────────────────────────
@@ -111,18 +109,18 @@ rm -f /tmp/pd_codex_response.json
 # ── Step 6: Check result ──────────────────────────────────────────────────────
 if echo "$RESPONSE" | grep -q '"success":true'; then
     echo ""
-    success "${BOLD}Codex is nu gekoppeld aan PocketDev!${RESET}"
+    success "${BOLD}Codex is now linked to PocketDev!${RESET}"
     echo ""
-    echo "  Je kunt nu Codex gebruiken in PocketDev."
-    echo "  Ga naar ${PD_URL} om te beginnen."
+    echo "  You can now use Codex in PocketDev."
+    echo "  Go to ${PD_URL} to get started."
     echo ""
 elif [ "$HTTP_CODE" = "400" ] && echo "$RESPONSE" | grep -q '"message"'; then
     MSG=$(echo "$RESPONSE" | grep -o '"message":"[^"]*"' | head -1 | cut -d'"' -f4)
     error "Server error: $MSG"
 elif [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
-    error "Toegang geweigerd (HTTP $HTTP_CODE). Voeg je Basic Auth credentials toe aan de URL:\n    $0 https://user:wachtwoord@jouw-pocketdev.com"
+    error "Access denied (HTTP $HTTP_CODE). Add your Basic Auth credentials to the URL:\n    $0 https://user:password@your-pocketdev.com"
 elif [ "$HTTP_CODE" = "000" ]; then
-    error "Kon PocketDev niet bereiken. Controleer de URL en je internetverbinding:\n    ${PD_URL}"
+    error "Could not reach PocketDev. Check the URL and your internet connection:\n    ${PD_URL}"
 else
-    error "Upload mislukt (HTTP $HTTP_CODE):\n$RESPONSE"
+    error "Upload failed (HTTP $HTTP_CODE):\n$RESPONSE"
 fi

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -91,7 +91,7 @@
                             @click="startAuth()"
                             class="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
                         >
-                            Login met ChatGPT
+                            Login with ChatGPT
                         </button>
                     </div>
 
@@ -194,13 +194,13 @@
                         </div>
                         <!-- Org restriction help -->
                         <div class="bg-yellow-900/20 border border-yellow-700/50 rounded-lg p-4 text-sm">
-                            <p class="text-yellow-400 font-semibold mb-1">💡 Ziet je de fout "neem contact op met je werkruimtebeheerder"?</p>
+                            <p class="text-yellow-400 font-semibold mb-1">💡 Seeing the error "contact your workspace administrator"?</p>
                             <p class="text-yellow-200/70 mb-3">
-                                Jouw OpenAI-organisatie heeft device-auth uitgeschakeld. Gebruik dan de <strong class="text-white">Via laptop / SSH</strong> tab —
-                                twee copy-paste commando's die werken zonder die beperking.
+                                Your OpenAI organization has disabled device auth. Use the <strong class="text-white">Via laptop / SSH</strong> tab instead —
+                                two copy-paste commands that work without that restriction.
                             </p>
                             <button onclick="switchTab('laptop')" class="px-4 py-1.5 bg-yellow-700/60 hover:bg-yellow-700 rounded text-xs font-medium text-yellow-100 transition-colors">
-                                Naar "Via laptop / SSH" →
+                                Go to "Via laptop / SSH" →
                             </button>
                         </div>
                     </div>
@@ -210,15 +210,15 @@
                 @php
                     $pdUrl = url('/');
                     $linux1 = 'npm install -g @openai/codex && codex login';
-                    $linux2 = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
-                    $linuxAll = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                    $linux2 = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Done!'";
+                    $linuxAll = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Done!'";
                     $win1 = 'npm install -g @openai/codex; codex login';
-                    $win2 = "\$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
-                    $winAll = "npm install -g @openai/codex; codex login; \$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
+                    $win2 = "\$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Done!'";
+                    $winAll = "npm install -g @openai/codex; codex login; \$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Done!'";
                 @endphp
                 <div id="content-laptop" class="tab-content hidden" x-data="{ os: 'linux' }">
-                    <p class="text-gray-300 mb-1">Draai deze commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
-                    <p class="text-sm text-gray-400 mb-4">Werkt altijd — geen org-restricties, geen device-auth nodig.</p>
+                    <p class="text-gray-300 mb-1">Run these commands on your <strong class="text-white">laptop, desktop, or via SSH</strong>.</p>
+                    <p class="text-sm text-gray-400 mb-4">Always works — no org restrictions, no device auth required.</p>
 
                     <!-- OS toggle -->
                     <div class="flex gap-2 mb-6">
@@ -234,9 +234,9 @@
                         >🪟 Windows (PowerShell)</button>
                     </div>
 
-                    <!-- Stap 1 -->
+                    <!-- Step 1 -->
                     <div class="mb-5">
-                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 1 — Installeer Codex en log in</p>
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 1 — Install Codex and log in</p>
                         <div class="flex items-center gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
                             <code class="text-green-400 text-sm flex-1 select-all" x-text="os === 'linux' ? {{ json_encode($linux1) }} : {{ json_encode($win1) }}"></code>
                             <button
@@ -244,12 +244,12 @@
                                 class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all"
                             >📋 Copy</button>
                         </div>
-                        <p class="text-xs text-gray-500 mt-1.5">Dit opent een browser om in te loggen met je ChatGPT-account.</p>
+                        <p class="text-xs text-gray-500 mt-1.5">This opens a browser to sign in with your ChatGPT account.</p>
                     </div>
 
-                    <!-- Stap 2 -->
+                    <!-- Step 2 -->
                     <div class="mb-5">
-                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 2 — Upload auth.json naar PocketDev</p>
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 2 — Upload auth.json to PocketDev</p>
                         <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
                             <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linux2) }} : {{ json_encode($win2) }}"></code>
                             <button
@@ -257,12 +257,12 @@
                                 class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
                             >📋 Copy</button>
                         </div>
-                        <p class="text-xs text-gray-500 mt-1.5">Voert stap 2 pas uit nadat je bent ingelogd in stap 1.</p>
+                        <p class="text-xs text-gray-500 mt-1.5">Run step 2 only after you complete sign-in in step 1.</p>
                     </div>
 
-                    <!-- Alles in één -->
+                    <!-- All in one -->
                     <div class="border-t border-gray-700 pt-4">
-                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Of alles in één commando</p>
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Or run everything in one command</p>
                         <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
                             <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linuxAll) }} : {{ json_encode($winAll) }}"></code>
                             <button
@@ -278,11 +278,11 @@
 
                     <!-- Option A: one-liner script (recommended) -->
                     <div class="mb-6">
-                        <p class="text-gray-300 font-medium mb-1">Optie A — Automatisch (aanbevolen)</p>
+                        <p class="text-gray-300 font-medium mb-1">Option A — Automatic (recommended)</p>
                         <p class="text-sm text-gray-400 mb-3">
-                            Draai dit commando op je <strong class="text-white">laptop of desktop</strong> met een browser.
-                            Het script installeert Codex, doet <code class="text-green-400">codex login</code> en
-                            uploadt <code class="text-green-400">auth.json</code> automatisch naar PocketDev.
+                            Run this command on your <strong class="text-white">laptop or desktop</strong> with a browser.
+                            The script installs Codex, runs <code class="text-green-400">codex login</code>, and
+                            uploads <code class="text-green-400">auth.json</code> to PocketDev automatically.
                         </p>
                         <div class="relative group">
                             <div class="bg-gray-900 rounded-lg border border-gray-700 p-3 font-mono text-sm text-green-400 overflow-x-auto pr-24">
@@ -294,38 +294,38 @@
                             >📋 Copy</button>
                         </div>
                         <p class="text-xs text-gray-500 mt-2">
-                            Werkt op macOS en Linux. Vereist Node.js/npm.
-                            Voeg je Basic Auth credentials toe als je die hebt:
+                            Works on macOS and Linux. Requires Node.js/npm.
+                            Add your Basic Auth credentials if needed:
                             <code class="text-gray-400">bash &lt;(curl ...) https://user:pass@{{ request()->getHost() }}</code>
                         </p>
                     </div>
 
                     <div class="flex items-center gap-3 my-4">
                         <div class="flex-1 border-t border-gray-700"></div>
-                        <span class="text-xs text-gray-500">of handmatig</span>
+                        <span class="text-xs text-gray-500">or manual</span>
                         <div class="flex-1 border-t border-gray-700"></div>
                     </div>
 
                     <!-- Option B: file upload or manual paste -->
                     <div>
-                        <p class="text-gray-300 font-medium mb-1">Optie B — Bestand uploaden of plakken</p>
+                        <p class="text-gray-300 font-medium mb-1">Option B — Upload or paste file</p>
                         <p class="text-sm text-gray-400 mb-3">
-                            Draai <code class="text-green-400">codex login</code> op een machine met browser.
-                            Selecteer daarna het <code class="text-green-400">auth.json</code> bestand, of plak de inhoud hieronder.
+                            Run <code class="text-green-400">codex login</code> on a machine with a browser.
+                            Then select the <code class="text-green-400">auth.json</code> file, or paste the contents below.
                         </p>
                         <form id="json-form" class="space-y-3">
                             <!-- File picker -->
                             <div class="flex items-center gap-3">
                                 <label class="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded cursor-pointer text-sm text-gray-200 transition-colors">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
-                                    Selecteer auth.json
+                                    Select auth.json
                                     <input type="file" id="json-file" accept=".json,application/json" class="hidden">
                                 </label>
-                                <span id="file-name" class="text-xs text-gray-500">Geen bestand geselecteerd</span>
+                                <span id="file-name" class="text-xs text-gray-500">No file selected</span>
                             </div>
                             <!-- Path hints with copy buttons -->
                             <div class="bg-gray-900/60 rounded-lg border border-gray-700/50 p-3 space-y-2">
-                                <p class="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">Bestandslocatie</p>
+                                <p class="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">File location</p>
                                 <div class="flex items-center gap-2">
                                     <span class="text-xs text-gray-500 w-24 shrink-0">🪟 Windows</span>
                                     <code class="text-xs text-gray-300 flex-1">%USERPROFILE%\.codex\auth.json</code>
@@ -341,7 +341,7 @@
                             <textarea id="json-input" rows="4" placeholder='{"OPENAI_API_KEY": "sk-proj-..."}'
                                 class="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm font-mono focus:outline-none focus:border-blue-500"></textarea>
                             <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                                Opslaan
+                                Save
                             </button>
                         </form>
                         <div id="json-result" class="mt-4"></div>

--- a/www/resources/views/codex-auth.blade.php
+++ b/www/resources/views/codex-auth.blade.php
@@ -6,6 +6,7 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Codex Authentication</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.8/dist/cdn.min.js"></script>
 </head>
 <body class="antialiased bg-gray-900 text-gray-100">
     <div class="min-h-screen flex items-center justify-center p-4">
@@ -64,68 +65,291 @@
 
                 <!-- Tabs -->
                 <div class="flex space-x-2 mb-6 border-b border-gray-700">
-                    <button onclick="switchTab('docker')" id="tab-docker" class="tab-btn px-4 py-2 -mb-px border-b-2 border-blue-500 text-blue-400">
-                        Subscription (Recommended)
+                    <button onclick="switchTab('device')" id="tab-device" class="tab-btn px-4 py-2 -mb-px border-b-2 border-blue-500 text-blue-400">
+                        Via PocketDev UI
+                    </button>
+                    <button onclick="switchTab('laptop')" id="tab-laptop" class="tab-btn px-4 py-2 -mb-px border-b-2 border-transparent text-gray-400 hover:text-gray-300">
+                        Via laptop / SSH
                     </button>
                     <button onclick="switchTab('json')" id="tab-json" class="tab-btn px-4 py-2 -mb-px border-b-2 border-transparent text-gray-400 hover:text-gray-300">
                         API Key
                     </button>
                 </div>
 
-                <!-- Docker Exec Tab (Subscription) -->
-                <div id="content-docker" class="tab-content">
-                    <p class="text-gray-300 mb-4">Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise):</p>
-                    @if(config('backup.user_id') !== null)
-                        <div class="bg-gray-900 rounded p-4 mb-4">
-                            <code class="text-sm text-green-400">docker exec -it -u {{ config('backup.user_id') }} {{ config('pocketdev.project_name', 'pocket-dev') }}-queue codex login --device-auth</code>
+                <!-- Inline Device Auth Tab (Subscription) -->
+                <div id="content-device" class="tab-content" x-data="codexDeviceAuth()">
+
+                    <!-- Idle state: show start button -->
+                    <div x-show="state === 'idle'">
+                        <p class="text-gray-300 mb-2">
+                            Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise).
+                        </p>
+                        <p class="text-sm text-gray-400 mb-6">
+                            Works on any device — no terminal, no Docker commands needed.
+                        </p>
+                        <button
+                            @click="startAuth()"
+                            class="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
+                        >
+                            Login met ChatGPT
+                        </button>
+                    </div>
+
+                    <!-- Starting state: spinner -->
+                    <div x-show="state === 'starting'" class="text-center py-8">
+                        <svg class="animate-spin w-8 h-8 mx-auto text-blue-400 mb-3" fill="none" viewBox="0 0 24 24">
+                            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                            <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                        </svg>
+                        <p class="text-gray-400">Connecting to OpenAI...</p>
+                    </div>
+
+                    <!-- Ready state: show URL and code -->
+                    <div x-show="state === 'ready'" style="display:none">
+                        <p class="text-gray-300 mb-6 text-sm">
+                            Open the link below on your phone or another browser window, then enter the code when prompted.
+                        </p>
+
+                        <!-- Step 1: URL -->
+                        <div class="mb-6">
+                            <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 1 — Open this link</p>
+                            <div class="flex items-center gap-3 bg-gray-900 rounded-lg p-3 border border-gray-700">
+                                <span class="text-blue-400 text-sm font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                                <a
+                                    :href="verificationUrl"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="flex-shrink-0 px-3 py-1.5 rounded text-sm bg-gray-700 hover:bg-gray-600 text-gray-300 transition-all"
+                                    title="Open in new tab"
+                                >↗ Open</a>
+                                <button
+                                    @click="copyUrl()"
+                                    class="flex-shrink-0 px-3 py-1.5 rounded text-sm transition-all"
+                                    :class="urlCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                >
+                                    <span x-show="!urlCopied">📋 Copy</span>
+                                    <span x-show="urlCopied">✓ Copied!</span>
+                                </button>
+                            </div>
                         </div>
-                    @else
-                        <div class="bg-red-900/50 border border-red-500 rounded p-4 mb-4 text-red-300 text-sm">
-                            <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">USER_ID</code> in your .env file (run <code>id -u</code> to get the value).
+
+                        <!-- Step 2: Code -->
+                        <div class="mb-6">
+                            <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Step 2 — Enter this code</p>
+                            <div class="flex items-center gap-4">
+                                <div class="bg-gray-900 border border-gray-600 rounded-lg px-6 py-4">
+                                    <span class="text-3xl font-mono font-bold tracking-widest text-white" x-text="userCode"></span>
+                                </div>
+                                <button
+                                    @click="copyCode()"
+                                    class="px-4 py-2 rounded-lg text-sm font-medium transition-all"
+                                    :class="codeCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                >
+                                    <span x-show="!codeCopied">📋 Copy code</span>
+                                    <span x-show="codeCopied">✓ Copied!</span>
+                                </button>
+                            </div>
                         </div>
-                    @endif
-                    <ol class="list-decimal list-inside space-y-2 text-sm text-gray-300 mb-4">
-                        <li>Copy the command above and run it in your terminal</li>
-                        <li>A URL and device code will appear</li>
-                        <li>Open the URL in your browser: <code class="text-blue-400">https://auth.openai.com/codex/device</code></li>
-                        <li>Enter the device code and sign in with your ChatGPT account</li>
-                        <li>Come back here and refresh the page</li>
-                    </ol>
-                    <button onclick="window.location.reload()" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                        Refresh Page
-                    </button>
+
+                        <!-- Waiting indicator + countdown -->
+                        <div class="flex items-center gap-3 text-sm text-gray-400">
+                            <svg class="animate-spin w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24">
+                                <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                            </svg>
+                            <span>Waiting for authentication…</span>
+                            <span class="text-gray-500">(expires in <span class="font-mono" x-text="countdown"></span>)</span>
+                        </div>
+                    </div>
+
+                    <!-- Authenticated! -->
+                    <div x-show="state === 'authenticated'" style="display:none" class="text-center py-8">
+                        <div class="text-5xl mb-4">✅</div>
+                        <p class="text-green-400 font-semibold text-lg mb-2">Successfully authenticated!</p>
+                        <p class="text-gray-400 text-sm mb-6">Your ChatGPT subscription is now connected to PocketDev.</p>
+                        <button
+                            onclick="window.location.reload()"
+                            class="px-6 py-3 bg-green-600 hover:bg-green-700 rounded-lg font-semibold transition-colors"
+                        >
+                            Reload Page
+                        </button>
+                    </div>
+
+                    <!-- Expired or failed -->
+                    <div x-show="state === 'expired' || state === 'failed'" style="display:none">
+                        <div class="bg-red-900/30 border border-red-700 rounded-lg p-4 mb-4">
+                            <p class="text-red-400 font-semibold mb-1">
+                                <span x-show="state === 'expired'">Code expired</span>
+                                <span x-show="state === 'failed'">Authentication failed</span>
+                            </p>
+                            <p class="text-red-300 text-sm" x-text="error || (state === 'expired' ? 'The code expired before authentication completed.' : 'Please try again.')"></p>
+                        </div>
+                        <div class="flex gap-3 flex-wrap mb-6">
+                            <button
+                                @click="reset(); startAuth()"
+                                class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors text-sm"
+                            >
+                                Try again
+                            </button>
+                        </div>
+                        <!-- Org restriction help -->
+                        <div class="bg-yellow-900/20 border border-yellow-700/50 rounded-lg p-4 text-sm">
+                            <p class="text-yellow-400 font-semibold mb-1">💡 Ziet je de fout "neem contact op met je werkruimtebeheerder"?</p>
+                            <p class="text-yellow-200/70 mb-3">
+                                Jouw OpenAI-organisatie heeft device-auth uitgeschakeld. Gebruik dan de <strong class="text-white">Via laptop / SSH</strong> tab —
+                                twee copy-paste commando's die werken zonder die beperking.
+                            </p>
+                            <button onclick="switchTab('laptop')" class="px-4 py-1.5 bg-yellow-700/60 hover:bg-yellow-700 rounded text-xs font-medium text-yellow-100 transition-colors">
+                                Naar "Via laptop / SSH" →
+                            </button>
+                        </div>
+                    </div>
                 </div>
 
-                <!-- API Key Tab -->
+                <!-- Via laptop / SSH tab -->
+                @php
+                    $pdUrl = url('/');
+                    $linux1 = 'npm install -g @openai/codex && codex login';
+                    $linux2 = "python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                    $linuxAll = "npm install -g @openai/codex && codex login && python3 -c \"import json,os; print(json.dumps({'json': open(os.path.expanduser('~/.codex/auth.json')).read()}))\" | curl -s -X POST '{$pdUrl}/api/codex/auth/upload' -H 'Content-Type: application/json' -d @- && echo '✓ Klaar!'";
+                    $win1 = 'npm install -g @openai/codex; codex login';
+                    $win2 = "\$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
+                    $winAll = "npm install -g @openai/codex; codex login; \$auth = (Get-Content \"\$env:USERPROFILE\\.codex\\auth.json\" -Raw -Encoding UTF8).Trim(); \$body = [System.Text.Encoding]::UTF8.GetBytes('{\"json\":' + (\$auth | ConvertTo-Json -Compress) + '}'); Invoke-RestMethod -Uri '{$pdUrl}/api/codex/auth/upload' -Method Post -ContentType 'application/json' -Body \$body; Write-Host '✓ Klaar!'";
+                @endphp
+                <div id="content-laptop" class="tab-content hidden" x-data="{ os: 'linux' }">
+                    <p class="text-gray-300 mb-1">Draai deze commando's op je <strong class="text-white">laptop, desktop of via SSH</strong>.</p>
+                    <p class="text-sm text-gray-400 mb-4">Werkt altijd — geen org-restricties, geen device-auth nodig.</p>
+
+                    <!-- OS toggle -->
+                    <div class="flex gap-2 mb-6">
+                        <button
+                            @click="os = 'linux'"
+                            :class="os === 'linux' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-400 hover:bg-gray-600'"
+                            class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
+                        >🐧 Linux / macOS</button>
+                        <button
+                            @click="os = 'windows'"
+                            :class="os === 'windows' ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-400 hover:bg-gray-600'"
+                            class="px-4 py-1.5 rounded-full text-sm font-medium transition-colors"
+                        >🪟 Windows (PowerShell)</button>
+                    </div>
+
+                    <!-- Stap 1 -->
+                    <div class="mb-5">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 1 — Installeer Codex en log in</p>
+                        <div class="flex items-center gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 select-all" x-text="os === 'linux' ? {{ json_encode($linux1) }} : {{ json_encode($win1) }}"></code>
+                            <button
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linux1) }} : {{ json_encode($win1) }})"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all"
+                            >📋 Copy</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1.5">Dit opent een browser om in te loggen met je ChatGPT-account.</p>
+                    </div>
+
+                    <!-- Stap 2 -->
+                    <div class="mb-5">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Stap 2 — Upload auth.json naar PocketDev</p>
+                        <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linux2) }} : {{ json_encode($win2) }}"></code>
+                            <button
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linux2) }} : {{ json_encode($win2) }})"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
+                            >📋 Copy</button>
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1.5">Voert stap 2 pas uit nadat je bent ingelogd in stap 1.</p>
+                    </div>
+
+                    <!-- Alles in één -->
+                    <div class="border-t border-gray-700 pt-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-2">Of alles in één commando</p>
+                        <div class="flex items-start gap-2 bg-gray-900 rounded-lg border border-gray-700 p-3">
+                            <code class="text-green-400 text-sm flex-1 break-all select-all" x-text="os === 'linux' ? {{ json_encode($linuxAll) }} : {{ json_encode($winAll) }}"></code>
+                            <button
+                                @click="copyCmd($el, os === 'linux' ? {{ json_encode($linuxAll) }} : {{ json_encode($winAll) }})"
+                                class="flex-shrink-0 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 rounded text-sm transition-all mt-0.5"
+                            >📋 Copy</button>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Upload script / Manual tab -->
                 <div id="content-json" class="tab-content hidden">
-                    <p class="text-gray-300 mb-4">Use an OpenAI API key for pay-per-use access:</p>
 
-                    @if(config('backup.user_id') !== null)
-                        <div class="bg-gray-900/50 border border-gray-700 rounded p-4 mb-4 text-sm">
-                            <p class="text-gray-400 mb-2"><strong>Option 1:</strong> CLI command</p>
-                            <code class="text-green-400">echo "sk-your-key" | docker exec -i -u {{ config('backup.user_id') }} {{ config('pocketdev.project_name', 'pocket-dev') }}-queue codex login --with-api-key</code>
+                    <!-- Option A: one-liner script (recommended) -->
+                    <div class="mb-6">
+                        <p class="text-gray-300 font-medium mb-1">Optie A — Automatisch (aanbevolen)</p>
+                        <p class="text-sm text-gray-400 mb-3">
+                            Draai dit commando op je <strong class="text-white">laptop of desktop</strong> met een browser.
+                            Het script installeert Codex, doet <code class="text-green-400">codex login</code> en
+                            uploadt <code class="text-green-400">auth.json</code> automatisch naar PocketDev.
+                        </p>
+                        <div class="relative group">
+                            <div class="bg-gray-900 rounded-lg border border-gray-700 p-3 font-mono text-sm text-green-400 overflow-x-auto pr-24">
+                                bash &lt;(curl -sL {{ route('codex.auth.downloadScript') }})
+                            </div>
+                            <button
+                                onclick="copyScriptCmd(this)"
+                                class="absolute right-2 top-2 px-2.5 py-1 bg-gray-700 hover:bg-gray-600 rounded text-xs text-gray-300 transition-all"
+                            >📋 Copy</button>
                         </div>
-                    @else
-                        <div class="bg-red-900/50 border border-red-500 rounded p-4 mb-4 text-red-300 text-sm">
-                            <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">USER_ID</code> in your .env file (run <code>id -u</code> to get the value).
-                        </div>
-                    @endif
+                        <p class="text-xs text-gray-500 mt-2">
+                            Werkt op macOS en Linux. Vereist Node.js/npm.
+                            Voeg je Basic Auth credentials toe als je die hebt:
+                            <code class="text-gray-400">bash &lt;(curl ...) https://user:pass@{{ request()->getHost() }}</code>
+                        </p>
+                    </div>
 
-                    <p class="text-gray-400 mb-2"><strong>Option 2:</strong> Paste auth.json content below</p>
-                    <form id="json-form" class="space-y-4">
-                        <div>
+                    <div class="flex items-center gap-3 my-4">
+                        <div class="flex-1 border-t border-gray-700"></div>
+                        <span class="text-xs text-gray-500">of handmatig</span>
+                        <div class="flex-1 border-t border-gray-700"></div>
+                    </div>
+
+                    <!-- Option B: file upload or manual paste -->
+                    <div>
+                        <p class="text-gray-300 font-medium mb-1">Optie B — Bestand uploaden of plakken</p>
+                        <p class="text-sm text-gray-400 mb-3">
+                            Draai <code class="text-green-400">codex login</code> op een machine met browser.
+                            Selecteer daarna het <code class="text-green-400">auth.json</code> bestand, of plak de inhoud hieronder.
+                        </p>
+                        <form id="json-form" class="space-y-3">
+                            <!-- File picker -->
+                            <div class="flex items-center gap-3">
+                                <label class="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded cursor-pointer text-sm text-gray-200 transition-colors">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+                                    Selecteer auth.json
+                                    <input type="file" id="json-file" accept=".json,application/json" class="hidden">
+                                </label>
+                                <span id="file-name" class="text-xs text-gray-500">Geen bestand geselecteerd</span>
+                            </div>
+                            <!-- Path hints with copy buttons -->
+                            <div class="bg-gray-900/60 rounded-lg border border-gray-700/50 p-3 space-y-2">
+                                <p class="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">Bestandslocatie</p>
+                                <div class="flex items-center gap-2">
+                                    <span class="text-xs text-gray-500 w-24 shrink-0">🪟 Windows</span>
+                                    <code class="text-xs text-gray-300 flex-1">%USERPROFILE%\.codex\auth.json</code>
+                                    <button type="button" onclick="copyCmd(this, '%USERPROFILE%\\.codex\\auth.json')" class="text-xs px-2 py-0.5 bg-gray-700 hover:bg-gray-600 text-gray-400 rounded transition-all">📋</button>
+                                </div>
+                                <div class="flex items-center gap-2">
+                                    <span class="text-xs text-gray-500 w-24 shrink-0">🐧 macOS/Linux</span>
+                                    <code class="text-xs text-gray-300 flex-1">~/.codex/auth.json</code>
+                                    <button type="button" onclick="copyCmd(this, '~/.codex/auth.json')" class="text-xs px-2 py-0.5 bg-gray-700 hover:bg-gray-600 text-gray-400 rounded transition-all">📋</button>
+                                </div>
+                            </div>
+                            <!-- Textarea (filled by file picker, or paste manually) -->
                             <textarea id="json-input" rows="4" placeholder='{"OPENAI_API_KEY": "sk-proj-..."}'
                                 class="w-full px-3 py-2 bg-gray-900 border border-gray-700 rounded text-sm font-mono focus:outline-none focus:border-blue-500"></textarea>
-                        </div>
-                        <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
-                            Save Credentials
-                        </button>
-                    </form>
-                    <div id="json-result" class="mt-4"></div>
+                            <button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded">
+                                Opslaan
+                            </button>
+                        </form>
+                        <div id="json-result" class="mt-4"></div>
+                    </div>
                 </div>
             </div>
 
-            <!-- Instructions -->
+            <!-- Info block -->
             <div class="bg-gray-800 rounded-lg p-6 border border-gray-700 text-sm">
                 <h3 class="font-semibold mb-2">About Codex Authentication:</h3>
                 <ul class="list-disc list-inside space-y-1 text-gray-300">
@@ -137,35 +361,212 @@
             </div>
             @endif
 
-            <!-- Back to Chat -->
-            @if($status["authenticated"])
-            <div class="text-center">
+            <!-- Navigation -->
+            <div class="text-center space-x-4">
+                <a href="{{ route('config.credentials') }}" class="inline-block px-6 py-3 bg-gray-700 hover:bg-gray-600 rounded-lg">
+                    Back to Settings
+                </a>
+                @if($status["authenticated"])
                 <a href="{{ url('/') }}" class="inline-block px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg">
                     Go to Chat
                 </a>
+                @endif
             </div>
-            @endif
         </div>
     </div>
 
     <script>
+        // ── Copy script command ────────────────────────────────────────────────────
+        // Generic copy-with-feedback for any button
+        function copyCmd(btn, text) {
+            navigator.clipboard.writeText(text).then(() => {
+                const orig = btn.textContent;
+                btn.textContent = '✓ Gekopieerd!';
+                btn.classList.add('bg-green-700', 'text-green-200');
+                btn.classList.remove('bg-gray-700', 'text-gray-300');
+                setTimeout(() => {
+                    btn.textContent = orig;
+                    btn.classList.remove('bg-green-700', 'text-green-200');
+                    btn.classList.add('bg-gray-700', 'text-gray-300');
+                }, 2000);
+            });
+        }
+
+        function copyScriptCmd(btn) {
+            const text = btn.previousElementSibling.textContent.trim()
+                .replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+            copyCmd(btn, text);
+        }
+
+        // ── Tab switching ──────────────────────────────────────────────────────────
         function switchTab(tab) {
-            // Hide all content
             document.querySelectorAll('.tab-content').forEach(el => el.classList.add('hidden'));
-            // Reset all tabs
             document.querySelectorAll('.tab-btn').forEach(el => {
                 el.classList.remove('border-blue-500', 'text-blue-400');
                 el.classList.add('border-transparent', 'text-gray-400');
             });
-            // Show selected content
             document.getElementById('content-' + tab).classList.remove('hidden');
-            // Highlight selected tab
             const activeTab = document.getElementById('tab-' + tab);
             activeTab.classList.remove('border-transparent', 'text-gray-400');
             activeTab.classList.add('border-blue-500', 'text-blue-400');
         }
 
-        // JSON form
+        // ── File picker → textarea ────────────────────────────────────────────────
+        document.getElementById('json-file')?.addEventListener('change', function (e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            document.getElementById('file-name').textContent = file.name;
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+                document.getElementById('json-input').value = ev.target.result;
+            };
+            reader.readAsText(file, 'UTF-8');
+        });
+
+        // ── Device auth Alpine component ───────────────────────────────────────────
+        function codexDeviceAuth() {
+            return {
+                state: 'idle',   // idle | starting | ready | authenticated | expired | failed
+                verificationUrl: '',
+                userCode: '',
+                expiresIn: 900,
+                urlCopied: false,
+                codeCopied: false,
+                error: '',
+                _pollTimer: null,
+                _countdownTimer: null,
+
+                get countdown() {
+                    const m = Math.floor(this.expiresIn / 60);
+                    const s = this.expiresIn % 60;
+                    return `${m}:${String(s).padStart(2, '0')}`;
+                },
+
+                async init() {
+                    // Resume any session already in progress (e.g. after page reload)
+                    await this.checkStatus();
+                },
+
+                async startAuth() {
+                    this.state = 'starting';
+                    this.error = '';
+
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStart') }}', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            }
+                        });
+                        const data = await res.json();
+
+                        if (!data.success) {
+                            this.state = 'failed';
+                            this.error = data.error || 'Unknown error';
+                            return;
+                        }
+
+                        this._applyStatus(data);
+                        this._startPolling();
+                    } catch (e) {
+                        this.state = 'failed';
+                        this.error = e.message;
+                    }
+                },
+
+                _startPolling() {
+                    if (this._pollTimer) clearInterval(this._pollTimer);
+                    this._pollTimer = setInterval(() => this.checkStatus(), 2500);
+                },
+
+                async checkStatus() {
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStatus') }}');
+                        const data = await res.json();
+                        this._applyStatus(data);
+                    } catch (e) {
+                        // Network error — keep polling silently
+                    }
+                },
+
+                _applyStatus(data) {
+                    const status = data.status;
+
+                    if (status === 'ready' && this.state !== 'ready') {
+                        this.state = 'ready';
+                        this.verificationUrl = data.verification_url || '';
+                        this.userCode = data.user_code || '';
+                        this.expiresIn = data.expires_in ?? 900;
+                        this._startCountdown();
+                        if (!this._pollTimer) this._startPolling();
+                    } else if (status === 'ready') {
+                        // Already showing — sync expiry
+                        if (data.expires_in !== undefined) this.expiresIn = data.expires_in;
+                    } else if (status === 'authenticated') {
+                        this.state = 'authenticated';
+                        this._stopTimers();
+                    } else if (status === 'failed') {
+                        this.state = 'failed';
+                        this.error = data.error || 'Authentication failed';
+                        this._stopTimers();
+                    } else if (status === 'expired') {
+                        this.state = 'expired';
+                        this._stopTimers();
+                    } else if (status === 'starting' && this.state === 'idle') {
+                        this.state = 'starting';
+                        this._startPolling();
+                    }
+                    // 'none': nothing to do (still idle)
+                },
+
+                _startCountdown() {
+                    if (this._countdownTimer) clearInterval(this._countdownTimer);
+                    this._countdownTimer = setInterval(() => {
+                        if (this.expiresIn > 0) {
+                            this.expiresIn--;
+                        } else {
+                            this.state = 'expired';
+                            this._stopTimers();
+                        }
+                    }, 1000);
+                },
+
+                _stopTimers() {
+                    if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+                    if (this._countdownTimer) { clearInterval(this._countdownTimer); this._countdownTimer = null; }
+                },
+
+                reset() {
+                    this._stopTimers();
+                    this.state = 'idle';
+                    this.verificationUrl = '';
+                    this.userCode = '';
+                    this.expiresIn = 900;
+                    this.error = '';
+                    this.urlCopied = false;
+                    this.codeCopied = false;
+                },
+
+                async copyUrl() {
+                    try {
+                        await navigator.clipboard.writeText(this.verificationUrl);
+                        this.urlCopied = true;
+                        setTimeout(() => { this.urlCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+
+                async copyCode() {
+                    try {
+                        await navigator.clipboard.writeText(this.userCode);
+                        this.codeCopied = true;
+                        setTimeout(() => { this.codeCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+            };
+        }
+
+        // ── JSON (API Key) form ────────────────────────────────────────────────────
         document.getElementById('json-form')?.addEventListener('submit', async (e) => {
             e.preventDefault();
             const jsonInput = document.getElementById('json-input').value;
@@ -198,7 +599,7 @@
             }
         });
 
-        // Logout
+        // ── Logout ─────────────────────────────────────────────────────────────────
         async function logout() {
             if (!confirm('Are you sure you want to clear your credentials?')) {
                 return;
@@ -225,11 +626,16 @@
             }
         }
 
-        // Helper function
+        // ── Helper ─────────────────────────────────────────────────────────────────
         function showResult(elementId, type, message) {
             const element = document.getElementById(elementId);
-            const bgColor = type === 'success' ? 'bg-green-900/30 border-green-700 text-green-400' : 'bg-red-900/30 border-red-700 text-red-400';
-            element.innerHTML = `<div class="border rounded p-3 ${bgColor}">${message}</div>`;
+            const bgColor = type === 'success'
+                ? 'bg-green-900/30 border-green-700 text-green-400'
+                : 'bg-red-900/30 border-red-700 text-red-400';
+            const div = document.createElement('div');
+            div.className = `border rounded p-3 ${bgColor}`;
+            div.textContent = message;
+            element.replaceChildren(div);
         }
     </script>
 </body>

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -117,11 +117,11 @@
                 @if(config('backup.user_id') !== null)
                     <div class="relative">
                         <div
-                            @click="copyCommand('docker exec -it -u {{ config('backup.user_id') }} {{ config('pocketdev.project_name', 'pocket-dev') }}-queue claude', 'claude')"
+                            @click="copyCommand('docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude', 'claude')"
                             class="bg-gray-900 rounded p-3 font-mono text-sm text-green-400 cursor-pointer hover:bg-gray-800 transition-colors mb-3"
                             title="Click to copy"
                         >
-                            docker exec -it -u {{ config('backup.user_id') }} {{ config('pocketdev.project_name', 'pocket-dev') }}-queue claude
+                            docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude
                         </div>
                         <div
                             x-show="copiedCommand === 'claude'"
@@ -153,45 +153,123 @@
 
             {{-- Codex Setup (conditional) --}}
             @if(!$hasCodex)
-            <div x-show="provider === 'codex'" x-cloak class="bg-gray-800 rounded-lg p-6">
+            <div x-show="provider === 'codex'" x-cloak class="bg-gray-800 rounded-lg p-6" x-data="wizardCodexDeviceAuth()">
                 <h3 class="text-lg font-semibold mb-3">Codex Setup</h3>
-                <p class="text-sm text-gray-400 mb-4">
-                    Run this command on your <strong class="text-white">host machine</strong> (not in Docker) to authenticate:
-                </p>
-                @if(config('backup.user_id') !== null && config('backup.group_id') !== null)
-                    <div class="relative">
-                        <div
-                            @click="copyCommand('sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json {{ config('pocketdev.project_name', 'pocket-dev') }}-queue:/home/appuser/.codex/auth.json && docker exec -u root {{ config('pocketdev.project_name', 'pocket-dev') }}-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec {{ config('pocketdev.project_name', 'pocket-dev') }}-queue chmod 600 /home/appuser/.codex/auth.json', 'codex')"
-                            class="bg-gray-900 rounded p-3 font-mono text-xs text-green-400 cursor-pointer hover:bg-gray-800 transition-colors mb-3 overflow-x-auto"
-                            title="Click to copy"
-                        >
-                            sudo npm install -g @openai/codex && codex login && docker cp ~/.codex/auth.json {{ config('pocketdev.project_name', 'pocket-dev') }}-queue:/home/appuser/.codex/auth.json && docker exec -u root {{ config('pocketdev.project_name', 'pocket-dev') }}-queue chown {{ config('backup.user_id') }}:{{ config('backup.group_id') }} /home/appuser/.codex/auth.json && docker exec {{ config('pocketdev.project_name', 'pocket-dev') }}-queue chmod 600 /home/appuser/.codex/auth.json
-                        </div>
-                        <div
-                            x-show="copiedCommand === 'codex'"
-                            x-transition:enter="transition ease-out duration-200"
-                            x-transition:enter-start="opacity-0 translate-y-1"
-                            x-transition:enter-end="opacity-100 translate-y-0"
-                            x-transition:leave="transition ease-in duration-150"
-                            x-transition:leave-start="opacity-100 translate-y-0"
-                            x-transition:leave-end="opacity-0 translate-y-1"
-                            class="absolute -top-8 left-1/2 -translate-x-1/2 px-2 py-1 bg-green-600 text-white text-xs rounded shadow-lg"
-                        >
-                            Copied!
+
+                <!-- Idle: show start button -->
+                <div x-show="state === 'idle'">
+                    <p class="text-sm text-gray-400 mb-4">
+                        Sign in with your ChatGPT subscription (Plus, Pro, Team, Edu, or Enterprise).
+                        No terminal or Docker commands needed.
+                    </p>
+                    <button
+                        type="button"
+                        @click="startAuth()"
+                        class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-semibold transition-colors"
+                    >
+                        Login met ChatGPT
+                    </button>
+                    <p class="text-xs text-gray-500 mt-3">
+                        If you prefer to use an API key instead, select "OpenAI API" above.
+                        You can also skip this and authenticate later via <strong class="text-gray-400">Settings → Codex Auth</strong>.
+                    </p>
+                </div>
+
+                <!-- Starting: spinner -->
+                <div x-show="state === 'starting'" class="text-center py-4">
+                    <svg class="animate-spin w-6 h-6 mx-auto text-blue-400 mb-2" fill="none" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity="0.25"/>
+                        <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+                    </svg>
+                    <p class="text-sm text-gray-400">Connecting to OpenAI...</p>
+                </div>
+
+                <!-- Ready: show URL and code -->
+                <div x-show="state === 'ready'" style="display:none">
+                    <p class="text-sm text-gray-400 mb-4">
+                        Open the link on your phone or another browser, then enter the code when prompted.
+                    </p>
+                    <!-- URL -->
+                    <div class="mb-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Step 1 — Open this link</p>
+                        <div class="flex items-center gap-2 bg-gray-900 rounded p-2 border border-gray-700">
+                            <span class="text-blue-400 text-xs font-mono flex-1 truncate" x-text="verificationUrl"></span>
+                            <a
+                                :href="verificationUrl"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="flex-shrink-0 px-2 py-1 rounded text-xs bg-gray-700 hover:bg-gray-600 text-gray-300 transition-all"
+                                title="Open in new tab"
+                            >↗</a>
+                            <button
+                                type="button"
+                                @click="copyUrl()"
+                                class="flex-shrink-0 px-2 py-1 rounded text-xs transition-all"
+                                :class="urlCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                x-text="urlCopied ? '✓' : '📋'"
+                            ></button>
                         </div>
                     </div>
-                @else
-                    <div class="bg-red-900/50 border border-red-500/50 rounded p-3 text-red-300 text-sm mb-3">
-                        <strong>Configuration required:</strong> Set <code class="bg-red-900 px-1 rounded">PD_USER_ID</code> and <code class="bg-red-900 px-1 rounded">PD_GROUP_ID</code> in your .env file.
-                        <span class="text-red-400 text-xs block mt-1">Run <code>id -u</code> and <code>id -g</code> on your host to get the values.</span>
+                    <!-- Code -->
+                    <div class="mb-4">
+                        <p class="text-xs text-gray-500 uppercase tracking-wide mb-1">Step 2 — Enter this code</p>
+                        <div class="flex items-center gap-3">
+                            <div class="bg-gray-900 border border-gray-600 rounded px-4 py-2">
+                                <span class="text-xl font-mono font-bold tracking-widest" x-text="userCode"></span>
+                            </div>
+                            <button
+                                type="button"
+                                @click="copyCode()"
+                                class="px-3 py-1.5 rounded text-xs font-medium transition-all"
+                                :class="codeCopied ? 'bg-green-700 text-green-200' : 'bg-gray-700 hover:bg-gray-600 text-gray-300'"
+                                x-text="codeCopied ? '✓ Copied' : '📋 Copy'"
+                            ></button>
+                        </div>
                     </div>
-                @endif
-                <p class="text-sm text-gray-400 mb-2">
-                    This installs Codex locally, opens a browser login, then copies credentials to the container. After completion, click <strong class="text-white">Verify & Continue</strong>.
-                </p>
-                <p class="text-xs text-gray-500">
-                    If you prefer to use an API key instead, select "OpenAI API" above.
-                </p>
+                    <p class="text-xs text-gray-500">
+                        Waiting for login… expires in <span class="font-mono" x-text="countdown"></span>
+                    </p>
+                </div>
+
+                <!-- Authenticated -->
+                <div x-show="state === 'authenticated'" style="display:none" class="text-center py-4">
+                    <div class="text-3xl mb-2">✅</div>
+                    <p class="text-green-400 font-semibold mb-1">Authenticated!</p>
+                    <p class="text-sm text-gray-400">Click <strong class="text-white">Verify &amp; Continue</strong> below to proceed.</p>
+                </div>
+
+                <!-- Failed / expired -->
+                <div x-show="state === 'expired' || state === 'failed'" style="display:none">
+                    <div class="bg-red-900/30 border border-red-700 rounded p-3 mb-3">
+                        <p class="text-red-400 text-sm font-semibold">
+                            <span x-show="state === 'expired'">Code expired</span>
+                            <span x-show="state === 'failed'">Failed</span>
+                        </p>
+                        <p class="text-red-300 text-xs mt-1" x-text="error || 'Please try again.'"></p>
+                    </div>
+                    <div class="flex gap-2 mb-4">
+                        <button
+                            type="button"
+                            @click="reset(); startAuth()"
+                            class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-sm font-medium"
+                        >
+                            Try again
+                        </button>
+                        <button
+                            type="button"
+                            @click="reset()"
+                            class="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm text-gray-300"
+                        >
+                            Skip — auth later
+                        </button>
+                    </div>
+                    <!-- Org restriction hint -->
+                    <p class="text-xs text-yellow-400/80">
+                        💡 If your organisation blocks device auth, run <code class="bg-black/20 px-1 rounded">codex login</code> on another machine,
+                        then upload <code class="bg-black/20 px-1 rounded">~/.codex/auth.json</code> via
+                        <a href="{{ route('codex.auth') }}" target="_blank" class="underline">Settings → Codex Auth</a>.
+                    </p>
+                </div>
             </div>
             @endif
 
@@ -337,6 +415,140 @@
                     });
                 }
             }
+        }
+
+        // Inline device auth component reused in the wizard's Codex step
+        function wizardCodexDeviceAuth() {
+            return {
+                state: 'idle',
+                verificationUrl: '',
+                userCode: '',
+                expiresIn: 900,
+                urlCopied: false,
+                codeCopied: false,
+                error: '',
+                _pollTimer: null,
+                _countdownTimer: null,
+
+                get countdown() {
+                    const m = Math.floor(this.expiresIn / 60);
+                    const s = this.expiresIn % 60;
+                    return `${m}:${String(s).padStart(2, '0')}`;
+                },
+
+                async init() {
+                    await this.checkStatus();
+                },
+
+                async startAuth() {
+                    this.state = 'starting';
+                    this.error = '';
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStart') }}', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            }
+                        });
+                        const data = await res.json();
+                        if (!data.success) {
+                            this.state = 'failed';
+                            this.error = data.error || 'Unknown error';
+                            return;
+                        }
+                        this._applyStatus(data);
+                        this._startPolling();
+                    } catch (e) {
+                        this.state = 'failed';
+                        this.error = e.message;
+                    }
+                },
+
+                _startPolling() {
+                    if (this._pollTimer) clearInterval(this._pollTimer);
+                    this._pollTimer = setInterval(() => this.checkStatus(), 2500);
+                },
+
+                async checkStatus() {
+                    try {
+                        const res = await fetch('{{ route('codex.auth.deviceStatus') }}');
+                        const data = await res.json();
+                        this._applyStatus(data);
+                    } catch (e) {}
+                },
+
+                _applyStatus(data) {
+                    const status = data.status;
+                    if (status === 'ready' && this.state !== 'ready') {
+                        this.state = 'ready';
+                        this.verificationUrl = data.verification_url || '';
+                        this.userCode = data.user_code || '';
+                        this.expiresIn = data.expires_in ?? 900;
+                        this._startCountdown();
+                        if (!this._pollTimer) this._startPolling();
+                    } else if (status === 'ready') {
+                        if (data.expires_in !== undefined) this.expiresIn = data.expires_in;
+                    } else if (status === 'authenticated') {
+                        this.state = 'authenticated';
+                        this._stopTimers();
+                    } else if (status === 'failed') {
+                        this.state = 'failed';
+                        this.error = data.error || 'Authentication failed';
+                        this._stopTimers();
+                    } else if (status === 'expired') {
+                        this.state = 'expired';
+                        this._stopTimers();
+                    } else if (status === 'starting' && this.state === 'idle') {
+                        this.state = 'starting';
+                        this._startPolling();
+                    }
+                },
+
+                _startCountdown() {
+                    if (this._countdownTimer) clearInterval(this._countdownTimer);
+                    this._countdownTimer = setInterval(() => {
+                        if (this.expiresIn > 0) {
+                            this.expiresIn--;
+                        } else {
+                            this.state = 'expired';
+                            this._stopTimers();
+                        }
+                    }, 1000);
+                },
+
+                _stopTimers() {
+                    if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+                    if (this._countdownTimer) { clearInterval(this._countdownTimer); this._countdownTimer = null; }
+                },
+
+                reset() {
+                    this._stopTimers();
+                    this.state = 'idle';
+                    this.verificationUrl = '';
+                    this.userCode = '';
+                    this.expiresIn = 900;
+                    this.error = '';
+                    this.urlCopied = false;
+                    this.codeCopied = false;
+                },
+
+                async copyUrl() {
+                    try {
+                        await navigator.clipboard.writeText(this.verificationUrl);
+                        this.urlCopied = true;
+                        setTimeout(() => { this.urlCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+
+                async copyCode() {
+                    try {
+                        await navigator.clipboard.writeText(this.userCode);
+                        this.codeCopied = true;
+                        setTimeout(() => { this.codeCopied = false; }, 2000);
+                    } catch (e) {}
+                },
+            };
         }
     </script>
 

--- a/www/resources/views/setup/wizard.blade.php
+++ b/www/resources/views/setup/wizard.blade.php
@@ -115,13 +115,14 @@
                     Run this command in your terminal to authenticate with your Claude Pro/Team subscription:
                 </p>
                 @if(config('backup.user_id') !== null)
+                    @php($queueContainerName = config('pocketdev.project_name', 'pocket-dev') . '-queue')
                     <div class="relative">
                         <div
-                            @click="copyCommand('docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude', 'claude')"
+                            @click="copyCommand('docker exec -it -u {{ config('backup.user_id') }} {{ $queueContainerName }} claude', 'claude')"
                             class="bg-gray-900 rounded p-3 font-mono text-sm text-green-400 cursor-pointer hover:bg-gray-800 transition-colors mb-3"
                             title="Click to copy"
                         >
-                            docker exec -it -u {{ config('backup.user_id') }} pocket-dev-queue claude
+                            docker exec -it -u {{ config('backup.user_id') }} {{ $queueContainerName }} claude
                         </div>
                         <div
                             x-show="copiedCommand === 'claude'"
@@ -167,7 +168,7 @@
                         @click="startAuth()"
                         class="px-5 py-2.5 bg-blue-600 hover:bg-blue-700 rounded-lg text-sm font-semibold transition-colors"
                     >
-                        Login met ChatGPT
+                        Login with ChatGPT
                     </button>
                     <p class="text-xs text-gray-500 mt-3">
                         If you prefer to use an API key instead, select "OpenAI API" above.

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -135,6 +135,11 @@ Route::get("/codex/auth/status", [CodexAuthController::class, "status"])->name("
 Route::middleware(['auth', 'throttle:10,1'])->group(function () {
     Route::post("/codex/auth/upload-json", [CodexAuthController::class, "uploadJson"])->name("codex.auth.uploadJson");
     Route::delete("/codex/auth/logout", [CodexAuthController::class, "logout"])->name("codex.auth.logout");
+    // Inline device auth flow (no terminal/sudo required)
+    Route::post("/codex/auth/device-start", [CodexAuthController::class, "startDeviceAuth"])->name("codex.auth.deviceStart");
+    Route::get("/codex/auth/device-status", [CodexAuthController::class, "deviceStatus"])->name("codex.auth.deviceStatus");
+    // Serve the local-run upload script (pre-filled with this instance's URL)
+    Route::get("/codex/auth/upload-script", [CodexAuthController::class, "downloadScript"])->name("codex.auth.downloadScript");
 });
 
 // Chat - Multi-provider conversation interface

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -137,9 +137,13 @@ Route::middleware(['auth', 'throttle:10,1'])->group(function () {
     Route::delete("/codex/auth/logout", [CodexAuthController::class, "logout"])->name("codex.auth.logout");
     // Inline device auth flow (no terminal/sudo required)
     Route::post("/codex/auth/device-start", [CodexAuthController::class, "startDeviceAuth"])->name("codex.auth.deviceStart");
-    Route::get("/codex/auth/device-status", [CodexAuthController::class, "deviceStatus"])->name("codex.auth.deviceStatus");
     // Serve the local-run upload script (pre-filled with this instance's URL)
     Route::get("/codex/auth/upload-script", [CodexAuthController::class, "downloadScript"])->name("codex.auth.downloadScript");
+});
+// Device-status is polled every 2.5 s by the frontend — give it a higher throttle
+// so it never hits the 10 req/min limit used by mutation routes.
+Route::middleware(['auth', 'throttle:120,1'])->group(function () {
+    Route::get("/codex/auth/device-status", [CodexAuthController::class, "deviceStatus"])->name("codex.auth.deviceStatus");
 });
 
 // Chat - Multi-provider conversation interface


### PR DESCRIPTION
## Summary

- **Inline device auth flow**: Browser-based Codex authentication via `codex login --device-auth`. A queue job runs the auth process and pushes the verification URL + user code to the frontend via cache polling — no terminal or Docker commands needed.
- **Org restriction fallback**: When device auth is blocked by org policy, users see a "Via laptop / SSH" tab with pre-filled copy commands to install Codex, log in, and upload `auth.json` — supporting both Linux/macOS (bash) and Windows (PowerShell, with explicit UTF-8 encoding fix).
- **File picker upload**: Alternative to CLI commands — users can browse to their local `auth.json` file and upload it directly via the browser, with path hints showing the exact location on each OS (`%USERPROFILE%\.codex\auth.json` / `~/.codex/auth.json`).
- **UX improvements**: Open-in-new-tab button on verification URL, copy buttons with green flash feedback, countdown timer, org restriction help text that links to the fallback tab.
- **Wizard integration**: Setup wizard's Codex step replaced with the inline device auth UI — no external redirect required.
- **Downloadable shell script**: `/scripts/codex-auth.sh` for advanced users who prefer a single piped command.

## New files
- `app/Jobs/StartCodexDeviceAuthJob.php` — queue job: runs `codex login --device-auth`, strips ANSI codes, parses URL/code with regex, stores in cache, polls for `~/.codex/auth.json`, calls `ensureDefaultAgentExists()` on success
- `public/scripts/codex-auth.sh` — bash script for local machine upload flow
- `docs/plans/codex-inline-device-auth.md` — original plan document

## Modified files
- `app/Http/Controllers/CodexAuthController.php` — `startDeviceAuth()`, `deviceStatus()`, `uploadJson()`, `downloadScript()`
- `routes/web.php` — `/codex/auth/device-start`, `/codex/auth/device-status`, `/codex/auth/upload-script`
- `routes/api.php` — `POST api/codex/auth/upload` (no CSRF, for CLI/script uploads)
- `resources/views/codex-auth.blade.php` — full rewrite: 3-tab UI with Alpine.js components (`codexDeviceAuth()`), polling every 2.5s, all states (idle/starting/ready/authenticated/expired/failed)
- `resources/views/setup/wizard.blade.php` — Codex step replaced with `wizardCodexDeviceAuth()` inline component

## Test plan
- [ ] Settings → Codex Auth → click "Start authenticatie" — should poll and show verification URL + code
- [ ] Click "↗ Open" on URL — opens in new tab
- [ ] Complete OAuth — PocketDev detects `auth.json` and shows success
- [ ] Org restriction scenario → "Via laptop / SSH" tab → copy commands work on Linux and Windows
- [ ] File picker → select `auth.json` from local machine → uploads successfully
- [ ] Fresh setup wizard → Codex step shows inline device auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline device authentication for Codex with a UI-driven flow, polling, and 15-minute verification countdown
  * "Via laptop / SSH" option with OS-specific install/login/upload commands and copy-to-clipboard actions
  * Downloadable script to run local login and securely upload credentials
  * Setup wizard updated to include the device-auth flow with retry/reset controls

* **Documentation**
  * Added a Dutch-language plan describing the inline device-auth design and behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tetrixdev/pocket-dev/pull/293)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->