### PR TITLE
Add adaptive 1M context policy with runtime detection and gated /compact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,5 +57,16 @@ CLAUDE_CODE_VERSION=
 # Claude Code context policy (safe | adaptive | force_legacy)
 PD_CLAUDE_CONTEXT_POLICY=safe
 
+# Adaptive rollout threshold: only apply 1M overrides when runtime-detected
+# effective context window is at or above this value.
+PD_CLAUDE_ADAPTIVE_CONTEXT_THRESHOLD=900000
+
+# Adaptive blocking limit override passed to Claude Code when adaptive is active.
+PD_CLAUDE_ADAPTIVE_BLOCKING_LIMIT_OVERRIDE=977000
+
+# Internal probe gate (set by queue-entrypoint probe at startup).
+# Leave false in static env config; startup script exports runtime value.
+PD_CLAUDE_ADAPTIVE_ALLOWED=false
+
 # Enable manual /compact command endpoint for Claude Code conversations
 PD_ENABLE_COMPACT_COMMAND=false

--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,12 @@ PD_DEPLOYMENT_MODE=local
 
 # Domain name for nginx server_name directive
 PD_DOMAIN_NAME=localhost
+
+# Optional: Pin Claude Code CLI version in queue container startup
+CLAUDE_CODE_VERSION=
+
+# Claude Code context policy (safe | adaptive | force_legacy)
+PD_CLAUDE_CONTEXT_POLICY=safe
+
+# Enable manual /compact command endpoint for Claude Code conversations
+PD_ENABLE_COMPACT_COMMAND=false

--- a/docker-laravel/local/php/Dockerfile
+++ b/docker-laravel/local/php/Dockerfile
@@ -121,6 +121,10 @@ RUN chmod +x /usr/local/bin/pd /usr/local/bin/pocketdev
 COPY docker-laravel/shared/scripts/install-system-packages.sh /usr/local/bin/install-system-packages
 RUN chmod +x /usr/local/bin/install-system-packages
 
+# Install Claude capability probe script (queue startup gate for adaptive 1M policy)
+COPY docker-laravel/shared/scripts/claude-capability-probe.sh /usr/local/bin/claude-capability-probe.sh
+RUN chmod +x /usr/local/bin/claude-capability-probe.sh
+
 # Set working directory
 WORKDIR /var/www
 

--- a/docker-laravel/local/php/queue-entrypoint.sh
+++ b/docker-laravel/local/php/queue-entrypoint.sh
@@ -144,6 +144,9 @@ fi
 # This is a fallback mechanism for pinning to a known-working version.
 # Example: CLAUDE_CODE_VERSION=2.1.17
 
+current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+echo "Claude Code CLI version: $current_version"
+
 if [ -n "$CLAUDE_CODE_VERSION" ]; then
     current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
     if [ "$current_version" != "$CLAUDE_CODE_VERSION" ]; then
@@ -156,6 +159,29 @@ if [ -n "$CLAUDE_CODE_VERSION" ]; then
         fi
     else
         echo "Claude Code already at requested version $CLAUDE_CODE_VERSION"
+    fi
+fi
+
+
+# =============================================================================
+# CLAUDE CAPABILITY PROBE
+# =============================================================================
+# Probe runtime 1M capability paths and export PD_CLAUDE_ADAPTIVE_ALLOWED.
+# Adaptive context policy uses this as a startup gate.
+if [ -x /usr/local/bin/claude-capability-probe.sh ]; then
+    echo "🔎 Running Claude capability probe..."
+    /usr/local/bin/claude-capability-probe.sh || true
+
+    if [ -f /tmp/claude-capability-probe.env ]; then
+        # shellcheck source=/dev/null
+        . /tmp/claude-capability-probe.env
+        export PD_CLAUDE_ADAPTIVE_ALLOWED
+        export PD_CLAUDE_PROBE_STATUS
+    fi
+
+    if [ -f /tmp/claude-capability-probe.json ]; then
+        echo "Claude capability probe result:"
+        cat /tmp/claude-capability-probe.json
     fi
 fi
 

--- a/docker-laravel/local/php/queue-entrypoint.sh
+++ b/docker-laravel/local/php/queue-entrypoint.sh
@@ -173,10 +173,13 @@ if [ -x /usr/local/bin/claude-capability-probe.sh ]; then
     /usr/local/bin/claude-capability-probe.sh || true
 
     if [ -f /tmp/claude-capability-probe.env ]; then
-        # shellcheck source=/dev/null
-        . /tmp/claude-capability-probe.env
-        export PD_CLAUDE_ADAPTIVE_ALLOWED
-        export PD_CLAUDE_PROBE_STATUS
+        while IFS='=' read -r key value; do
+            case "$key" in
+                PD_CLAUDE_ADAPTIVE_ALLOWED|PD_CLAUDE_PROBE_STATUS)
+                    export "$key=$value"
+                    ;;
+            esac
+        done < /tmp/claude-capability-probe.env
     fi
 
     if [ -f /tmp/claude-capability-probe.json ]; then

--- a/docker-laravel/production/.env.example
+++ b/docker-laravel/production/.env.example
@@ -11,6 +11,26 @@ PD_DB_DATABASE=pocket-dev
 PD_DB_USERNAME=pocket-dev
 PD_DB_PASSWORD=CHANGE_THIS_PASSWORD
 
+# Optional: Pin Claude Code CLI version in queue container startup
+CLAUDE_CODE_VERSION=
+
+# Claude Code context policy (safe | adaptive | force_legacy)
+PD_CLAUDE_CONTEXT_POLICY=safe
+
+# Adaptive rollout threshold: only apply 1M overrides when runtime-detected
+# effective context window is at or above this value.
+PD_CLAUDE_ADAPTIVE_CONTEXT_THRESHOLD=900000
+
+# Adaptive blocking limit override passed to Claude Code when adaptive is active.
+PD_CLAUDE_ADAPTIVE_BLOCKING_LIMIT_OVERRIDE=977000
+
+# Internal probe gate (set by queue-entrypoint probe at startup).
+# Leave false in static env config; startup script exports runtime value.
+PD_CLAUDE_ADAPTIVE_ALLOWED=false
+
+# Enable manual /compact command endpoint for Claude Code conversations
+PD_ENABLE_COMPACT_COMMAND=false
+
 PD_NGINX_PORT=80
 
 # Optional: pin Claude Code CLI version

--- a/docker-laravel/production/.env.example
+++ b/docker-laravel/production/.env.example
@@ -12,3 +12,12 @@ PD_DB_USERNAME=pocket-dev
 PD_DB_PASSWORD=CHANGE_THIS_PASSWORD
 
 PD_NGINX_PORT=80
+
+# Optional: pin Claude Code CLI version
+CLAUDE_CODE_VERSION=
+
+# Claude Code context policy (safe | adaptive | force_legacy)
+PD_CLAUDE_CONTEXT_POLICY=safe
+
+# Enable manual /compact endpoint
+PD_ENABLE_COMPACT_COMMAND=false

--- a/docker-laravel/production/php/Dockerfile
+++ b/docker-laravel/production/php/Dockerfile
@@ -120,6 +120,10 @@ RUN chmod +x /usr/local/bin/pd /usr/local/bin/pocketdev
 COPY docker-laravel/shared/scripts/install-system-packages.sh /usr/local/bin/install-system-packages
 RUN chmod +x /usr/local/bin/install-system-packages
 
+# Install Claude capability probe script (queue startup gate for adaptive 1M policy)
+COPY docker-laravel/shared/scripts/claude-capability-probe.sh /usr/local/bin/claude-capability-probe.sh
+RUN chmod +x /usr/local/bin/claude-capability-probe.sh
+
 # Set working directory
 WORKDIR /var/www
 

