### PR TITLE
Fix system prompt modal closing immediately from agent selector

### DIFF
--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -401,6 +401,7 @@
                 count: 0,
                 _initialized: false,
                 _handledBackNavigation: false,  // Flag to prevent chatApp from also handling
+                _closeTimer: null,  // Deferred history.back() timer for modal transitions
 
                 init() {
                     if (this._initialized) return;
@@ -419,10 +420,15 @@
                 },
 
                 opened() {
+                    // Cancel any pending history.back() from a closing modal (modal-to-modal transition)
+                    if (this._closeTimer) {
+                        clearTimeout(this._closeTimer);
+                        this._closeTimer = null;
+                    }
                     const wasZero = this.count === 0;
                     this.count++;
-                    if (wasZero) {
-                        // First modal - push one history entry as buffer
+                    if (wasZero && !history.state?.modalOpen) {
+                        // First modal and no existing history entry - push one as buffer
                         history.pushState({ modalOpen: true }, '');
                     }
                 },
@@ -431,8 +437,15 @@
                     if (this.count > 0) {
                         this.count--;
                         if (this.count === 0 && history.state?.modalOpen) {
-                            // Last modal closed via UI - clean up history entry
-                            history.back();
+                            // Defer history.back() to allow modal transitions (close one, open another)
+                            // If opened() is called before this fires, the timer is cancelled
+                            this._closeTimer = setTimeout(() => {
+                                this._closeTimer = null;
+                                if (this.count === 0 && history.state?.modalOpen) {
+                                    // Last modal truly closed - clean up history entry
+                                    history.back();
+                                }
+                            }, 0);
                         }
                     }
                 }

--- a/www/resources/views/chat.blade.php
+++ b/www/resources/views/chat.blade.php
@@ -397,6 +397,13 @@
 
             // Simple modal back button support
             // Pushes ONE history entry when first modal opens, closes ALL modals on back
+            //
+            // IMPORTANT — Modal-to-modal transitions (close A, open B) require both
+            // state changes to happen synchronously in the same handler, before any
+            // await/nextTick/rAF. Alpine batches x-effect callbacks via microtask, so
+            // opened() can cancel the deferred history.back() timer set by closed().
+            // If the open is deferred (behind await/nextTick/rAF), the timer fires
+            // first and closes the new modal.
             Alpine.store('modalBackButton', {
                 count: 0,
                 _initialized: false,
@@ -415,6 +422,11 @@
                             // Back button pressed - close all modals
                             window.dispatchEvent(new CustomEvent('close-all-modals'));
                             this.count = 0;
+                            // Cancel any pending deferred history.back() to prevent double navigation
+                            if (this._closeTimer) {
+                                clearTimeout(this._closeTimer);
+                                this._closeTimer = null;
+                            }
                         }
                     });
                 },


### PR DESCRIPTION
## Summary
- Fixed a bug where clicking "System Prompt" from the agent selector modal would briefly flash the system prompt preview and then close it
- Root cause: `modalBackButton.closed()` called `history.back()` synchronously, whose async `popstate` event would fire `close-all-modals` on the newly opened modal
- Fix defers `history.back()` with `setTimeout(0)` so `opened()` can cancel it during modal-to-modal transitions, and skips duplicate `pushState` when a history entry already exists

## Test plan
- [ ] Open agent selector → click "System Prompt" → verify it stays open
- [ ] Open any modal → close it → verify browser back button still works correctly
- [ ] Open modal → press browser back → verify all modals close
- [ ] Open multiple modals stacked → close them one by one → verify history cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal back-button behavior: modal closes are deferred during transitions to avoid premature navigation.
  * Added handling to cancel a pending deferred back action when the browser back button is used, preventing double navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->