### PR TITLE
Fix auth middleware rejecting users in bypass mode

### DIFF
--- a/www/app/Http/Middleware/Authenticate.php
+++ b/www/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\AppSettingsService;
+use Illuminate\Auth\Middleware\Authenticate as BaseAuthenticate;
+use Illuminate\Http\Request;
+
+/**
+ * Bypass-aware authentication middleware.
+ *
+ * Extends Laravel's built-in Authenticate middleware to honour PocketDev's
+ * two auth-bypass modes (permanent and session-based).  Without this,
+ * routes that apply the `auth` middleware as defense-in-depth would reject
+ * bypassed users — they pass through EnsureSetupComplete (which knows about
+ * bypass) but fail the standard Auth::check() because no user is logged in.
+ */
+class Authenticate extends BaseAuthenticate
+{
+    /**
+     * Determine if the user is logged in to any of the given guards,
+     * allowing bypass modes to skip the check entirely.
+     */
+    protected function authenticate($request, array $guards): void
+    {
+        $settings = app(AppSettingsService::class);
+
+        // When auth is bypassed there is no user to authenticate — let through.
+        if ($settings->isAuthBypassPermanent()
+            || $request->session()->get('auth_bypass_session')) {
+            return;
+        }
+
+        parent::authenticate($request, $guards);
+    }
+
+    /**
+     * Get the path the user should be redirected to when not authenticated.
+     */
+    protected function redirectTo(Request $request): ?string
+    {
+        return $request->expectsJson() ? null : route('login');
+    }
+}

--- a/www/bootstrap/app.php
+++ b/www/bootstrap/app.php
@@ -25,6 +25,13 @@ return Application::configure(basePath: dirname(__DIR__))
             '192.168.0.0/16',  // Private network range
         ]);
 
+        // Override the default 'auth' middleware with our bypass-aware version
+        // so that routes using `auth` as defense-in-depth don't reject users
+        // who are operating in auth-bypass mode (permanent or session).
+        $middleware->alias([
+            'auth' => \App\Http\Middleware\Authenticate::class,
+        ]);
+
         // Redirect to setup wizard if not complete (web routes)
         // Note: API routes are now in web.php under /api prefix, so they get
         // full web middleware (session, CSRF, cookies) automatically.

--- a/www/docs/architecture/authentication.md
+++ b/www/docs/architecture/authentication.md
@@ -52,6 +52,20 @@ All `/settings/security/*` mutation routes are `auth`-gated and `throttle:10,1`-
 
 Any action that rotates recovery codes (first-time 2FA enrollment, regenerate, reset TOTP) stashes the new codes in `session('pending_2fa_commit')` and redirects to `/settings/security/recovery-codes`. The user sees the codes, must explicitly acknowledge them, and only then is the user record updated. This prevents account lockouts where 2FA is enabled but the user never saw their codes.
 
+## Middleware: Authenticate (bypass-aware `auth`)
+
+The custom `Authenticate` middleware (`app/Http/Middleware/Authenticate.php`) overrides Laravel's built-in `auth` middleware alias (registered in `bootstrap/app.php`). It extends `Illuminate\Auth\Middleware\Authenticate` with one addition: before checking `Auth::check()`, it honours PocketDev's bypass modes.
+
+### Why This Exists
+
+Several routes apply `auth` as defense-in-depth (system management, Claude/Codex auth uploads, security settings mutations). Without the bypass-aware override, users operating in auth-bypass mode would be rejected by these routes — `EnsureSetupComplete` lets them through, but the standard `auth` middleware sees no logged-in user and redirects to `/login`.
+
+### Check Order
+
+1. **Permanent bypass** (`auth_bypass_permanent = true`) — allow through
+2. **Session bypass** (`auth_bypass_session` in session) — allow through
+3. **Delegate to parent** — standard `Auth::check()` against the given guard(s)
+
 ## Middleware: EnsureSetupComplete
 
 The `EnsureSetupComplete` middleware (`app/Http/Middleware/EnsureSetupComplete.php`) protects both web and API routes.


### PR DESCRIPTION
## Summary
- Routes with explicit `auth` middleware (system restart, check-update, Claude/Codex auth uploads, security settings mutations) redirected to `/login` for users in auth-bypass mode
- The global `EnsureSetupComplete` middleware honours bypass, but Laravel's built-in `Authenticate` does not — causing a mismatch where the page loads fine but form submissions get rejected
- Added a custom `Authenticate` middleware that checks bypass modes before delegating to `Auth::check()`, registered as the `auth` alias

## Test plan
- [ ] With `auth_bypass_permanent = true`: click "Check for Updates" and "Restart Containers" on `/config/system` — should work without redirect
- [ ] With full auth enabled and logged in: same buttons should work normally
- [ ] With full auth enabled but not logged in: should redirect to `/login` as before
- [ ] Claude/Codex auth file uploads in bypass mode should work
- [ ] Security settings mutations in bypass mode should be accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented custom authentication middleware supporting development bypass modes, allowing authentication checks to be skipped when enabled while maintaining standard authentication for regular scenarios. JSON and non-JSON requests receive different handling.

* **Documentation**
  * Updated authentication architecture documentation with comprehensive details on the new middleware behavior and bypass mode verification sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->