--- a/docker-laravel/production/php/queue-entrypoint.sh
+++ b/docker-laravel/production/php/queue-entrypoint.sh
@@ -220,10 +220,13 @@ if [ -x /usr/local/bin/claude-capability-probe.sh ]; then
     /usr/local/bin/claude-capability-probe.sh || true
 
     if [ -f /tmp/claude-capability-probe.env ]; then
-        # shellcheck source=/dev/null
-        . /tmp/claude-capability-probe.env
-        export PD_CLAUDE_ADAPTIVE_ALLOWED
-        export PD_CLAUDE_PROBE_STATUS
+        while IFS='=' read -r key value; do
+            case "$key" in
+                PD_CLAUDE_ADAPTIVE_ALLOWED|PD_CLAUDE_PROBE_STATUS)
+                    export "$key=$value"
+                    ;;
+            esac
+        done < /tmp/claude-capability-probe.env
     fi
 
     if [ -f /tmp/claude-capability-probe.json ]; then

--- a/docker-laravel/production/php/queue-entrypoint.sh
+++ b/docker-laravel/production/php/queue-entrypoint.sh
@@ -191,6 +191,9 @@ fi
 # This is a fallback mechanism for pinning to a known-working version.
 # Example: CLAUDE_CODE_VERSION=2.1.17
 
+current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
+echo "Claude Code CLI version: $current_version"
+
 if [ -n "$CLAUDE_CODE_VERSION" ]; then
     current_version=$(claude --version 2>/dev/null | head -1 | awk '{print $1}' || echo "unknown")
     if [ "$current_version" != "$CLAUDE_CODE_VERSION" ]; then
@@ -203,6 +206,29 @@ if [ -n "$CLAUDE_CODE_VERSION" ]; then
         fi
     else
         echo "Claude Code already at requested version $CLAUDE_CODE_VERSION"
+    fi
+fi
+
+
+# =============================================================================
+# CLAUDE CAPABILITY PROBE
+# =============================================================================
+# Probe runtime 1M capability paths and export PD_CLAUDE_ADAPTIVE_ALLOWED.
+# Adaptive context policy uses this as a startup gate.
+if [ -x /usr/local/bin/claude-capability-probe.sh ]; then
+    echo "🔎 Running Claude capability probe..."
+    /usr/local/bin/claude-capability-probe.sh || true
+
+    if [ -f /tmp/claude-capability-probe.env ]; then
+        # shellcheck source=/dev/null
+        . /tmp/claude-capability-probe.env
+        export PD_CLAUDE_ADAPTIVE_ALLOWED
+        export PD_CLAUDE_PROBE_STATUS
+    fi
+
+    if [ -f /tmp/claude-capability-probe.json ]; then
+        echo "Claude capability probe result:"
+        cat /tmp/claude-capability-probe.json
     fi
 fi
 

--- a/docker-laravel/shared/scripts/claude-capability-probe.sh
+++ b/docker-laravel/shared/scripts/claude-capability-probe.sh
@@ -132,9 +132,24 @@ if [ -n "$max_window" ] && [ "$max_window" -ge 900000 ]; then
   adaptive_allowed=true
 fi
 
+overall_ok=false
+for result in "$result_standard" "$result_suffix" "$result_beta"; do
+  case "$result" in
+    *"\"status\":\"ok\""*)
+      overall_ok=true
+      break
+      ;;
+  esac
+done
+
+probe_status="failed"
+if [ "$overall_ok" = true ]; then
+  probe_status="ok"
+fi
+
 cat > "$OUTPUT_JSON" <<JSON
 {
-  "ok": true,
+  "ok": $overall_ok,
   "claude_version": "$claude_version",
   "adaptive_allowed": $adaptive_allowed,
   "max_context_window": ${max_window:-0},
@@ -148,7 +163,7 @@ JSON
 
 cat > "$OUTPUT_ENV" <<ENV
 PD_CLAUDE_ADAPTIVE_ALLOWED=$adaptive_allowed
-PD_CLAUDE_PROBE_STATUS=ok
+PD_CLAUDE_PROBE_STATUS=$probe_status
 ENV
 
 exit 0

--- a/docker-laravel/shared/scripts/claude-capability-probe.sh
+++ b/docker-laravel/shared/scripts/claude-capability-probe.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+set -u
+
+OUTPUT_JSON="/tmp/claude-capability-probe.json"
+OUTPUT_ENV="/tmp/claude-capability-probe.env"
+PROMPT_FILE="/tmp/claude-capability-probe-prompt.txt"
+
+printf 'Respond with exactly: ok\n' > "$PROMPT_FILE"
+
+if ! command -v claude >/dev/null 2>&1; then
+  cat > "$OUTPUT_JSON" <<'JSON'
+{"ok":false,"reason":"claude_binary_missing","adaptive_allowed":false,"results":[]}
+JSON
+  cat > "$OUTPUT_ENV" <<'ENV'
+PD_CLAUDE_ADAPTIVE_ALLOWED=false
+PD_CLAUDE_PROBE_STATUS=claude_binary_missing
+ENV
+  exit 0
+fi
+
+claude_version="$(claude --version 2>/dev/null | head -1 | awk '{print $1}')"
+if [ -z "$claude_version" ]; then
+  claude_version="unknown"
+fi
+
+extract_context_window() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+if not path.exists():
+    print('')
+    raise SystemExit(0)
+
+windows = []
+
+def walk(node):
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == 'contextWindow' and isinstance(v, (int, float)):
+                iv = int(v)
+                if iv > 0:
+                    windows.append(iv)
+            else:
+                walk(v)
+    elif isinstance(node, list):
+        for item in node:
+            walk(item)
+
+for line in path.read_text(errors='ignore').splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        obj = json.loads(line)
+    except Exception:
+        continue
+    walk(obj)
+
+print(max(windows) if windows else '')
+PY
+}
+
+run_probe() {
+  local name="$1"
+  local model="$2"
+  local beta="${3:-}"
+  local out_file="/tmp/claude-capability-probe-${name}.log"
+  local status="error"
+  local rc=0
+  local context_window=""
+  local err_preview=""
+
+  local -a cmd
+  cmd=(claude --print --verbose --output-format stream-json --include-partial-messages --dangerously-skip-permissions --model "$model")
+  if [ -n "$beta" ]; then
+    cmd+=(--betas "$beta")
+  fi
+
+  if timeout 75s "${cmd[@]}" < "$PROMPT_FILE" > "$out_file" 2>&1; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  context_window="$(extract_context_window "$out_file")"
+
+  if [ "$rc" -eq 124 ]; then
+    status="timeout"
+  elif [ "$rc" -ne 0 ]; then
+    if grep -qi "rate limit" "$out_file"; then
+      status="rate_limited"
+    else
+      status="error"
+    fi
+  elif [ -n "$context_window" ]; then
+    status="ok"
+  else
+    status="no_context"
+  fi
+
+  err_preview="$(tail -n 5 "$out_file" | tr '\n' ' ' | sed 's/"/\\"/g' | cut -c1-300)"
+
+  printf '{"name":"%s","model":"%s","beta":"%s","status":"%s","exit_code":%s,"context_window":%s,"output_preview":"%s"}' \
+    "$name" "$model" "$beta" "$status" "$rc" "${context_window:-null}" "$err_preview"
+}
+
+result_standard="$(run_probe standard claude-sonnet-4-6)"
+result_suffix="$(run_probe suffix_1m claude-sonnet-4-6[1m])"
+result_beta="$(run_probe beta_1m claude-sonnet-4-6 context-1m-2025-08-07)"
+
+max_window="$(python3 - <<'PY' "$result_standard" "$result_suffix" "$result_beta"
+import json
+import sys
+w = 0
+for raw in sys.argv[1:]:
+    try:
+        obj = json.loads(raw)
+    except Exception:
+        continue
+    cw = obj.get('context_window')
+    if isinstance(cw, int) and cw > w:
+        w = cw
+print(w)
+PY
+)"
+
+adaptive_allowed=false
+if [ -n "$max_window" ] && [ "$max_window" -ge 900000 ]; then
+  adaptive_allowed=true
+fi
+
+cat > "$OUTPUT_JSON" <<JSON
+{
+  "ok": true,
+  "claude_version": "$claude_version",
+  "adaptive_allowed": $adaptive_allowed,
+  "max_context_window": ${max_window:-0},
+  "results": [
+    $result_standard,
+    $result_suffix,
+    $result_beta
+  ]
+}
+JSON
+
+cat > "$OUTPUT_ENV" <<ENV
+PD_CLAUDE_ADAPTIVE_ALLOWED=$adaptive_allowed
+PD_CLAUDE_PROBE_STATUS=ok
+ENV
+
+exit 0

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -9,6 +9,7 @@ use App\Models\Conversation;
 use App\Models\Screen;
 use App\Models\Session;
 use App\Models\Workspace;
