### PR TITLE
Auto-focus chat input after voice transcription (desktop only)

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -6275,6 +6275,11 @@
                             if (this.autoSendAfterTranscription) {
                                 this.autoSendAfterTranscription = false;
                                 setTimeout(() => this.sendMessage(), 100);
+                            } else {
+                                // Focus the chat input after transcription
+                                this.$nextTick(() => {
+                                    this.focusPromptInput();
+                                });
                             }
                         } else {
                             this.showError('Transcription failed: ' + (data.error || 'Unknown error'));
@@ -6517,10 +6522,15 @@
                     }
                     this.cleanupRealtimeSession();
 
-                    // Handle auto-send
+                    // Handle auto-send or focus input
                     if (this.autoSendAfterTranscription && this.prompt.trim()) {
                         this.autoSendAfterTranscription = false;
                         setTimeout(() => this.sendMessage(), 100);
+                    } else {
+                        // Focus the chat input after transcription
+                        this.$nextTick(() => {
+                            this.focusPromptInput();
+                        });
                     }
                 },
 
@@ -6617,6 +6627,24 @@
                             textarea.scrollTop = textarea.scrollHeight;
                         });
                     });
+                },
+
+                // Focus the prompt input (desktop only - on mobile it would trigger keyboard)
+                focusPromptInput() {
+                    // Skip on mobile to avoid keyboard popping up after voice transcription
+                    if (this.windowWidth < 768) {
+                        return;
+                    }
+
+                    // Find the visible textarea
+                    const textareas = this.$root.querySelectorAll('textarea[x-model="prompt"]');
+                    for (const textarea of textareas) {
+                        // Check if visible (not display:none and has dimensions)
+                        if (textarea.offsetParent !== null) {
+                            textarea.focus();
+                            return;
+                        }
+                    }
                 },
 
                 // ==================== Copy Conversation ====================


### PR DESCRIPTION
## Summary
- After voice transcription completes, the chat input automatically receives focus on desktop
- On mobile, auto-focus is skipped to avoid the keyboard popping up unexpectedly after voice input
- Adds `focusPromptInput()` helper that finds the visible textarea (handles both desktop/mobile DOM elements)

## Test plan
- [ ] On desktop: record voice message → after transcription, input should be focused
- [ ] On mobile: record voice message → after transcription, keyboard should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcription auto-send behavior is now conditional based on user settings
  * Input field automatically receives focus after transcription completes
  * Mobile experience optimized to prevent unwanted keyboard activation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->