+use App\Services\ClaudeContextPolicyService;
 use App\Services\ConversationFactory;
 use App\Services\ConversationStreamLogger;
 use App\Services\NativeToolService;
@@ -31,6 +32,7 @@ class ConversationController extends Controller
         private ProviderFactory $providerFactory,
         private StreamManager $streamManager,
         private ConversationFactory $conversationFactory,
+        private ClaudeContextPolicyService $claudeContextPolicy,
     ) {}
 
     /**
@@ -140,6 +142,10 @@ class ConversationController extends Controller
             'context' => [
                 'last_context_tokens' => $conversation->last_context_tokens,
                 'context_window_size' => $conversation->context_window_size,
+                'effective_context_window' => $conversation->effective_context_window,
+                'is_effective_context_mismatch' => $conversation->context_window_size !== null
+                    && $conversation->effective_context_window !== null
+                    && $conversation->context_window_size !== $conversation->effective_context_window,
                 'usage_percentage' => $conversation->getContextUsagePercentage(),
                 'warning_level' => $conversation->getContextWarningLevel(),
             ],
@@ -335,6 +341,70 @@ class ConversationController extends Controller
             RequestFlowLogger::endRequest('error');
             throw $e;
         }
+    }
+
+    /**
+     * Trigger a manual Claude Code /compact command.
+     *
+     * Guarded by PD_ENABLE_COMPACT_COMMAND and only valid for Claude Code
+     * conversations with an existing provider session.
+     */
+    public function compact(Request $request, Conversation $conversation): JsonResponse
+    {
+        RequestFlowLogger::startRequest($conversation->uuid, 'compact');
+        RequestFlowLogger::log('controller.compact.entry', 'Compact request received');
+
+        if (!$this->claudeContextPolicy->compactCommandEnabled()) {
+            RequestFlowLogger::endRequest('compact_disabled');
+            return response()->json([
+                'success' => false,
+                'error' => 'Compact command is disabled by policy.',
+            ], 400);
+        }
+
+        if ($conversation->provider_type !== 'claude_code') {
+            RequestFlowLogger::endRequest('invalid_provider');
+            return response()->json([
+                'success' => false,
+                'error' => 'Compact is only supported for Claude Code conversations.',
+            ], 400);
+        }
+
+        if (empty($conversation->provider_session_id)) {
+            RequestFlowLogger::endRequest('missing_session');
+            return response()->json([
+                'success' => false,
+                'error' => 'Compact requires an active Claude Code session.',
+            ], 409);
+        }
+
+        if ($this->streamManager->isStreaming($conversation->uuid)) {
+            RequestFlowLogger::endRequest('already_streaming');
+            return response()->json([
+                'success' => false,
+                'error' => 'Conversation is already streaming',
+            ], 409);
+        }
+
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+            'command' => 'compact',
+        ]);
+
+        ProcessConversationStream::dispatch(
+            $conversation->uuid,
+            '/compact',
+            []
+        );
+
+        RequestFlowLogger::endRequest('success');
+        return response()->json([
+            'success' => true,
+            'conversation_uuid' => $conversation->uuid,
+            'started_at' => now()->toIso8601String(),
+            'message' => 'Compaction started. Connect to /stream-events to receive updates.',
+        ]);
     }
 
     /**
@@ -574,6 +644,7 @@ class ConversationController extends Controller
             'total_input_tokens' => $conversation->total_input_tokens,
             'total_output_tokens' => $conversation->total_output_tokens,
             'context_window' => $provider->getContextWindow($conversation->model),
+            'effective_context_window' => $conversation->effective_context_window,
             'last_activity_at' => $conversation->last_activity_at,
         ]);
     }

--- a/www/app/Http/Controllers/Api/ConversationController.php
+++ b/www/app/Http/Controllers/Api/ConversationController.php
@@ -386,17 +386,24 @@ class ConversationController extends Controller
             ], 409);
         }
 
-        $this->streamManager->startStream($conversation->uuid, [
-            'model' => $conversation->model,
-            'provider' => $conversation->provider_type,
-            'command' => 'compact',
-        ]);
+        try {
+            $this->streamManager->startStream($conversation->uuid, [
+                'model' => $conversation->model,
+                'provider' => $conversation->provider_type,
+                'command' => 'compact',
+            ]);
 
-        ProcessConversationStream::dispatch(
-            $conversation->uuid,
-            '/compact',
-            []
-        );
+            ProcessConversationStream::dispatch(
+                $conversation->uuid,
+                '/compact',
+                []
+            );
+        } catch (\Throwable $e) {
+            $this->streamManager->cleanup($conversation->uuid);
+            RequestFlowLogger::logError('controller.compact.exception', 'Compact request failed', $e);
+            RequestFlowLogger::endRequest('error');
+            throw $e;
+        }
 
         RequestFlowLogger::endRequest('success');
         return response()->json([

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Contracts\AIProviderInterface;
 use App\Models\Conversation;
 use App\Models\Message;
+use App\Services\ClaudeContextPolicyService;
 use App\Services\Providers\AbstractCliProvider;
 use App\Services\ModelRepository;
 use App\Services\ProviderFactory;
@@ -312,6 +313,7 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
         // (cumulative tokens above are for billing, context tokens below are for context % calculation)
         $contextInputTokens = null;
         $contextOutputTokens = null;
+        $effectiveContextWindow = $conversation->effective_context_window;
 
         // Get the model for cost calculation
         $aiModel = $modelRepository->findByModelId($conversation->model);
@@ -386,6 +388,16 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                 // Use same preserve-previous pattern as billing tokens for consistency
                 $contextInputTokens = $event->metadata['context_input_tokens'] ?? $contextInputTokens;
                 $contextOutputTokens = $event->metadata['context_output_tokens'] ?? $contextOutputTokens;
+                $effectiveContextWindow = $event->metadata['effective_context_window'] ?? $effectiveContextWindow;
+
+                if (
+                    is_int($effectiveContextWindow)
+                    && $effectiveContextWindow > 0
+                    && $conversation->effective_context_window !== $effectiveContextWindow
+                ) {
+                    $conversation->update(['effective_context_window' => $effectiveContextWindow]);
+                    $conversation->refresh();
+                }
 
                 // Calculate cost using model pricing
                 $cost = null;
@@ -410,7 +422,8 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                     $cost,
                     $conversation->context_window_size,
                     $contextInputTokens,
-                    $contextOutputTokens
+                    $contextOutputTokens,
+                    $effectiveContextWindow
                 );
                 $streamManager->appendEvent($this->conversationUuid, $enrichedEvent);
                 continue;
@@ -553,6 +566,22 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                     break;
 
                 case StreamEvent::ERROR:
+                    if (
+                        $conversation->provider_type === 'claude_code'
+                        && $event->content
+                        && app(ClaudeContextPolicyService::class)->isHardPromptLimitError($event->content)
+                    ) {
+                        $demoted = app(ClaudeContextPolicyService::class)->demoteWorkspaceToSafe(
+                            $conversation->workspace_id,
+                            'hard_prompt_limit'
+                        );
+                        Log::warning('ProcessConversationStream: Auto-demoted workspace to safe policy', [
+                            'workspace_id' => $conversation->workspace_id,
+                            'conversation' => $this->conversationUuid,
+                            'demoted' => $demoted,
+                            'error' => $event->content,
+                        ]);
+                    }
                     RequestFlowLogger::logError('job.loop.error_event', 'Received ERROR event', null, [
                         'error_content' => $event->content,
                     ]);
@@ -623,7 +652,8 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             $stopReason,
             $turnCost > 0 ? $turnCost : null,
             $contextInputTokens,
-            $contextOutputTokens
+            $contextOutputTokens,
+            $effectiveContextWindow
         );
 
         // Handle tool execution
@@ -718,7 +748,8 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
         ?string $stopReason,
         ?float $cost = null,
         ?int $contextInputTokens = null,
-        ?int $contextOutputTokens = null
+        ?int $contextOutputTokens = null,
+        ?int $effectiveContextWindow = null
     ): Message {
         $message = Message::create([
             'conversation_id' => $conversation->id,
@@ -760,6 +791,14 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                     ]);
                 }
             }
+        }
+
+        if (
+            is_int($effectiveContextWindow)
+            && $effectiveContextWindow > 0
+            && $conversation->effective_context_window !== $effectiveContextWindow
+        ) {
+            $conversation->update(['effective_context_window' => $effectiveContextWindow]);
         }
 
         return $message;
@@ -944,7 +983,8 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
                     'aborted',
                     $turnCost > 0 ? $turnCost : null,
                     $contextInputTokens,
-                    $contextOutputTokens
+                    $contextOutputTokens,
+                    $conversation->effective_context_window
                 );
 
                 // Determine whether to sync to CLI session based on content analysis.

--- a/www/app/Models/Conversation.php
+++ b/www/app/Models/Conversation.php
@@ -33,6 +33,7 @@ class Conversation extends Model
         // Context window tracking
         'last_context_tokens',
         'context_window_size',
+        'effective_context_window',
         'status',
         'last_activity_at',
         // Unified reasoning config (JSON)
@@ -50,6 +51,7 @@ class Conversation extends Model
         'total_output_tokens' => 'integer',
         'last_context_tokens' => 'integer',
         'context_window_size' => 'integer',
+        'effective_context_window' => 'integer',
         'reasoning_config' => 'array',
         'response_level' => 'integer',
         'last_embedded_turn_number' => 'integer',

--- a/www/app/Services/ClaudeContextPolicyService.php
+++ b/www/app/Services/ClaudeContextPolicyService.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Conversation;
+use App\Models\Setting;
+
+class ClaudeContextPolicyService
+{
+    public const MODE_SAFE = 'safe';
+    public const MODE_ADAPTIVE = 'adaptive';
+    public const MODE_FORCE_LEGACY = 'force_legacy';
+
+    private const WORKSPACE_DEMOTIONS_KEY = 'claude_context_policy.workspace_demotions';
+
+    /**
+     * @return array{requested_mode:string,applied_mode:string,apply_overrides:bool,reason:string,effective_context_window:?int,probe_allows_adaptive:bool,workspace_demoted:bool,blocking_limit_override:?int}
+     */
+    public function evaluateForConversation(Conversation $conversation): array
+    {
+        $requestedMode = $this->getConfiguredMode();
+        $effectiveContextWindow = $conversation->effective_context_window;
+        $workspaceDemoted = $this->isWorkspaceDemoted($conversation->workspace_id);
+        $probeAllowsAdaptive = $this->probeAllowsAdaptive();
+        $adaptiveThreshold = $this->adaptiveThreshold();
+
+        if ($requestedMode === self::MODE_FORCE_LEGACY) {
+            return [
+                'requested_mode' => $requestedMode,
+                'applied_mode' => self::MODE_FORCE_LEGACY,
+                'apply_overrides' => false,
+                'reason' => 'force_legacy_mode',
+                'effective_context_window' => $effectiveContextWindow,
+                'probe_allows_adaptive' => $probeAllowsAdaptive,
+                'workspace_demoted' => $workspaceDemoted,
+                'blocking_limit_override' => null,
+            ];
+        }
+
+        if ($requestedMode !== self::MODE_ADAPTIVE) {
+            return [
+                'requested_mode' => $requestedMode,
+                'applied_mode' => self::MODE_SAFE,
+                'apply_overrides' => false,
+                'reason' => 'safe_mode',
+                'effective_context_window' => $effectiveContextWindow,
+                'probe_allows_adaptive' => $probeAllowsAdaptive,
+                'workspace_demoted' => $workspaceDemoted,
+                'blocking_limit_override' => null,
+            ];
+        }
+
+        if (!$probeAllowsAdaptive) {
+            return [
+                'requested_mode' => $requestedMode,
+                'applied_mode' => self::MODE_SAFE,
+                'apply_overrides' => false,
+                'reason' => 'probe_gate_blocked',
+                'effective_context_window' => $effectiveContextWindow,
+                'probe_allows_adaptive' => false,
+                'workspace_demoted' => $workspaceDemoted,
+                'blocking_limit_override' => null,
+            ];
+        }
+
+        if ($workspaceDemoted) {
+            return [
+                'requested_mode' => $requestedMode,
+                'applied_mode' => self::MODE_SAFE,
+                'apply_overrides' => false,
+                'reason' => 'workspace_auto_demoted',
+                'effective_context_window' => $effectiveContextWindow,
+                'probe_allows_adaptive' => true,
+                'workspace_demoted' => true,
+                'blocking_limit_override' => null,
+            ];
+        }
+
+        if ($effectiveContextWindow === null || $effectiveContextWindow < $adaptiveThreshold) {
+            return [
+                'requested_mode' => $requestedMode,
+                'applied_mode' => self::MODE_SAFE,
+                'apply_overrides' => false,
+                'reason' => 'effective_context_not_proven',
+                'effective_context_window' => $effectiveContextWindow,
+                'probe_allows_adaptive' => true,
+                'workspace_demoted' => false,
+                'blocking_limit_override' => null,
+            ];
+        }
+
+        return [
+            'requested_mode' => $requestedMode,
+            'applied_mode' => self::MODE_ADAPTIVE,
+            'apply_overrides' => true,
+            'reason' => 'adaptive_enabled',
+            'effective_context_window' => $effectiveContextWindow,
+            'probe_allows_adaptive' => true,
+            'workspace_demoted' => false,
+            'blocking_limit_override' => $this->adaptiveBlockingLimitOverride(),
+        ];
+    }
+
+    public function getConfiguredMode(): string
+    {
+        $mode = (string) config('ai.providers.claude_code.context_policy', self::MODE_SAFE);
+        if (!in_array($mode, [self::MODE_SAFE, self::MODE_ADAPTIVE, self::MODE_FORCE_LEGACY], true)) {
+            return self::MODE_SAFE;
+        }
+
+        return $mode;
+    }
+
+    public function probeAllowsAdaptive(): bool
+    {
+        return (bool) config('ai.providers.claude_code.adaptive_allowed', false);
+    }
+
+    public function adaptiveThreshold(): int
+    {
+        return max(1, (int) config('ai.providers.claude_code.adaptive_context_threshold', 900000));
+    }
+
+    public function adaptiveBlockingLimitOverride(): int
+    {
+        return max(1, (int) config('ai.providers.claude_code.adaptive_blocking_limit_override', 977000));
+    }
+
+    public function compactCommandEnabled(): bool
+    {
+        return (bool) config('ai.providers.claude_code.enable_compact_command', false);
+    }
+
+    public function isWorkspaceDemoted(?string $workspaceId): bool
+    {
+        if (!$workspaceId) {
+            return false;
+        }
+
+        $demotions = $this->getWorkspaceDemotions();
+        return isset($demotions[$workspaceId]);
+    }
+
+    public function demoteWorkspaceToSafe(?string $workspaceId, string $reason): bool
+    {
+        if (!$workspaceId) {
+            return false;
+        }
+
+        $demotions = $this->getWorkspaceDemotions();
+        if (isset($demotions[$workspaceId])) {
+            return false;
+        }
+
+        $demotions[$workspaceId] = [
+            'demoted_at' => now()->toIso8601String(),
+            'reason' => $reason,
+        ];
+
+        Setting::set(self::WORKSPACE_DEMOTIONS_KEY, $demotions);
+
+        return true;
+    }
+
+    public function isHardPromptLimitError(string $message): bool
+    {
+        $normalized = strtolower($message);
+
+        $patterns = [
+            'prompt is too long',
+            'prompt too long',
+            'context length exceeded',
+            'context window exceeded',
+            'maximum context length',
+            'input is too long',
+            'input length exceeds',
+            'exceeds the maximum context',
+            'exceeds model context',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (str_contains($normalized, $pattern)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, array{demoted_at:string,reason:string}>
+     */
+    private function getWorkspaceDemotions(): array
+    {
+        $value = Setting::get(self::WORKSPACE_DEMOTIONS_KEY, []);
+        if (!is_array($value)) {
+            return [];
+        }
+
+        return $value;
+    }
+}

--- a/www/app/Services/ClaudeContextPolicyService.php
+++ b/www/app/Services/ClaudeContextPolicyService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\Conversation;
 use App\Models\Setting;
+use Illuminate\Support\Facades\DB;
 
 class ClaudeContextPolicyService
 {
@@ -147,19 +148,42 @@ class ClaudeContextPolicyService
             return false;
         }
 
-        $demotions = $this->getWorkspaceDemotions();
-        if (isset($demotions[$workspaceId])) {
-            return false;
-        }
+        return DB::transaction(function () use ($workspaceId, $reason): bool {
+            $setting = Setting::where('key', self::WORKSPACE_DEMOTIONS_KEY)
+                ->lockForUpdate()
+                ->first();
 
-        $demotions[$workspaceId] = [
-            'demoted_at' => now()->toIso8601String(),
-            'reason' => $reason,
-        ];
+            $demotions = [];
+            if ($setting) {
+                $decoded = json_decode((string) $setting->value, true);
+                if (is_array($decoded)) {
+                    $demotions = $decoded;
+                }
+            }
 
-        Setting::set(self::WORKSPACE_DEMOTIONS_KEY, $demotions);
+            if (isset($demotions[$workspaceId])) {
+                return false;
+            }
 
-        return true;
+            $demotions[$workspaceId] = [
+                'demoted_at' => now()->toIso8601String(),
+                'reason' => $reason,
+            ];
+
+            $storedValue = json_encode($demotions);
+
+            if ($setting) {
+                $setting->value = $storedValue;
+                $setting->save();
+            } else {
+                Setting::create([
+                    'key' => self::WORKSPACE_DEMOTIONS_KEY,
+                    'value' => $storedValue,
+                ]);
+            }
+
+            return true;
+        });
     }
 
     public function isHardPromptLimitError(string $message): bool

--- a/www/app/Services/Providers/ClaudeCodeProvider.php
+++ b/www/app/Services/Providers/ClaudeCodeProvider.php
@@ -4,6 +4,7 @@ namespace App\Services\Providers;
 
 use App\Models\Conversation;
 use App\Models\Message;
+use App\Services\ClaudeContextPolicyService;
 use App\Services\ModelRepository;
 use App\Streaming\StreamEvent;
 use Generator;
@@ -187,6 +188,23 @@ class ClaudeCodeProvider extends AbstractCliProvider
         // Enable tool_progress heartbeats during tool execution
         $env['CLAUDE_CODE_CONTAINER_ID'] = 'pocketdev';
 
+        $policy = app(ClaudeContextPolicyService::class)->evaluateForConversation($conversation);
+        if ($policy['apply_overrides']) {
+            $env['DISABLE_AUTO_COMPACT'] = '1';
+            $env['CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE'] = (string) $policy['blocking_limit_override'];
+        }
+
+        Log::channel('api')->info('ClaudeCodeProvider: Context policy applied', [
+            'conversation' => $conversation->uuid,
+            'requested_mode' => $policy['requested_mode'],
+            'applied_mode' => $policy['applied_mode'],
+            'reason' => $policy['reason'],
+            'effective_context_window' => $policy['effective_context_window'],
+            'workspace_demoted' => $policy['workspace_demoted'],
+            'probe_allows_adaptive' => $policy['probe_allows_adaptive'],
+            'overrides_applied' => $policy['apply_overrides'],
+        ]);
+
         return $env;
     }
 
@@ -206,6 +224,7 @@ class ClaudeCodeProvider extends AbstractCliProvider
             'outputTokens' => 0,
             'cacheCreationTokens' => 0,
             'cacheReadTokens' => 0,
+            'effectiveContextWindow' => null,
         ];
     }
 
@@ -278,7 +297,11 @@ class ClaudeCodeProvider extends AbstractCliProvider
                 $state['outputTokens'],
                 $state['cacheCreationTokens'] ?: null,
                 $state['cacheReadTokens'] ?: null,
-                $state['totalCost']
+                $state['totalCost'],
+                null,
+                null,
+                null,
+                $state['effectiveContextWindow']
             );
         }
     }
@@ -291,6 +314,7 @@ class ClaudeCodeProvider extends AbstractCliProvider
             'total_cost' => $state['totalCost'],
             'input_tokens' => $state['inputTokens'],
             'output_tokens' => $state['outputTokens'],
+            'effective_context_window' => $state['effectiveContextWindow'],
         ];
     }
 
@@ -339,12 +363,17 @@ class ClaudeCodeProvider extends AbstractCliProvider
                 if (isset($data['total_cost_usd'])) {
                     $state['totalCost'] = (float) $data['total_cost_usd'];
                 }
+                $effectiveContextWindow = $this->extractEffectiveContextWindow($data);
+                if ($effectiveContextWindow !== null) {
+                    $state['effectiveContextWindow'] = $effectiveContextWindow;
+                }
                 Log::channel('api')->info('ClaudeCodeProvider: Result received', [
                     'subtype' => $data['subtype'] ?? 'unknown',
                     'is_error' => $data['is_error'] ?? false,
                     'session_id' => $state['sessionId'],
                     'total_cost' => $state['totalCost'],
                     'num_turns' => $data['num_turns'] ?? null,
+                    'effective_context_window' => $state['effectiveContextWindow'],
                 ]);
 
                 if (!empty($data['is_error'])) {
@@ -886,5 +915,43 @@ class ClaudeCodeProvider extends AbstractCliProvider
     {
         $reasoningConfig = $conversation->getReasoningConfig();
         return $reasoningConfig['thinking_tokens'] ?? 0;
+    }
+
+    private function extractEffectiveContextWindow(array $resultPayload): ?int
+    {
+        if (!isset($resultPayload['modelUsage']) || !is_array($resultPayload['modelUsage'])) {
+            return null;
+        }
+
+        $contextWindows = [];
+        $this->collectContextWindows($resultPayload['modelUsage'], $contextWindows);
+
+        if (empty($contextWindows)) {
+            return null;
+        }
+
+        return max($contextWindows);
+    }
+
+    /**
+     * @param mixed $node
+     * @param array<int, int> $collector
+     */
+    private function collectContextWindows(mixed $node, array &$collector): void
+    {
+        if (!is_array($node)) {
+            return;
+        }
+
+        foreach ($node as $key => $value) {
+            if ($key === 'contextWindow' && is_numeric($value)) {
+                $window = (int) $value;
+                if ($window > 0) {
+                    $collector[] = $window;
+                }
+                continue;
+            }
+            $this->collectContextWindows($value, $collector);
+        }
     }
 }

--- a/www/app/Streaming/StreamEvent.php
+++ b/www/app/Streaming/StreamEvent.php
@@ -119,7 +119,8 @@ class StreamEvent
         ?float $cost = null,
         ?int $contextWindowSize = null,
         ?int $contextInputTokens = null,
-        ?int $contextOutputTokens = null
+        ?int $contextOutputTokens = null,
+        ?int $effectiveContextWindow = null
     ): self {
         $metadata = array_filter([
             'input_tokens' => $inputTokens,
@@ -128,6 +129,7 @@ class StreamEvent
             'cache_read_tokens' => $cacheRead,
             'cost' => $cost,
             'context_window_size' => $contextWindowSize,
+            'effective_context_window' => $effectiveContextWindow,
         ], fn($v) => $v !== null);
 
         // Include per-turn context tokens for updateContextUsage whenever provided

--- a/www/config/ai.php
+++ b/www/config/ai.php
@@ -43,6 +43,18 @@ return [
             'default_model' => 'opus',
             // When set, overrides the per-conversation/agent model selection entirely
             'override_model' => env('CLAUDE_CODE_OVERRIDE_MODEL'),
+            // Runtime context policy:
+            // - safe: keep current CLI behavior (default)
+            // - adaptive: apply overrides only when runtime 1M capability is proven
+            // - force_legacy: explicitly keep v0.61.1-compatible behavior
+            'context_policy' => env('PD_CLAUDE_CONTEXT_POLICY', 'safe'),
+            // Re-enable /compact command for Claude Code conversations
+            'enable_compact_command' => env('PD_ENABLE_COMPACT_COMMAND', false),
+            // Adaptive policy gates/limits
+            'adaptive_context_threshold' => (int) env('PD_CLAUDE_ADAPTIVE_CONTEXT_THRESHOLD', 900000),
+            'adaptive_blocking_limit_override' => (int) env('PD_CLAUDE_ADAPTIVE_BLOCKING_LIMIT_OVERRIDE', 977000),
+            // Set by queue-entrypoint probe gate. If false, adaptive mode is blocked.
+            'adaptive_allowed' => env('PD_CLAUDE_ADAPTIVE_ALLOWED', false),
             // Available tools that can be enabled/disabled via UI
             // Empty array = all tools allowed (default behavior)
             'available_tools' => [

--- a/www/database/migrations/2026_04_11_210000_add_effective_context_window_to_conversations_table.php
+++ b/www/database/migrations/2026_04_11_210000_add_effective_context_window_to_conversations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->unsignedInteger('effective_context_window')
+                ->nullable()
+                ->after('context_window_size');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropColumn('effective_context_window');
+        });
+    }
+};

--- a/www/resources/js/stores/streamStore.js
+++ b/www/resources/js/stores/streamStore.js
@@ -901,6 +901,7 @@ export function createStreamStore(callbacks) {
                         // Update context window tracking
                         callbacks.updateContext({
                             contextWindowSize: event.metadata.context_window_size,
+                            effectiveContextWindow: event.metadata.effective_context_window,
                             contextPercentage: event.metadata.context_percentage,
                             lastContextTokens: input + output
                         });

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1528,7 +1528,7 @@
                         getCurrentAgent: () => this.currentAgent,
                         updateContext: (data) => {
                             if (data.contextWindowSize) this.contextWindowSize = data.contextWindowSize;
-                            if (data.effectiveContextWindow) this.effectiveContextWindow = data.effectiveContextWindow;
+                            if (data.effectiveContextWindow !== undefined) this.effectiveContextWindow = data.effectiveContextWindow;
                             if (data.contextPercentage !== undefined) {
                                 this.contextPercentage = data.contextPercentage;
                                 this.lastContextTokens = data.lastContextTokens || 0;
@@ -4766,6 +4766,12 @@
                     const attachments = Alpine.store('attachments');
                     const trimmedPrompt = this.prompt.trim();
 
+                    // Block sending while conversation is being loaded (prevents race conditions)
+                    if (this.loadingConversation) {
+                        this.showError('Please wait for the conversation to load');
+                        return;
+                    }
+
                     if (trimmedPrompt === '/compact' && !this.activeSkill) {
                         await this.sendCompactCommand();
                         return;
@@ -4774,12 +4780,6 @@
                     // Allow sending if there's text OR files OR active skill
                     if (!this.prompt.trim() && !attachments.hasFiles && !this.activeSkill) return;
                     if (this.isStreaming) return;
-
-                    // Block sending while conversation is being loaded (prevents race conditions)
-                    if (this.loadingConversation) {
-                        this.showError('Please wait for the conversation to load');
-                        return;
-                    }
 
                     // Block unmatched /commands - if prompt starts with / but no skill is active
                     if (this.prompt.trim().startsWith('/') && !this.activeSkill) {
@@ -4943,6 +4943,11 @@
                 },
 
                 async sendCompactCommand() {
+                    if (this.loadingConversation) {
+                        this.showError('Please wait for the conversation to load');
+                        return;
+                    }
+
                     if (!this.currentConversationUuid) {
                         this.showError('/compact requires an existing conversation.');
                         return;

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -1397,6 +1397,7 @@
 
                 // Context window tracking
                 contextWindowSize: 0,
+                effectiveContextWindow: 0,
                 lastContextTokens: 0,
                 contextPercentage: 0,
                 contextWarningLevel: 'safe',
@@ -1527,6 +1528,7 @@
                         getCurrentAgent: () => this.currentAgent,
                         updateContext: (data) => {
                             if (data.contextWindowSize) this.contextWindowSize = data.contextWindowSize;
+                            if (data.effectiveContextWindow) this.effectiveContextWindow = data.effectiveContextWindow;
                             if (data.contextPercentage !== undefined) {
                                 this.contextPercentage = data.contextPercentage;
                                 this.lastContextTokens = data.lastContextTokens || 0;
@@ -3035,6 +3037,7 @@
                         // Load context window tracking data
                         if (data.context) {
                             this.contextWindowSize = data.context.context_window_size || 0;
+                            this.effectiveContextWindow = data.context.effective_context_window || 0;
                             this.lastContextTokens = data.context.last_context_tokens || 0;
                             this.contextPercentage = data.context.usage_percentage || 0;
                             this.contextWarningLevel = data.context.warning_level || 'safe';
@@ -3396,9 +3399,12 @@
                         // Load context tracking
                         if (data.context) {
                             this.contextWindowSize = data.context.context_window_size || 0;
+                            this.effectiveContextWindow = data.context.effective_context_window || 0;
                             this.lastContextTokens = data.context.last_context_tokens || 0;
                             this.contextPercentage = data.context.usage_percentage || 0;
                             this.contextWarningLevel = data.context.warning_level || 'safe';
+                        } else {
+                            this.resetContextTracking();
                         }
 
                         // Load messages (pass targetTurn to center initial batch if searching)
@@ -4758,6 +4764,12 @@
 
                 async sendMessage() {
                     const attachments = Alpine.store('attachments');
+                    const trimmedPrompt = this.prompt.trim();
+
+                    if (trimmedPrompt === '/compact' && !this.activeSkill) {
+                        await this.sendCompactCommand();
+                        return;
+                    }
 
                     // Allow sending if there's text OR files OR active skill
                     if (!this.prompt.trim() && !attachments.hasFiles && !this.activeSkill) return;
@@ -4927,6 +4939,46 @@
                         this.showError('Failed to start streaming: ' + err.message);
                         this.isStreaming = false;
                         this.prompt = userPrompt; // Restore prompt so user can retry
+                    }
+                },
+
+                async sendCompactCommand() {
+                    if (!this.currentConversationUuid) {
+                        this.showError('/compact requires an existing conversation.');
+                        return;
+                    }
+
+                    if (this.isStreaming) {
+                        this.showError('Conversation is already streaming');
+                        return;
+                    }
+
+                    this.prompt = '';
+                    this.lastEventIndex = 0;
+                    this._justCompletedStream = false;
+                    this._streamStore.resetStreamState();
+
+                    try {
+                        const response = await fetch(`/api/conversations/${this.currentConversationUuid}/compact`, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' }
+                        });
+
+                        const data = await response.json();
+                        if (!data.success) {
+                            this.showError(data.error || 'Failed to start /compact');
+                            this.prompt = '/compact';
+                            return;
+                        }
+
+                        if (data.started_at) {
+                            this._streamState.startedAt = data.started_at;
+                        }
+
+                        await this.connectToStreamEvents();
+                    } catch (err) {
+                        this.showError('Failed to start /compact: ' + err.message);
+                        this.prompt = '/compact';
                     }
                 },
 
@@ -5268,7 +5320,17 @@
                     if (!this.contextWindowSize) return 'Context: --';
                     const used = (this.lastContextTokens / 1000).toFixed(0);
                     const total = (this.contextWindowSize / 1000).toFixed(0);
+                    if (this.hasContextWindowMismatch()) {
+                        const effective = (this.effectiveContextWindow / 1000).toFixed(0);
+                        return `${used}k / ${total}k tokens (runtime: ${effective}k)`;
+                    }
                     return `${used}k / ${total}k tokens`;
+                },
+
+                hasContextWindowMismatch() {
+                    return this.contextWindowSize > 0
+                        && this.effectiveContextWindow > 0
+                        && this.contextWindowSize !== this.effectiveContextWindow;
                 },
 
                 updateContextWarningLevel() {
@@ -5283,6 +5345,7 @@
 
                 resetContextTracking() {
                     this.contextWindowSize = 0;
+                    this.effectiveContextWindow = 0;
                     this.lastContextTokens = 0;
                     this.contextPercentage = 0;
                     this.contextWarningLevel = 'safe';

--- a/www/resources/views/components/chat/context-progress.blade.php
+++ b/www/resources/views/components/chat/context-progress.blade.php
@@ -19,6 +19,10 @@
         <span class="absolute inset-0 flex items-center justify-center text-[10px] font-mono text-white font-medium"
               x-text="contextPercentage.toFixed(0) + '%'"></span>
     </div>
+    <span x-show="hasContextWindowMismatch()"
+          x-cloak
+          class="text-[10px] text-amber-300 font-medium"
+          title="Configured context differs from runtime-detected context">R</span>
 </div>
 @else
 {{-- Standard version for desktop --}}
@@ -35,6 +39,10 @@
         <span class="absolute inset-0 flex items-center justify-center text-xs font-mono text-white font-medium"
               x-text="contextPercentage.toFixed(0) + '%'"></span>
     </div>
+    <span x-show="hasContextWindowMismatch()"
+          x-cloak
+          class="text-[10px] text-amber-300 font-medium"
+          title="Configured context differs from runtime-detected context">Runtime</span>
     {{-- Warning icon for danger level --}}
     <svg x-show="contextWarningLevel === 'danger'"
          x-cloak

--- a/www/routes/api.php
+++ b/www/routes/api.php
@@ -81,6 +81,7 @@ Route::apiResource('conversations', ConversationController::class)
 Route::prefix('conversations/{conversation}')->group(function () {
     Route::get('status', [ConversationController::class, 'status']);
     Route::post('stream', [ConversationController::class, 'stream']);
+    Route::post('compact', [ConversationController::class, 'compact']);
     Route::post('abort', [ConversationController::class, 'abort']);
     Route::get('stream-status', [ConversationController::class, 'streamStatus']);
     Route::get('stream-events', [ConversationController::class, 'streamEvents']);

--- a/www/tests/Feature/CompactCommandTest.php
+++ b/www/tests/Feature/CompactCommandTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\ProcessConversationStream;
+use App\Models\Conversation;
+use App\Services\StreamManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use Tests\TestCase;
+
+class CompactCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_compact_requires_feature_flag(): void
+    {
+        config()->set('ai.providers.claude_code.enable_compact_command', false);
+
+        $conversation = Conversation::create([
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'provider_type' => 'claude_code',
+            'model' => 'claude-sonnet-4-6',
+            'working_directory' => '/workspace/default',
+            'provider_session_id' => 'sess_123',
+        ]);
+
+        $response = $this->postJson("/api/conversations/{$conversation->uuid}/compact");
+
+        $response->assertStatus(400)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_compact_requires_claude_code_provider(): void
+    {
+        config()->set('ai.providers.claude_code.enable_compact_command', true);
+
+        $conversation = Conversation::create([
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'provider_type' => 'anthropic',
+            'model' => 'claude-sonnet-4-6',
+            'working_directory' => '/workspace/default',
+        ]);
+
+        $response = $this->postJson("/api/conversations/{$conversation->uuid}/compact");
+
+        $response->assertStatus(400)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_compact_requires_existing_provider_session(): void
+    {
+        config()->set('ai.providers.claude_code.enable_compact_command', true);
+
+        $conversation = Conversation::create([
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'provider_type' => 'claude_code',
+            'model' => 'claude-sonnet-4-6',
+            'working_directory' => '/workspace/default',
+        ]);
+
+        $response = $this->postJson("/api/conversations/{$conversation->uuid}/compact");
+
+        $response->assertStatus(409)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_compact_dispatches_stream_job_when_valid(): void
+    {
+        config()->set('ai.providers.claude_code.enable_compact_command', true);
+        Queue::fake();
+
+        $conversation = Conversation::create([
+            'uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'provider_type' => 'claude_code',
+            'model' => 'claude-sonnet-4-6',
+            'working_directory' => '/workspace/default',
+            'provider_session_id' => 'sess_123',
+        ]);
+
+        $streamManager = Mockery::mock(StreamManager::class);
+        $streamManager->shouldReceive('isStreaming')->once()->with($conversation->uuid)->andReturn(false);
+        $streamManager->shouldReceive('startStream')->once();
+        $this->app->instance(StreamManager::class, $streamManager);
+
+        $response = $this->postJson("/api/conversations/{$conversation->uuid}/compact");
+
+        $response->assertOk()->assertJsonPath('success', true);
+        Queue::assertPushed(ProcessConversationStream::class, function (ProcessConversationStream $job) use ($conversation) {
+            return $job->conversationUuid === $conversation->uuid && $job->prompt === '/compact';
+        });
+    }
+}

--- a/www/tests/Unit/ClaudeCodeProviderContextWindowTest.php
+++ b/www/tests/Unit/ClaudeCodeProviderContextWindowTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\ModelRepository;
+use App\Services\Providers\ClaudeCodeProvider;
+use ReflectionMethod;
+use Tests\TestCase;
+
+class ClaudeCodeProviderContextWindowTest extends TestCase
+{
+    public function test_extracts_effective_context_window_from_result_payload(): void
+    {
+        $provider = new ClaudeCodeProvider(new ModelRepository());
+
+        $payload = [
+            'type' => 'result',
+            'modelUsage' => [
+                'primary' => [
+                    'contextWindow' => 200000,
+                ],
+                'secondary' => [
+                    'nested' => [
+                        'contextWindow' => 1000000,
+                    ],
+                ],
+            ],
+        ];
+
+        $method = new ReflectionMethod($provider, 'extractEffectiveContextWindow');
+        $method->setAccessible(true);
+        $window = $method->invoke($provider, $payload);
+
+        $this->assertSame(1000000, $window);
+    }
+
+    public function test_returns_null_when_result_payload_has_no_context_window(): void
+    {
+        $provider = new ClaudeCodeProvider(new ModelRepository());
+
+        $payload = [
+            'type' => 'result',
+            'modelUsage' => [
+                'primary' => [
+                    'tokens' => 123,
+                ],
+            ],
+        ];
+
+        $method = new ReflectionMethod($provider, 'extractEffectiveContextWindow');
+        $method->setAccessible(true);
+        $window = $method->invoke($provider, $payload);
+
+        $this->assertNull($window);
+    }
+}

--- a/www/tests/Unit/ClaudeContextPolicyServiceTest.php
+++ b/www/tests/Unit/ClaudeContextPolicyServiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Conversation;
+use App\Services\ClaudeContextPolicyService;
+use Tests\TestCase;
+
+class ClaudeContextPolicyServiceTest extends TestCase
+{
+    public function test_safe_policy_never_applies_overrides(): void
+    {
+        config()->set('ai.providers.claude_code.context_policy', 'safe');
+        config()->set('ai.providers.claude_code.adaptive_allowed', true);
+
+        $conversation = new Conversation([
+            'provider_type' => 'claude_code',
+            'effective_context_window' => 1000000,
+        ]);
+
+        $decision = app(ClaudeContextPolicyService::class)->evaluateForConversation($conversation);
+
+        $this->assertSame('safe', $decision['applied_mode']);
+        $this->assertFalse($decision['apply_overrides']);
+    }
+
+    public function test_adaptive_applies_only_when_probe_and_effective_window_allow_it(): void
+    {
+        config()->set('ai.providers.claude_code.context_policy', 'adaptive');
+        config()->set('ai.providers.claude_code.adaptive_allowed', true);
+        config()->set('ai.providers.claude_code.adaptive_context_threshold', 900000);
+
+        $conversation = new Conversation([
+            'provider_type' => 'claude_code',
+            'effective_context_window' => 1000000,
+        ]);
+
+        $decision = app(ClaudeContextPolicyService::class)->evaluateForConversation($conversation);
+
+        $this->assertSame('adaptive', $decision['applied_mode']);
+        $this->assertTrue($decision['apply_overrides']);
+        $this->assertSame(977000, $decision['blocking_limit_override']);
+    }
+
+    public function test_adaptive_falls_back_to_safe_when_probe_gate_is_closed(): void
+    {
+        config()->set('ai.providers.claude_code.context_policy', 'adaptive');
+        config()->set('ai.providers.claude_code.adaptive_allowed', false);
+
+        $conversation = new Conversation([
+            'provider_type' => 'claude_code',
+            'effective_context_window' => 1000000,
+        ]);
+
+        $decision = app(ClaudeContextPolicyService::class)->evaluateForConversation($conversation);
+
+        $this->assertSame('safe', $decision['applied_mode']);
+        $this->assertFalse($decision['apply_overrides']);
+        $this->assertSame('probe_gate_blocked', $decision['reason']);
+    }
+
+    public function test_hard_prompt_limit_pattern_detection(): void
+    {
+        $service = app(ClaudeContextPolicyService::class);
+
+        $this->assertTrue($service->isHardPromptLimitError('API Error: Prompt is too long for this model.'));
+        $this->assertFalse($service->isHardPromptLimitError('Temporary network error while reading stream'));
+    }
+}


### PR DESCRIPTION
## Summary
Implements the 1M context working plan with safe defaults and phased rollout controls:

- Phase 1 telemetry path:
  - Parse effective runtime context window from Claude Code result payload (`result.modelUsage.*.contextWindow`)
  - Propagate through stream usage metadata
  - Persist `effective_context_window` on conversations (new migration)
  - Expose configured vs effective context mismatch to API/UI

- Phase 2 policy engine:
  - Add `PD_CLAUDE_CONTEXT_POLICY` (`safe` default, `adaptive`, `force_legacy`)
  - Add `PD_ENABLE_COMPACT_COMMAND` (default `false`)
  - Add adaptive gating and limits:
    - `PD_CLAUDE_ADAPTIVE_ALLOWED`
    - `PD_CLAUDE_ADAPTIVE_CONTEXT_THRESHOLD` (default `900000`)
    - `PD_CLAUDE_ADAPTIVE_BLOCKING_LIMIT_OVERRIDE` (default `977000`)
  - Apply `DISABLE_AUTO_COMPACT=1` and `CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE` only when adaptive is proven for the conversation
  - Auto-demote workspace to safe on hard prompt-limit errors

- Phase 3 `/compact` reintroduction (flagged):
  - New endpoint `POST /api/conversations/{conversation}/compact`
  - Feature-flagged and provider/session validated
  - Frontend intercepts exact `/compact` before slash-skill parsing

- Phase 4 probe gate + startup logs:
  - Add `claude-capability-probe.sh`
  - Queue entrypoints now log CLI version + probe results and export adaptive gate env
  - Adaptive rollout is blocked automatically when probe fails

- Phase 5 tests:
  - Unit tests for context extraction and policy decisions
  - Feature tests for compact routing/validation/dispatch

## Files
- Provider/policy/streaming:
  - `www/app/Services/Providers/ClaudeCodeProvider.php`
  - `www/app/Services/ClaudeContextPolicyService.php`
  - `www/app/Streaming/StreamEvent.php`
  - `www/app/Jobs/ProcessConversationStream.php`

- API/UI:
  - `www/app/Http/Controllers/Api/ConversationController.php`
  - `www/routes/api.php`
  - `www/resources/views/chat.blade.php`
  - `www/resources/js/stores/streamStore.js`
  - `www/resources/views/components/chat/context-progress.blade.php`

- Data/config:
  - `www/database/migrations/2026_04_11_210000_add_effective_context_window_to_conversations_table.php`
  - `www/app/Models/Conversation.php`
  - `www/config/ai.php`
  - `.env.example`
  - `docker-laravel/production/.env.example`

- Probe/startup:
  - `docker-laravel/shared/scripts/claude-capability-probe.sh`
  - `docker-laravel/local/php/queue-entrypoint.sh`
  - `docker-laravel/production/php/queue-entrypoint.sh`
  - `docker-laravel/local/php/Dockerfile`
  - `docker-laravel/production/php/Dockerfile`

- Tests:
  - `www/tests/Unit/ClaudeContextPolicyServiceTest.php`
  - `www/tests/Unit/ClaudeCodeProviderContextWindowTest.php`
  - `www/tests/Feature/CompactCommandTest.php`

## Local test run (this workspace)
Followed `CONTRIBUTING.md` local-container test pattern (`docker compose exec pocket-dev-php ...`).

1. Install dependencies in this checkout:
```bash
cd /workspace/default/pocket-dev
docker compose exec pocket-dev-php sh -lc 'cd /workspace/default/pocket-dev/www && composer install --no-interaction --prefer-dist'
```

2. Run focused tests (with DB env from running container):
```bash
cd /workspace/default/pocket-dev
docker compose exec pocket-dev-php sh -lc '\
  cd /workspace/default/pocket-dev/www && \
  PD_DB_CONNECTION=pgsql \
  PD_DB_HOST=pocket-dev-postgres \
  PD_DB_PORT=5432 \
  PD_DB_DATABASE=pocket-dev \
  PD_DB_USERNAME=pocket-dev \
  PD_DB_PASSWORD=<from /var/www/.env> \
  PD_DB_READONLY_PASSWORD=<from /var/www/.env> \
  PD_DB_MEMORY_AI_PASSWORD=<from /var/www/.env> \
  php artisan test \
    tests/Unit/ClaudeContextPolicyServiceTest.php \
    tests/Unit/ClaudeCodeProviderContextWindowTest.php \
    tests/Feature/CompactCommandTest.php \
    --colors=never'
```

Note: PHPUnit reports these runs as warnings (`file_get_contents(/workspace/...)`) but assertions pass and command exits successfully.

## Rollback switches
- `PD_CLAUDE_CONTEXT_POLICY=safe`
- `PD_ENABLE_COMPACT_COMMAND=false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `/compact` command for Claude Code conversations to optimize context usage.
  * Introduced context policy modes (`safe`, `adaptive`, `force_legacy`) with automatic runtime detection.
  * Added visual indicator when runtime context window differs from configured context window.
  * New environment variables for context policy, compact command toggle, and adaptive mode configuration.

* **Chores**
  * Added Docker capability probing to detect Claude CLI capabilities at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->