### PR TITLE
feat: native subagents and agents as native tool calls

### DIFF
--- a/www/app/Console/Commands/SubAgentCancelCommand.php
+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentCancelTool;
+use Illuminate\Console\Command;
+
+class SubAgentCancelCommand extends Command
+{
+    protected $signature = 'subagent:cancel
+        {--task-id= : The task UUID returned by subagent:run --background}';
+
+    protected $description = 'Cancel a running background sub-agent task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentCancelTool();
+
+        $input = [
+            'task_id' => $this->option('task-id') ?? '',
+        ];
+
+        // Note: when called from CLI (not from within a conversation), there is no
+        // parent conversation UUID — the ownership guard in the tool is skipped.
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Console/Commands/SubAgentCancelCommand.php
+++ b/www/app/Console/Commands/SubAgentCancelCommand.php
@@ -36,6 +36,12 @@ class SubAgentCancelCommand extends Command
 
     private function outputJson(array $data): void
     {
-        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if ($json === false) {
+            throw new \RuntimeException('Failed to encode sub-agent output as JSON: ' . json_last_error_msg());
+        }
+
+        $this->output->writeln($json);
     }
 }

--- a/www/app/Console/Commands/SubAgentOutputCommand.php
+++ b/www/app/Console/Commands/SubAgentOutputCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentOutputTool;
+use Illuminate\Console\Command;
+
+class SubAgentOutputCommand extends Command
+{
+    protected $signature = 'subagent:output
+        {--task-id= : The task UUID returned by subagent:run --background}';
+
+    protected $description = 'Retrieve the status and output of a sub-agent task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentOutputTool();
+
+        $input = [
+            'task_id' => $this->option('task-id') ?? '',
+        ];
+
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Console/Commands/SubAgentOutputCommand.php
+++ b/www/app/Console/Commands/SubAgentOutputCommand.php
@@ -34,6 +34,12 @@ class SubAgentOutputCommand extends Command
 
     private function outputJson(array $data): void
     {
-        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if ($json === false) {
+            throw new \RuntimeException('Failed to encode sub-agent output as JSON: ' . json_last_error_msg());
+        }
+
+        $this->output->writeln($json);
     }
 }

--- a/www/app/Console/Commands/SubAgentRunCommand.php
+++ b/www/app/Console/Commands/SubAgentRunCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Session;
+use App\Models\Workspace;
+use App\Tools\ExecutionContext;
+use App\Tools\SubAgentTool;
+use Illuminate\Console\Command;
+
+class SubAgentRunCommand extends Command
+{
+    protected $signature = 'subagent:run
+        {--agent= : Agent slug or UUID}
+        {--prompt= : The task/prompt to send to the sub-agent}
+        {--background : Return immediately with a task ID (default: wait for completion)}';
+
+    protected $description = 'Spawn a child PocketDev agent to handle a task';
+
+    public function handle(): int
+    {
+        $tool = new SubAgentTool();
+
+        $input = [
+            'agent' => $this->option('agent') ?? '',
+            'prompt' => $this->option('prompt') ?? '',
+            'background' => $this->option('background'),
+        ];
+
+        // Build execution context from environment
+        $session = null;
+        $workspace = null;
+        $conversationUuid = null;
+
+        $sessionId = getenv('POCKETDEV_SESSION_ID') ?: null;
+        if ($sessionId) {
+            $session = Session::find($sessionId);
+        }
+
+        $workspaceId = getenv('POCKETDEV_WORKSPACE_ID') ?: null;
+        if ($workspaceId) {
+            $workspace = Workspace::find($workspaceId);
+        }
+
+        $conversationUuid = getenv('POCKETDEV_CONVERSATION_UUID') ?: null;
+
+        $context = new ExecutionContext(
+            getcwd() ?: '/var/www',
+            workspace: $workspace,
+            session: $session,
+            conversationUuid: $conversationUuid,
+        );
+
+        $result = $tool->execute($input, $context);
+
+        $this->outputJson($result->toArray());
+
+        return $result->isError() ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function outputJson(array $data): void
+    {
+        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/www/app/Console/Commands/SubAgentRunCommand.php
+++ b/www/app/Console/Commands/SubAgentRunCommand.php
@@ -60,6 +60,12 @@ class SubAgentRunCommand extends Command
 
     private function outputJson(array $data): void
     {
-        $this->output->writeln(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if ($json === false) {
+            throw new \RuntimeException('Failed to encode sub-agent output as JSON: ' . json_last_error_msg());
+        }
+
+        $this->output->writeln($json);
     }
 }

--- a/www/app/Http/Controllers/ConfigController.php
+++ b/www/app/Http/Controllers/ConfigController.php
@@ -346,6 +346,17 @@ class ConfigController extends Controller
     {
         $request->session()->put('config_last_section', 'agents');
 
+        $selectedWorkspaceId = $request->query('workspace_id');
+
+        $exposedAgents = collect();
+        if ($selectedWorkspaceId) {
+            $exposedAgents = Agent::where('workspace_id', $selectedWorkspaceId)
+                ->where('enabled', true)
+                ->where('expose_as_tool', true)
+                ->orderBy('name')
+                ->get(['id', 'name', 'slug']);
+        }
+
         $viewData = [
             'providers' => Agent::getProviders(),
             'modelsPerProvider' => collect(Agent::getProviders())
@@ -355,9 +366,10 @@ class ConfigController extends Controller
                 ->mapWithKeys(fn ($p) => [$p => $this->getMaxContextPerProvider($p)])
                 ->toArray(),
             'workspaces' => Workspace::orderBy('name')->get(),
-            'selectedWorkspaceId' => $request->query('workspace_id'),
+            'selectedWorkspaceId' => $selectedWorkspaceId,
             'sourceAgent' => null,
             'cloneWarnings' => null,
+            'exposedAgents' => $exposedAgents,
         ];
 
         // Handle "Create from" (cloning an existing agent)
@@ -505,7 +517,9 @@ class ConfigController extends Controller
                     'extended_context' => ($validated['extended_context'] ?? '1') === '1',
                     'expose_as_tool' => $validated['expose_as_tool'] ?? false,
                     'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? true),
-                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
+                    'allowed_subagents' => ((bool) ($validated['can_call_subagents'] ?? true) && !empty($validated['allowed_subagents']))
+                        ? $validated['allowed_subagents']
+                        : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)
@@ -642,7 +656,9 @@ class ConfigController extends Controller
                     'extended_context' => ($validated['extended_context'] ?? '1') === '1',
                     'expose_as_tool' => $validated['expose_as_tool'] ?? false,
                     'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? true),
-                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
+                    'allowed_subagents' => ((bool) ($validated['can_call_subagents'] ?? true) && !empty($validated['allowed_subagents']))
+                        ? $validated['allowed_subagents']
+                        : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)

--- a/www/app/Http/Controllers/ConfigController.php
+++ b/www/app/Http/Controllers/ConfigController.php
@@ -8,11 +8,13 @@ use App\Models\Workspace;
 use App\Services\NativeToolService;
 use App\Services\ToolSelector;
 use App\Services\VersionService;
+use App\Tools\AgentTool;
 use App\Tools\Tool;
 use App\Tools\UserTool;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
 
 class ConfigController extends Controller
 {
@@ -443,6 +445,17 @@ class ConfigController extends Controller
                 'is_default' => 'nullable|boolean',
                 'enabled' => 'nullable|boolean',
                 'extended_context' => 'nullable|in:0,1',
+                'expose_as_tool' => 'nullable|boolean',
+                'can_call_subagents' => 'nullable|boolean',
+                'allowed_subagents' => 'nullable|array',
+                'allowed_subagents.*' => [
+                    'uuid',
+                    Rule::exists('agents', 'id')->where(function ($query) use ($request) {
+                        $query->where('workspace_id', $request->input('workspace_id'))
+                            ->where('enabled', true)
+                            ->where('expose_as_tool', true);
+                    }),
+                ],
             ]);
 
             // Check for duplicate slug within workspace
@@ -451,6 +464,12 @@ class ConfigController extends Controller
                 return redirect()->back()
                     ->withInput()
                     ->with('error', 'An agent with this name already exists in this workspace');
+            }
+
+            if (($validated['expose_as_tool'] ?? false) && !AgentTool::isCompatibleAgentSlug($slug)) {
+                return redirect()->back()
+                    ->withInput()
+                    ->with('error', 'This agent name produces a native tool name that is too long or contains unsupported characters. Keep the generated slug at 58 characters or fewer.');
             }
 
             // Parse inherit settings
@@ -484,6 +503,9 @@ class ConfigController extends Controller
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
                     'extended_context' => ($validated['extended_context'] ?? '1') === '1',
+                    'expose_as_tool' => $validated['expose_as_tool'] ?? false,
+                    'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? true),
+                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)
@@ -510,6 +532,15 @@ class ConfigController extends Controller
     {
         $request->session()->put('config_last_section', 'agents');
 
+        // Load other agents in this workspace that have expose_as_tool enabled
+        // (candidates for the caller-side allowed_subagents multi-select)
+        $exposedAgents = Agent::where('workspace_id', $agent->workspace_id)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true)
+            ->where('id', '!=', $agent->id)
+            ->orderBy('name')
+            ->get(['id', 'name', 'slug']);
+
         return view('config.agents.form', [
             'agent' => $agent,
             'providers' => Agent::getProviders(),
@@ -519,6 +550,7 @@ class ConfigController extends Controller
             'maxContextPerProvider' => collect(Agent::getProviders())
                 ->mapWithKeys(fn ($p) => [$p => $this->getMaxContextPerProvider($p)])
                 ->toArray(),
+            'exposedAgents' => $exposedAgents,
         ]);
     }
 
@@ -549,6 +581,18 @@ class ConfigController extends Controller
                 'is_default' => 'nullable|boolean',
                 'enabled' => 'nullable|boolean',
                 'extended_context' => 'nullable|in:0,1',
+                'expose_as_tool' => 'nullable|boolean',
+                'can_call_subagents' => 'nullable|boolean',
+                'allowed_subagents' => 'nullable|array',
+                'allowed_subagents.*' => [
+                    'uuid',
+                    Rule::exists('agents', 'id')->where(function ($query) use ($agent) {
+                        $query->where('workspace_id', $agent->workspace_id)
+                            ->where('enabled', true)
+                            ->where('expose_as_tool', true)
+                            ->where('id', '!=', $agent->id);
+                    }),
+                ],
             ]);
 
             // Check for duplicate slug within workspace (excluding current agent)
@@ -557,6 +601,12 @@ class ConfigController extends Controller
                 return redirect()->back()
                     ->withInput()
                     ->with('error', 'An agent with this name already exists in this workspace');
+            }
+
+            if (($validated['expose_as_tool'] ?? false) && !AgentTool::isCompatibleAgentSlug($slug)) {
+                return redirect()->back()
+                    ->withInput()
+                    ->with('error', 'This agent name produces a native tool name that is too long or contains unsupported characters. Keep the generated slug at 58 characters or fewer.');
             }
 
             // Parse inherit settings
@@ -590,6 +640,9 @@ class ConfigController extends Controller
                     'is_default' => $validated['is_default'] ?? false,
                     'enabled' => $validated['enabled'] ?? true,
                     'extended_context' => ($validated['extended_context'] ?? '1') === '1',
+                    'expose_as_tool' => $validated['expose_as_tool'] ?? false,
+                    'can_call_subagents' => (bool) ($validated['can_call_subagents'] ?? true),
+                    'allowed_subagents' => !empty($validated['allowed_subagents']) ? $validated['allowed_subagents'] : null,
                 ]);
 
                 // Sync memory schemas (only if not inheriting)

--- a/www/app/Jobs/ProcessConversationStream.php
+++ b/www/app/Jobs/ProcessConversationStream.php
@@ -283,7 +283,7 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
 
         // Prepare provider options
         $getToolDefsStart = microtime(true);
-        $toolDefinitions = $toolRegistry->getDefinitions();
+        $toolDefinitions = $toolRegistry->getDefinitions($conversation->agent);
         $getToolDefsTime = (microtime(true) - $getToolDefsStart) * 1000;
         RequestFlowLogger::log('job.loop.tool_definitions', 'Tool definitions retrieved', [
             'duration_ms' => round($getToolDefsTime, 2),
@@ -702,6 +702,44 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             RequestFlowLogger::log('job.loop.saving_tool_results', 'Saving tool results message');
             $this->saveToolResultMessage($conversation, $toolResults);
 
+            // Check for end-turn signal from a tool (e.g. SubAgent in background mode).
+            // When present, finalize the parent turn immediately without a second AI call,
+            // saving a synthetic assistant message to keep the conversation history well-formed
+            // (avoids two consecutive user messages on the next turn).
+            $endTurnResults = array_values(array_filter(
+                $toolResults,
+                fn (array $result) => $result['end_turn'] ?? false
+            ));
+
+            if (!empty($endTurnResults) && count($endTurnResults) === count($toolResults)) {
+                $messages = array_values(array_unique(array_filter(
+                    array_map(
+                        fn (array $result) => $result['end_turn_message'] ?? null,
+                        $endTurnResults
+                    )
+                )));
+
+                $endTurnMessage = match (count($messages)) {
+                    0 => 'Background agent started.',
+                    1 => $messages[0],
+                    default => implode("\n", $messages),
+                };
+
+                RequestFlowLogger::log('job.loop.end_turn_signal', 'End-turn signal from tool — ending parent turn early', [
+                    'tool_use_ids' => array_map(
+                        fn (array $result) => $result['tool_use_id'],
+                        $endTurnResults
+                    ),
+                ]);
+                $this->saveAssistantMessage(
+                    $conversation,
+                    [['type' => 'text', 'text' => $endTurnMessage]],
+                    0, 0, null, null,
+                    'end_turn',
+                );
+                return; // handle() will call completeProcessing()
+            }
+
             // Continue with tool results (recursive)
             // Pass the original user message for abort sync consistency
             RequestFlowLogger::log('job.loop.recursive_call', 'Making recursive call for tool results', [
@@ -825,11 +863,12 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
         // Get session from conversation's screen (for panel tools that need to create screens)
         $session = $conversation->screen?->session;
 
-        // Pass workspace, session, and stream context so tools can access workspace-specific credentials,
-        // create panel screens, and emit stream events when needed
+        // Pass workspace, agent, session, and stream context so tools can access workspace-specific
+        // credentials, create panel screens, emit stream events, and enforce sub-agent permissions
         $context = new ExecutionContext(
             $conversation->working_directory,
             workspace: $conversation->workspace,
+            agent: $conversation->agent,
             session: $session,
             streamManager: $streamManager,
             conversationUuid: $this->conversationUuid,
@@ -844,9 +883,11 @@ class ProcessConversationStream implements ShouldQueue, ShouldBeUniqueUntilProce
             );
 
             $results[] = [
-                'tool_use_id' => $toolUse['id'],
-                'content' => $result->output,
-                'is_error' => $result->isError,
+                'tool_use_id'      => $toolUse['id'],
+                'content'          => $result->output,
+                'is_error'         => $result->isError,
+                'end_turn'         => $result->endTurn,
+                'end_turn_message' => $result->endTurnMessage,
             ];
         }
 

--- a/www/app/Models/Agent.php
+++ b/www/app/Models/Agent.php
@@ -45,6 +45,9 @@ class Agent extends Model
         'is_default',
         'enabled',
         'extended_context',
+        'expose_as_tool',
+        'can_call_subagents',
+        'allowed_subagents',
     ];
 
     protected $casts = [
@@ -56,6 +59,9 @@ class Agent extends Model
         'extended_context' => 'boolean',
         'reasoning_config' => 'array',
         'response_level' => 'integer',
+        'expose_as_tool' => 'boolean',
+        'can_call_subagents' => 'boolean',
+        'allowed_subagents' => 'array',
     ];
 
     protected static function boot(): void

--- a/www/app/Models/SubAgentTask.php
+++ b/www/app/Models/SubAgentTask.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SubAgentTask extends Model
+{
+    use HasUuids;
+
+    protected $table = 'subagent_tasks';
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'parent_conversation_uuid',
+        'child_conversation_uuid',
+        'agent_id',
+        'prompt',
+        'is_background',
+    ];
+
+    protected $casts = [
+        'is_background' => 'boolean',
+    ];
+
+    // -------------------------------------------------------------------------
+    // Relationships
+    // -------------------------------------------------------------------------
+
+    public function childConversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class, 'child_conversation_uuid', 'uuid');
+    }
+
+    public function parentConversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class, 'parent_conversation_uuid', 'uuid');
+    }
+
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Agent::class);
+    }
+
+    // -------------------------------------------------------------------------
+    // Derived methods (read from the child conversation live, no caching)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the current status of the subagent task.
+     * Derived from the child conversation's status.
+     */
+    public function getStatus(): string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation) {
+            return 'pending';
+        }
+        return match ($conversation->status) {
+            Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED => 'completed',
+            Conversation::STATUS_PROCESSING => 'running',
+            Conversation::STATUS_FAILED => 'failed',
+            default => 'pending',
+        };
+    }
+
+    /**
+     * Collect the output from all assistant messages in the child conversation.
+     */
+    public function collectOutput(): string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation) {
+            return '';
+        }
+
+        $messages = $conversation->messages()
+            ->where('role', 'assistant')
+            ->orderBy('sequence')
+            ->get();
+
+        $output = [];
+        foreach ($messages as $message) {
+            $text = trim($message->getTextContent());
+            if ($text !== '') {
+                $output[] = $text;
+            }
+        }
+
+        return implode("\n\n", $output);
+    }
+
+    /**
+     * Get error message if the task failed.
+     */
+    public function getError(): ?string
+    {
+        $conversation = $this->childConversation;
+        if (!$conversation || $conversation->status !== Conversation::STATUS_FAILED) {
+            return null;
+        }
+
+        $errorMessage = $conversation->messages()
+            ->where('role', 'error')
+            ->orderByDesc('sequence')
+            ->first();
+
+        if ($errorMessage) {
+            $content = $errorMessage->content;
+            if (is_array($content)) {
+                foreach ($content as $block) {
+                    if (is_array($block) && ($block['type'] ?? '') === 'text') {
+                        return $block['text'];
+                    }
+                }
+            }
+            if (is_string($content)) {
+                return $content;
+            }
+        }
+
+        return 'Task failed (no error details available)';
+    }
+}

--- a/www/app/Models/SubAgentTask.php
+++ b/www/app/Models/SubAgentTask.php
@@ -112,7 +112,7 @@ class SubAgentTask extends Model
             $content = $errorMessage->content;
             if (is_array($content)) {
                 foreach ($content as $block) {
-                    if (is_array($block) && ($block['type'] ?? '') === 'text') {
+                    if (is_array($block) && ($block['type'] ?? '') === 'text' && array_key_exists('text', $block)) {
                         return $block['text'];
                     }
                 }

--- a/www/app/Services/Providers/AbstractCliProvider.php
+++ b/www/app/Services/Providers/AbstractCliProvider.php
@@ -192,6 +192,12 @@ abstract class AbstractCliProvider implements AIProviderInterface, HasNativeSess
             $env['POCKETDEV_SESSION_ID'] = $sessionId;
         }
 
+        // Inject conversation UUID and workspace ID for sub-agent spawning
+        $env['POCKETDEV_CONVERSATION_UUID'] = $conversation->uuid;
+        if ($conversation->workspace_id) {
+            $env['POCKETDEV_WORKSPACE_ID'] = $conversation->workspace_id;
+        }
+
         return $env;
     }
 

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -146,11 +146,12 @@ class SubAgentRunner
         ?string $workspaceId,
     ): ToolResult {
         $conversation = Conversation::where('uuid', $conversationId)
+            ->where('agent_id', $agent->id)
             ->when($workspaceId, fn($q) => $q->where('workspace_id', $workspaceId))
             ->first();
 
         if (!$conversation) {
-            return ToolResult::error("Conversation '{$conversationId}' not found or not accessible.");
+            return ToolResult::error("Conversation '{$conversationId}' not found, not accessible, or belongs to a different agent.");
         }
 
         if ($conversation->status === Conversation::STATUS_PROCESSING) {

--- a/www/app/Services/SubAgentRunner.php
+++ b/www/app/Services/SubAgentRunner.php
@@ -1,0 +1,250 @@
+<?php
+
+namespace App\Services;
+
+use App\Jobs\ProcessConversationStream;
+use App\Models\Agent;
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Tools\ExecutionContext;
+use App\Tools\ToolResult;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Encapsulates the logic for spawning a sub-agent conversation.
+ *
+ * Used by both SubAgentTool (generic slug-based dispatch) and AgentTool
+ * (per-agent native tool calls). Supports foreground and background modes,
+ * as well as resuming an existing conversation.
+ */
+class SubAgentRunner
+{
+    public function __construct(
+        private readonly ConversationFactory $factory,
+        private readonly StreamManager $streamManager,
+    ) {}
+
+    /**
+     * Run an agent with the given prompt.
+     *
+     * @param Agent           $agent          The agent to spawn
+     * @param string          $prompt         The task/prompt to send
+     * @param bool            $isBackground   Return immediately (background) or wait (foreground)
+     * @param ExecutionContext $context        Caller's execution context
+     * @param string|null     $conversationId Existing conversation UUID to resume (optional)
+     */
+    public function run(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        ?string $conversationId = null,
+    ): ToolResult {
+        $workspace = $context->getWorkspace() ?? $agent->workspace;
+        $workspaceId = $workspace?->id;
+        $workingDirectory = $context->workingDirectory;
+
+        try {
+            if ($conversationId !== null) {
+                return $this->resume($agent, $prompt, $isBackground, $context, $conversationId, $workspaceId);
+            }
+
+            return $this->spawn($agent, $prompt, $isBackground, $context, $workspaceId, $workingDirectory);
+        } catch (\Throwable $e) {
+            Log::error('SubAgentRunner: failed to start sub-agent', [
+                'agent' => $agent->slug,
+                'error' => $e->getMessage(),
+            ]);
+            return ToolResult::error('Failed to start sub-agent: ' . $e->getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private function spawn(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        ?string $workspaceId,
+        string $workingDirectory,
+    ): ToolResult {
+        [$conversation, $task] = DB::transaction(function () use ($agent, $workingDirectory, $workspaceId, $prompt, $context, $isBackground) {
+            $conversation = $this->factory->createFromAgent(
+                $agent,
+                $workingDirectory,
+                $workspaceId,
+                'Subagent: ' . Str::limit($prompt, 60)
+            );
+
+            $task = SubAgentTask::create([
+                'parent_conversation_uuid' => $context->conversationUuid,
+                'child_conversation_uuid' => $conversation->uuid,
+                'agent_id' => $agent->id,
+                'prompt' => $prompt,
+                'is_background' => $isBackground,
+            ]);
+
+            return [$conversation, $task];
+        });
+
+        // Initialize the Redis stream (outside transaction)
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+            'subagent_task_id' => $task->id,
+        ]);
+
+        // Mark as processing BEFORE dispatching so waitForCompletion doesn't see
+        // the initial 'idle' status and return prematurely before the job starts.
+        $conversation->startProcessing();
+
+        ProcessConversationStream::dispatch($conversation->uuid, $prompt);
+
+        Log::info('SubAgentRunner: task started', [
+            'task_id' => $task->id,
+            'parent_conversation' => $context->conversationUuid,
+            'child_conversation' => $conversation->uuid,
+            'agent' => $agent->slug,
+            'background' => $isBackground,
+        ]);
+
+        if ($isBackground) {
+            $jsonOutput = json_encode([
+                'task_id' => $task->id,
+                'conversation_id' => $conversation->uuid,
+                'status' => 'running',
+                'agent' => $agent->slug,
+                'provider' => $agent->provider,
+                'model' => $conversation->model,
+                'message' => "Background sub-agent started. Use SubAgentOutput with task_id '{$task->id}' to check status and retrieve output. Use SubAgentCancel with task_id '{$task->id}' to cancel.",
+            ], JSON_PRETTY_PRINT);
+
+            $endTurnMessage = "Background sub-agent started (task `{$task->id}`, agent `{$agent->slug}`). "
+                . "Use SubAgentOutput to check status and retrieve results, "
+                . "or SubAgentCancel to stop it.";
+
+            return ToolResult::successEndTurn($jsonOutput, $endTurnMessage);
+        }
+
+        return $this->waitForCompletion($task, $conversation);
+    }
+
+    /**
+     * Resume an existing conversation by adding a new user message.
+     */
+    private function resume(
+        Agent $agent,
+        string $prompt,
+        bool $isBackground,
+        ExecutionContext $context,
+        string $conversationId,
+        ?string $workspaceId,
+    ): ToolResult {
+        $conversation = Conversation::where('uuid', $conversationId)
+            ->when($workspaceId, fn($q) => $q->where('workspace_id', $workspaceId))
+            ->first();
+
+        if (!$conversation) {
+            return ToolResult::error("Conversation '{$conversationId}' not found or not accessible.");
+        }
+
+        if ($conversation->status === Conversation::STATUS_PROCESSING) {
+            return ToolResult::error("Conversation '{$conversationId}' is still running. Wait for it to complete before resuming.");
+        }
+
+        // Create a new task linked to this resumed conversation
+        $task = SubAgentTask::create([
+            'parent_conversation_uuid' => $context->conversationUuid,
+            'child_conversation_uuid' => $conversation->uuid,
+            'agent_id' => $agent->id,
+            'prompt' => $prompt,
+            'is_background' => $isBackground,
+        ]);
+
+        // Re-initialise the stream for this turn
+        $this->streamManager->startStream($conversation->uuid, [
+            'model' => $conversation->model,
+            'provider' => $conversation->provider_type,
+            'subagent_task_id' => $task->id,
+        ]);
+
+        // Match spawn(): mark processing before dispatch so foreground resume
+        // polling does not race against the queued job's first status update.
+        $conversation->startProcessing();
+
+        ProcessConversationStream::dispatch($conversation->uuid, $prompt);
+
+        Log::info('SubAgentRunner: conversation resumed', [
+            'task_id' => $task->id,
+            'parent_conversation' => $context->conversationUuid,
+            'child_conversation' => $conversation->uuid,
+            'agent' => $agent->slug,
+            'background' => $isBackground,
+        ]);
+
+        if ($isBackground) {
+            $jsonOutput = json_encode([
+                'task_id' => $task->id,
+                'conversation_id' => $conversation->uuid,
+                'status' => 'running',
+                'agent' => $agent->slug,
+                'provider' => $agent->provider,
+                'model' => $conversation->model,
+                'message' => "Resumed conversation. Use SubAgentOutput with task_id '{$task->id}' to check status.",
+            ], JSON_PRETTY_PRINT);
+
+            $endTurnMessage = "Background sub-agent resumed (task `{$task->id}`, agent `{$agent->slug}`). "
+                . "Use SubAgentOutput to check status and retrieve results, "
+                . "or SubAgentCancel to stop it.";
+
+            return ToolResult::successEndTurn($jsonOutput, $endTurnMessage);
+        }
+
+        return $this->waitForCompletion($task, $conversation);
+    }
+
+    /**
+     * Poll the conversation until it reaches a terminal state or times out.
+     */
+    private function waitForCompletion(SubAgentTask $task, Conversation $conversation): ToolResult
+    {
+        $maxWaitSeconds = 600; // 10 minutes
+        $pollIntervalMicroseconds = 1_000_000; // 1 second
+        $startTime = time();
+
+        while (time() - $startTime < $maxWaitSeconds) {
+            $conversation->refresh();
+
+            if (in_array($conversation->status, [Conversation::STATUS_IDLE, Conversation::STATUS_ARCHIVED], true)) {
+                $task->unsetRelation('childConversation');
+                $output = $task->collectOutput();
+                return ToolResult::success(json_encode([
+                    'task_id' => $task->id,
+                    'conversation_id' => $conversation->uuid,
+                    'status' => 'completed',
+                    'output' => $output,
+                ], JSON_PRETTY_PRINT));
+            }
+
+            if ($conversation->status === Conversation::STATUS_FAILED) {
+                $task->unsetRelation('childConversation');
+                $error = $task->getError();
+                return ToolResult::error("Sub-agent task '{$task->id}' failed: {$error}");
+            }
+
+            usleep($pollIntervalMicroseconds);
+        }
+
+        return ToolResult::success(json_encode([
+            'task_id' => $task->id,
+            'conversation_id' => $conversation->uuid,
+            'status' => 'timeout',
+            'message' => "Sub-agent did not complete within {$maxWaitSeconds} seconds. Use SubAgentOutput with task_id '{$task->id}' to check status later.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -10,6 +10,9 @@ use App\Models\MemoryDatabase;
 use App\Models\Screen;
 use App\Models\SystemPackage;
 use App\Models\Workspace;
+use App\Tools\AgentTool;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
  * Builds the system prompt for AI providers.
@@ -94,6 +97,11 @@ class SystemPromptBuilder
             $sections[] = $memorySection;
         }
 
+        // 3b. Available agents section (for SubAgent tool)
+        if ($agentsSection = $this->buildAvailableAgentsSection($workspace)) {
+            $sections[] = $agentsSection;
+        }
+
         // 4. Skills section (slash commands)
         if ($skillsSection = $this->toolSelector->buildSkillsSection($agent)) {
             $sections[] = $skillsSection;
@@ -133,6 +141,14 @@ class SystemPromptBuilder
         // 11. Environment (credentials and packages)
         if ($envSection = $this->buildEnvironmentSection($workspace)) {
             $sections[] = $envSection;
+        }
+
+        // 12. Dedicated agent tools — injected last so it's in the recency zone
+        // For CLI providers this is the equivalent of API agent_* tool definitions.
+        if ($promptType === 'cli' && $agent) {
+            if ($agentToolsSection = $this->buildExposedAgentToolsSection($agent, $workspace)) {
+                $sections[] = $agentToolsSection;
+            }
         }
 
         // Note: Context usage section removed to improve prompt caching.
@@ -462,6 +478,132 @@ pd panel:peek <panel-slug>
 pd panel:peek <panel-slug> --id=<panel-id>
 ```
 PROMPT;
+    }
+
+    /**
+     * Build the Available Agents section for the SubAgent tool.
+     * Only included when agents exist in the workspace.
+     */
+    private function buildAvailableAgentsSection(?Workspace $workspace): ?string
+    {
+        if (!$workspace) {
+            return null;
+        }
+
+        $agents = Agent::where('workspace_id', $workspace->id)
+            ->where('enabled', true)
+            ->orderBy('name')
+            ->get(['slug', 'name', 'provider', 'model', 'description']);
+
+        if ($agents->isEmpty()) {
+            return null;
+        }
+
+        $lines = ["# Available Agents\n"];
+        $lines[] = "Use these agent slugs with the SubAgent tool (`pd subagent:run --agent=<slug>`).\n";
+        $lines[] = "| Slug | Provider | Model | Description |";
+        $lines[] = "|------|----------|-------|-------------|";
+
+        $escapeCell = static function (?string $value): string {
+            $value = preg_replace('/\s+/', ' ', trim((string) $value)) ?? '';
+            return str_replace('|', '\|', $value === '' ? '-' : $value);
+        };
+
+        foreach ($agents as $agent) {
+            $desc = $agent->description
+                ? Str::limit(preg_replace('/\s+/', ' ', trim($agent->description)) ?? '', 60)
+                : '-';
+
+            $lines[] = sprintf(
+                '| %s | %s | %s | %s |',
+                $escapeCell($agent->slug),
+                $escapeCell($agent->provider),
+                $escapeCell($agent->model),
+                $escapeCell($desc),
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * Build a section describing exposed agents as dedicated named tools for CLI providers.
+     *
+     * For API providers this is handled via getDefinitions() injecting agent_* tool schemas.
+     * For CLI providers (Claude Code, Codex) the equivalent is text in the system prompt
+     * describing each exposed agent as a callable tool via `pd subagent:run`.
+     */
+    private function buildExposedAgentToolsSection(?Agent $callerAgent, ?Workspace $workspace = null): ?string
+    {
+        if (!$callerAgent || !$callerAgent->can_call_subagents) {
+            return null;
+        }
+
+        // Resolve the workspace to scope agent lookup.
+        // Agents without a workspace_id (global defaults) fall back to the
+        // conversation workspace so they can still see exposed agents.
+        $workspaceId = $callerAgent->workspace_id ?? $workspace?->id;
+
+        if (!$workspaceId) {
+            return null;
+        }
+
+        $query = Agent::where('workspace_id', $workspaceId)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true)
+            ->where('id', '!=', $callerAgent->id);
+
+        $allowlist = $callerAgent->allowed_subagents;
+        if (!empty($allowlist)) {
+            $query->whereIn('id', $allowlist);
+        }
+
+        $agents = $query->orderBy('name')->get();
+
+        $lines = [];
+        $lines[] = "# AGENT ORCHESTRATION — STRICT RULES\n";
+        $lines[] = "## ❌ NEVER do any of these:";
+        $lines[] = "- Use your built-in `Task` tool to spawn subagents";
+        $lines[] = "- Use any native agent/subagent spawning mechanism";
+        $lines[] = "- Look up agents in memory";
+        $lines[] = "- Use the generic SubAgent tool\n";
+        $lines[] = "## ✅ ALWAYS use PocketDev's `pd subagent:run` via Bash for ALL agent calls:\n";
+        $lines[] = "```bash";
+        $lines[] = "pd subagent:run --agent=<slug> --prompt=\"<task>\"";
+        $lines[] = "```\n";
+        $lines[] = "PocketDev manages all agent orchestration, context, and output. Bypassing it breaks tracking and output capture.\n";
+
+        if ($agents->isEmpty()) {
+            return implode("\n", $lines);
+        }
+
+        $lines[] = "---\n";
+        $lines[] = "## Available PocketDev Agents\n";
+
+        foreach ($agents as $agent) {
+            if (! AgentTool::isCompatibleAgentSlug($agent->slug)) {
+                Log::warning('SystemPromptBuilder: Skipping exposed agent with incompatible tool name', [
+                    'agent_id' => $agent->id,
+                    'agent_slug' => $agent->slug,
+                    'tool_name' => AgentTool::toolNameForSlug($agent->slug),
+                ]);
+                continue;
+            }
+
+            $toolName = AgentTool::toolNameForSlug($agent->slug);
+            $lines[] = "### `{$toolName}`";
+            if ($agent->description) {
+                $lines[] = trim($agent->description);
+            }
+            $lines[] = "**Run via Bash (the ONLY correct way):**";
+            $lines[] = "```bash";
+            $lines[] = "pd subagent:run --agent={$agent->slug} --prompt=\"<task>\"";
+            $lines[] = "```";
+            $lines[] = "❌ Wrong: using Task tool with `{$toolName}`";
+            $lines[] = "✅ Right: `pd subagent:run --agent={$agent->slug} --prompt=\"...\"`\n";
+        }
+
+        return implode("\n", $lines);
     }
 
     /**

--- a/www/app/Services/SystemPromptBuilder.php
+++ b/www/app/Services/SystemPromptBuilder.php
@@ -98,7 +98,7 @@ class SystemPromptBuilder
         }
 
         // 3b. Available agents section (for SubAgent tool)
-        if ($agentsSection = $this->buildAvailableAgentsSection($workspace)) {
+        if ($agentsSection = $this->buildAvailableAgentsSection($agent, $workspace)) {
             $sections[] = $agentsSection;
         }
 
@@ -484,16 +484,28 @@ PROMPT;
      * Build the Available Agents section for the SubAgent tool.
      * Only included when agents exist in the workspace.
      */
-    private function buildAvailableAgentsSection(?Workspace $workspace): ?string
+    private function buildAvailableAgentsSection(?Agent $callerAgent, ?Workspace $workspace): ?string
     {
         if (!$workspace) {
             return null;
         }
 
-        $agents = Agent::where('workspace_id', $workspace->id)
+        if ($callerAgent && !$callerAgent->can_call_subagents) {
+            return null;
+        }
+
+        $query = Agent::where('workspace_id', $workspace->id)
             ->where('enabled', true)
-            ->orderBy('name')
-            ->get(['slug', 'name', 'provider', 'model', 'description']);
+            ->orderBy('name');
+
+        if ($callerAgent) {
+            $allowlist = $callerAgent->allowed_subagents;
+            if (!empty($allowlist)) {
+                $query->whereIn('id', $allowlist);
+            }
+        }
+
+        $agents = $query->get(['slug', 'name', 'provider', 'model', 'description']);
 
         if ($agents->isEmpty()) {
             return null;

--- a/www/app/Services/ToolRegistry.php
+++ b/www/app/Services/ToolRegistry.php
@@ -2,13 +2,16 @@
 
 namespace App\Services;
 
+use App\Models\Agent;
 use App\Models\PocketTool;
 use App\Models\Workspace;
+use App\Tools\AgentTool;
 use App\Tools\ExecutionContext;
 use App\Tools\Tool;
 use App\Tools\ToolResult;
 use App\Tools\UserTool;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 
 /**
  * Registry for available tools.
@@ -17,6 +20,10 @@ use Illuminate\Support\Facades\Log;
  * Built-in tools (from app/Tools) are cached in the singleton.
  * User tools (from database) are always fetched fresh to ensure
  * newly created tools are available without restarting the queue worker.
+ *
+ * Agent tools (agents with expose_as_tool = true) are always fetched fresh
+ * and injected per-caller based on the caller agent's can_call_subagents
+ * and allowed_subagents settings.
  *
  * Tool filtering follows a three-tier hierarchy:
  * 1. Global enablement (PocketTool.enabled) - tool exists and is globally enabled
@@ -63,8 +70,72 @@ class ToolRegistry
     }
 
     /**
+     * Get AgentTools for agents that are opted-in (expose_as_tool = true)
+     * and permitted for the given caller.
+     *
+     * Rules:
+     * - If no caller: inject nothing
+     * - If caller has can_call_subagents = false: inject nothing
+     * - If caller has allowed_subagents (non-null array): inject only those agent IDs
+     * - Otherwise: inject all opted-in agents in the same workspace as the caller
+     *
+     * @return array<string, AgentTool>
+     */
+    private function getAgentTools(?Agent $callerAgent = null): array
+    {
+        $agentTools = [];
+
+        try {
+            // No caller context (e.g. CLI) — do not inject any agent tools
+            if ($callerAgent === null) {
+                return [];
+            }
+
+            // Caller has explicitly disabled sub-agent calling
+            if (! $callerAgent->can_call_subagents) {
+                return [];
+            }
+
+            $query = Agent::query()
+                ->where('enabled', true)
+                ->where('expose_as_tool', true)
+                ->where('workspace_id', $callerAgent->workspace_id)
+                ->where('id', '!=', $callerAgent->id);
+
+            // Apply allowlist if set
+            $allowlist = $callerAgent->allowed_subagents;
+            if (!empty($allowlist)) {
+                $query->whereIn('id', $allowlist);
+            }
+
+            $agents = $query->get();
+
+            foreach ($agents as $agent) {
+                if (! AgentTool::isCompatibleAgentSlug($agent->slug)) {
+                    Log::warning('ToolRegistry: Skipping exposed agent with incompatible tool name', [
+                        'agent_id' => $agent->id,
+                        'agent_slug' => $agent->slug,
+                        'tool_name' => AgentTool::toolNameForSlug($agent->slug),
+                    ]);
+                    continue;
+                }
+
+                $tool = new AgentTool($agent);
+                $agentTools[$tool->name] = $tool;
+            }
+        } catch (\Throwable $e) {
+            Log::debug('ToolRegistry: Could not load agent tools', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $agentTools;
+    }
+
+    /**
      * Get a tool by name.
      * Checks built-in tools first, then user tools.
+     * Does not include agent tools (use execute() which handles agent_* prefix).
      */
     public function get(string $name): ?Tool
     {
@@ -88,6 +159,7 @@ class ToolRegistry
 
     /**
      * Get all registered tools (built-in + fresh user tools).
+     * Does not include agent tools (context-dependent).
      *
      * @return array<string, Tool>
      */
@@ -144,15 +216,20 @@ class ToolRegistry
 
     /**
      * Get tool definitions for the API.
-     * Returns array of tool definition objects.
      *
+     * Merges built-in tools, user tools, and per-caller agent tools.
+     * Agent tools are filtered based on the caller's sub-agent settings.
+     *
+     * @param Agent|null $callerAgent The agent making the request (null = no per-agent filtering)
      * @return array<array{name: string, description: string, input_schema: array}>
      */
-    public function getDefinitions(): array
+    public function getDefinitions(?Agent $callerAgent = null): array
     {
+        $tools = array_merge($this->all(), $this->getAgentTools($callerAgent));
+
         return array_map(
             fn(Tool $tool) => $tool->toDefinition(),
-            array_values($this->all())
+            array_values($tools)
         );
     }
 
@@ -184,9 +261,17 @@ class ToolRegistry
 
     /**
      * Execute a tool by name.
+     *
+     * Handles the agent_* prefix for native per-agent tool calls.
+     * Agent resolution is scoped to the context workspace for security.
      */
     public function execute(string $name, array $input, ExecutionContext $context): ToolResult
     {
+        // Handle native agent tool calls (agent_<slug> prefix)
+        if (Str::startsWith($name, 'agent_')) {
+            return $this->executeAgentTool($name, $input, $context);
+        }
+
         $tool = $this->get($name);
 
         if ($tool === null) {
@@ -197,6 +282,59 @@ class ToolRegistry
             return $tool->execute($input, $context);
         } catch (\Throwable $e) {
             return ToolResult::error("Tool execution failed: {$e->getMessage()}");
+        }
+    }
+
+    /**
+     * Dispatch an agent_* tool call.
+     *
+     * Resolves the target agent by slug, verifies it has expose_as_tool = true,
+     * and checks that the caller's sub-agent settings permit the call.
+     */
+    private function executeAgentTool(string $name, array $input, ExecutionContext $context): ToolResult
+    {
+        $slug = Str::after($name, 'agent_');
+        $workspace = $context->getWorkspace();
+        $callerAgent = $context->getAgent();
+
+        // Security: caller must have sub-agent calling enabled
+        if ($callerAgent !== null && ! $callerAgent->can_call_subagents) {
+            return ToolResult::error("This agent is not permitted to call other agents.");
+        }
+
+        $query = Agent::query()
+            ->where('slug', $slug)
+            ->where('enabled', true)
+            ->where('expose_as_tool', true);
+
+        if ($workspace) {
+            $query->where('workspace_id', $workspace->id);
+        }
+
+        $agent = $query->first();
+
+        if (!$agent) {
+            return ToolResult::error("Agent tool '{$name}' not found or not available. The agent may not exist, be disabled, or not have expose_as_tool enabled.");
+        }
+
+        // Check allowlist
+        if ($callerAgent !== null) {
+            $allowlist = $callerAgent->allowed_subagents;
+            if (!empty($allowlist) && !in_array($agent->id, $allowlist, true)) {
+                return ToolResult::error("Agent '{$agent->name}' is not in this agent's allowed sub-agents list.");
+            }
+
+            // Prevent self-call
+            if ($callerAgent->id === $agent->id) {
+                return ToolResult::error("An agent cannot call itself as a sub-agent.");
+            }
+        }
+
+        try {
+            $agentTool = new AgentTool($agent);
+            return $agentTool->execute($input, $context);
+        } catch (\Throwable $e) {
+            return ToolResult::error("Agent tool execution failed: {$e->getMessage()}");
         }
     }
 

--- a/www/app/Tools/AgentTool.php
+++ b/www/app/Tools/AgentTool.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Agent;
+use App\Services\SubAgentRunner;
+
+/**
+ * A per-agent tool wrapper that exposes a PocketDev agent as a native tool call.
+ *
+ * Only created for agents with expose_as_tool = true. Each instance wraps one
+ * agent and generates a dedicated tool definition named `agent_<slug>`.
+ *
+ * The AI calls it like any other tool — no slug lookup, no generic SubAgent
+ * dispatch. This follows Anthropic's recommended "agents as tools" pattern.
+ */
+class AgentTool extends Tool
+{
+    public const NAME_PREFIX = 'agent_';
+    public const MAX_TOOL_NAME_LENGTH = 64;
+
+    public string $category = 'agents';
+
+    public function __construct(private readonly Agent $agent)
+    {
+        $this->name = self::toolNameForSlug($agent->slug);
+
+        $providerLabel = match ($agent->provider) {
+            'claude_code' => 'Claude Code',
+            'codex'       => 'Codex',
+            'anthropic'   => 'Anthropic',
+            'openai'      => 'OpenAI',
+            default       => ucfirst($agent->provider),
+        };
+
+        $this->description = $agent->description
+            ?? "Delegate to the {$agent->name} agent ({$providerLabel} / {$agent->model}).";
+
+        $this->inputSchema = [
+            'type' => 'object',
+            'properties' => [
+                'prompt' => [
+                    'type' => 'string',
+                    'description' => "Task for {$agent->name}. Be self-contained — the agent has no context from your conversation.",
+                ],
+                'background' => [
+                    'type' => 'boolean',
+                    'description' => 'Run in background and return task_id immediately. Poll with SubAgentOutput. Default: false.',
+                ],
+                'conversation_id' => [
+                    'type' => 'string',
+                    'description' => 'Optional: UUID of a previous conversation with this agent to resume. When provided, prompt is appended as the next user message.',
+                ],
+            ],
+            'required' => ['prompt'],
+        ];
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $prompt = trim($input['prompt'] ?? '');
+        $isBackground = (bool) ($input['background'] ?? false);
+        $conversationId = isset($input['conversation_id']) ? trim($input['conversation_id']) : null;
+
+        if (empty($prompt)) {
+            return ToolResult::error('prompt is required');
+        }
+
+        return app(SubAgentRunner::class)->run(
+            $this->agent,
+            $prompt,
+            $isBackground,
+            $context,
+            $conversationId ?: null,
+        );
+    }
+
+    /**
+     * Get the underlying agent model.
+     */
+    public function getAgent(): Agent
+    {
+        return $this->agent;
+    }
+
+    public static function toolNameForSlug(string $slug): string
+    {
+        return self::NAME_PREFIX . $slug;
+    }
+
+    public static function isCompatibleAgentSlug(string $slug): bool
+    {
+        return self::isCompatibleToolName(self::toolNameForSlug($slug));
+    }
+
+    public static function isCompatibleToolName(string $name): bool
+    {
+        if (strlen($name) > self::MAX_TOOL_NAME_LENGTH) {
+            return false;
+        }
+
+        return preg_match('/^[a-zA-Z0-9_-]{1,64}$/', $name) === 1;
+    }
+}

--- a/www/app/Tools/SubAgentCancelTool.php
+++ b/www/app/Tools/SubAgentCancelTool.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Conversation;
+use App\Models\SubAgentTask;
+use App\Services\StreamManager;
+
+class SubAgentCancelTool extends Tool
+{
+    public string $name = 'SubAgentCancel';
+
+    public string $description = 'Cancel a running background sub-agent task.';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'task_id' => [
+                'type' => 'string',
+                'description' => 'The task UUID returned by SubAgent when launched with background=true.',
+            ],
+        ],
+        'required' => ['task_id'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Cancel a running background sub-agent task by its task ID.
+
+## When to Use
+- After launching a sub-agent with background=true and deciding to stop it
+- When a background task is no longer needed
+
+## How It Works
+Sets an abort flag on the child conversation. The running sub-agent detects the flag
+within ~1 second on its next event-loop tick and shuts down cleanly.
+Cancellation is non-blocking — this tool returns immediately.
+
+## Notes
+- Only tasks you spawned (from this conversation) can be cancelled
+- If the task has already completed or failed, cancellation is a no-op
+- After cancellation the task status becomes "failed" (same as a user-initiated stop)
+
+## Parameters
+- task_id: The UUID returned by SubAgent when background=true
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+pd subagent:cancel --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:cancel';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $taskId = trim($input['task_id'] ?? '');
+
+        if (empty($taskId)) {
+            return ToolResult::error('task_id is required');
+        }
+
+        $task = SubAgentTask::with('childConversation')->find($taskId);
+
+        if (!$task) {
+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
+        }
+
+        // Guard: only allow cancellation of tasks spawned by this conversation.
+        // Prevents one conversation from aborting another conversation's subagents.
+        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
+            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
+        }
+
+        $conversation = $task->childConversation;
+
+        if (!$conversation) {
+            return ToolResult::error("Sub-agent task '{$taskId}' has no associated conversation.");
+        }
+
+        // If already terminal, nothing to cancel
+        $terminalStatuses = [
+            Conversation::STATUS_IDLE,
+            Conversation::STATUS_ARCHIVED,
+            Conversation::STATUS_FAILED,
+        ];
+
+        if (in_array($conversation->status, $terminalStatuses, true)) {
+            $status = $task->getStatus();
+            return ToolResult::success(json_encode([
+                'task_id'   => $task->id,
+                'cancelled' => false,
+                'status'    => $status,
+                'message'   => "Task is already {$status} — nothing to cancel.",
+            ], JSON_PRETTY_PRINT));
+        }
+
+        // Set the abort flag on the child conversation's stream.
+        // ProcessConversationStream checks this flag in its event loop and will
+        // shut down the child cleanly within ~1 second.
+        $streamManager = app(StreamManager::class);
+        $streamManager->setAbortFlag($conversation->uuid);
+
+        return ToolResult::success(json_encode([
+            'task_id'   => $task->id,
+            'cancelled' => true,
+            'status'    => 'cancelling',
+            'message'   => "Abort signal sent to sub-agent task '{$task->id}'. "
+                . 'The task will stop within ~1 second. '
+                . "Use SubAgentOutput with task_id '{$task->id}' to confirm.",
+        ], JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentOutputTool.php
+++ b/www/app/Tools/SubAgentOutputTool.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\SubAgentTask;
+
+class SubAgentOutputTool extends Tool
+{
+    public string $name = 'SubAgentOutput';
+
+    public string $description = 'Retrieve the status and output of a sub-agent task.';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'task_id' => [
+                'type' => 'string',
+                'description' => 'The task UUID returned by SubAgent when using background mode.',
+            ],
+        ],
+        'required' => ['task_id'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Retrieve the status and output of a background sub-agent task.
+
+## When to Use
+- After launching a sub-agent with background=true
+- To poll for completion of a running sub-agent
+- To retrieve the final output once a sub-agent completes
+
+## Status Values
+- **running**: Sub-agent is still processing
+- **completed**: Sub-agent finished, output is included in the response
+- **failed**: Sub-agent encountered an error, error details are included
+- **pending**: Sub-agent has not started yet (rare, transient state)
+
+## Polling Pattern
+For background tasks, poll periodically until status is "completed" or "failed":
+1. Launch sub-agent with background=true, get task_id
+2. Do other work
+3. Check status with SubAgentOutput
+4. If still "running", wait and check again
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+pd subagent:output --task-id=a1b2c3d4-e5f6-7890-abcd-ef1234567890
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "task_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:output';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $taskId = trim($input['task_id'] ?? '');
+
+        if (empty($taskId)) {
+            return ToolResult::error('task_id is required');
+        }
+
+        $task = SubAgentTask::with('childConversation')->find($taskId);
+
+        if (!$task) {
+            return ToolResult::error("Sub-agent task '{$taskId}' not found.");
+        }
+
+        $status = $task->getStatus();
+
+        $result = [
+            'task_id' => $task->id,
+            'status' => $status,
+            'agent_id' => $task->agent_id,
+            'is_background' => $task->is_background,
+            'created_at' => $task->created_at?->toIso8601String(),
+        ];
+
+        if ($status === 'completed') {
+            $result['output'] = $task->collectOutput();
+        } elseif ($status === 'failed') {
+            $result['error'] = $task->getError();
+        } elseif ($status === 'running') {
+            $result['message'] = 'Sub-agent is still processing. Check again later.';
+        }
+
+        return ToolResult::success(json_encode($result, JSON_PRETTY_PRINT));
+    }
+}

--- a/www/app/Tools/SubAgentOutputTool.php
+++ b/www/app/Tools/SubAgentOutputTool.php
@@ -82,6 +82,14 @@ API;
             return ToolResult::error("Sub-agent task '{$taskId}' not found.");
         }
 
+        if (!$context->conversationUuid) {
+            return ToolResult::error('Cannot verify task ownership without a conversation context.');
+        }
+
+        if ($task->parent_conversation_uuid !== $context->conversationUuid) {
+            return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
+        }
+
         $status = $task->getStatus();
 
         $result = [

--- a/www/app/Tools/SubAgentOutputTool.php
+++ b/www/app/Tools/SubAgentOutputTool.php
@@ -82,11 +82,9 @@ API;
             return ToolResult::error("Sub-agent task '{$taskId}' not found.");
         }
 
-        if (!$context->conversationUuid) {
-            return ToolResult::error('Cannot verify task ownership without a conversation context.');
-        }
-
-        if ($task->parent_conversation_uuid !== $context->conversationUuid) {
+        // When called from within a conversation/tool context, enforce ownership.
+        // Standalone CLI usage has no parent conversation UUID, so it is allowed.
+        if ($context->conversationUuid && $task->parent_conversation_uuid !== $context->conversationUuid) {
             return ToolResult::error("Task '{$taskId}' was not spawned by this conversation.");
         }
 

--- a/www/app/Tools/SubAgentTool.php
+++ b/www/app/Tools/SubAgentTool.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\Agent;
+use App\Services\SubAgentRunner;
+use Illuminate\Support\Str;
+
+class SubAgentTool extends Tool
+{
+    public string $name = 'SubAgent';
+
+    public string $description = 'Spawn a child PocketDev agent to handle a task. Supports cross-provider delegation (e.g. Claude Code can call Codex and vice versa).';
+
+    public string $category = 'custom';
+
+    public array $inputSchema = [
+        'type' => 'object',
+        'properties' => [
+            'agent' => [
+                'type' => 'string',
+                'description' => 'Agent slug or UUID. See "Available Agents" in the system prompt for valid values.',
+            ],
+            'prompt' => [
+                'type' => 'string',
+                'description' => 'The task/prompt to send to the sub-agent.',
+            ],
+            'background' => [
+                'type' => 'boolean',
+                'description' => 'If true, return immediately with a task_id. If false (default), wait for the sub-agent to complete and return its output.',
+            ],
+            'conversation_id' => [
+                'type' => 'string',
+                'description' => 'Optional: UUID of a previous conversation with this agent to resume. When provided, prompt is appended as the next user message.',
+            ],
+        ],
+        'required' => ['agent', 'prompt'],
+    ];
+
+    public ?string $instructions = <<<'INSTRUCTIONS'
+Spawn a child PocketDev agent to handle a task using any configured provider. This enables cross-provider delegation: Claude Code can call a Codex agent, Codex can call a Claude Code agent, etc.
+
+## When to Use
+- Delegate specialized tasks to a different AI model or provider
+- Run multiple tasks in parallel using background mode
+- Break complex work into sub-tasks handled by purpose-built agents
+- For agents with `expose_as_tool = true`, prefer calling them directly by name (e.g. `agent_code_reviewer`) instead of using SubAgent
+
+## Foreground Mode (default)
+Blocks until the sub-agent completes and returns its full output. Use for tasks where you need the result before continuing.
+
+## Background Mode
+Returns immediately with a task_id. Use SubAgentOutput to check status and retrieve results later. Ideal for parallelism.
+
+## Resuming a Conversation
+Pass `conversation_id` from a previous response to continue from where you left off. The sub-agent will see the full conversation history.
+
+## Parameters
+- agent: Agent slug or UUID (see "Available Agents" section in this prompt)
+- prompt: The task/prompt to send. Be specific and self-contained — the sub-agent has no context from your conversation
+- background: Optional boolean (default: false). Set to true for background execution
+- conversation_id: Optional UUID to resume an existing sub-agent conversation
+
+## Important Notes
+- The sub-agent starts a fresh conversation (unless conversation_id is provided)
+- Write self-contained prompts with all necessary context
+- The sub-agent shares your working directory and workspace
+- Foreground mode has a 10-minute timeout
+- For background tasks, use SubAgentOutput to poll for completion
+- To stop a running background task, use SubAgentCancel with its task_id
+INSTRUCTIONS;
+
+    public ?string $cliExamples = <<<'CLI'
+## CLI Example
+
+```bash
+# Foreground: wait for result
+pd subagent:run --agent=codex-default --prompt="List all TODO comments in the codebase"
+
+# Background: get task ID immediately
+pd subagent:run --agent=claude-code-default --prompt="Refactor the auth module" --background
+
+# Then check output later
+pd subagent:output --task-id=<uuid-from-above>
+```
+CLI;
+
+    public ?string $apiExamples = <<<'API'
+## API Example (JSON input)
+
+```json
+{
+  "agent": "codex-default",
+  "prompt": "Find and fix all TypeScript type errors",
+  "background": true
+}
+```
+API;
+
+    public function getArtisanCommand(): ?string
+    {
+        return 'subagent:run';
+    }
+
+    public function execute(array $input, ExecutionContext $context): ToolResult
+    {
+        $agentIdentifier = trim($input['agent'] ?? '');
+        $prompt = trim($input['prompt'] ?? '');
+        $isBackground = (bool) ($input['background'] ?? false);
+        $conversationId = isset($input['conversation_id']) ? trim($input['conversation_id']) : null;
+
+        if (empty($agentIdentifier)) {
+            return ToolResult::error('agent is required. See "Available Agents" in the system prompt.');
+        }
+        if (empty($prompt)) {
+            return ToolResult::error('prompt is required');
+        }
+
+        // Scope agent resolution to the caller's workspace
+        $workspace = $context->getWorkspace();
+        $agentQuery = Agent::query()->where('enabled', true);
+        if ($workspace) {
+            $agentQuery->where('workspace_id', $workspace->id);
+        }
+
+        $agent = (clone $agentQuery)->where('slug', $agentIdentifier)->first();
+        if (!$agent && Str::isUuid($agentIdentifier)) {
+            $agent = (clone $agentQuery)->whereKey($agentIdentifier)->first();
+        }
+
+        if (!$agent) {
+            return ToolResult::error("Agent '{$agentIdentifier}' not found. Use an agent slug or UUID from the Available Agents list.");
+        }
+
+        return app(SubAgentRunner::class)->run(
+            $agent,
+            $prompt,
+            $isBackground,
+            $context,
+            $conversationId ?: null,
+        );
+    }
+}

--- a/www/app/Tools/ToolResult.php
+++ b/www/app/Tools/ToolResult.php
@@ -4,6 +4,21 @@ namespace App\Tools;
 
 class ToolResult
 {
+    /**
+     * When true, the stream loop should end the parent turn immediately after
+     * this tool result is saved — without making another AI round-trip.
+     * Used by SubAgentTool in background mode so the parent conversation
+     * becomes interactive again as soon as the child job is dispatched.
+     */
+    public bool $endTurn = false;
+
+    /**
+     * Human-readable text saved as a synthetic closing assistant message
+     * when $endTurn is true. Keeps the conversation history well-formed
+     * (prevents two consecutive user messages on the next turn).
+     */
+    public ?string $endTurnMessage = null;
+
     public function __construct(
         public string $output,
         public bool $isError = false,
@@ -12,6 +27,21 @@ class ToolResult
     public static function success(string $output): self
     {
         return new self($output, false);
+    }
+
+    /**
+     * Like success(), but signals the stream loop to end the parent turn
+     * immediately without a second AI call.
+     *
+     * @param string $output       JSON output returned as the tool result content
+     * @param string $endTurnMessage  Text for the synthetic closing assistant message
+     */
+    public static function successEndTurn(string $output, string $endTurnMessage): self
+    {
+        $result = new self($output, false);
+        $result->endTurn = true;
+        $result->endTurnMessage = $endTurnMessage;
+        return $result;
     }
 
     public static function error(string $message): self

--- a/www/app/Tools/ToolResult.php
+++ b/www/app/Tools/ToolResult.php
@@ -64,6 +64,8 @@ class ToolResult
         return [
             'output' => $this->output,
             'is_error' => $this->isError,
+            'end_turn' => $this->endTurn,
+            'end_turn_message' => $this->endTurnMessage,
         ];
     }
 }

--- a/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
+++ b/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subagent_tasks', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+
+            // Links to the parent conversation that spawned this
+            $table->string('parent_conversation_uuid', 36)->nullable()->index();
+
+            // Links to the child conversation running the task
+            $table->string('child_conversation_uuid', 36)->index();
+
+            // Which agent was used
+            $table->uuid('agent_id')->index();
+
+            // The prompt that was sent
+            $table->text('prompt');
+
+            // Whether this is a background task
+            $table->boolean('is_background')->default(false);
+
+            $table->timestamps();
+
+            $table->foreign('child_conversation_uuid')
+                ->references('uuid')
+                ->on('conversations')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subagent_tasks');
+    }
+};

--- a/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
+++ b/www/database/migrations/2026_03_13_000001_create_subagent_tasks_table.php
@@ -32,6 +32,16 @@ return new class extends Migration
                 ->references('uuid')
                 ->on('conversations')
                 ->cascadeOnDelete();
+
+            $table->foreign('parent_conversation_uuid')
+                ->references('uuid')
+                ->on('conversations')
+                ->nullOnDelete();
+
+            $table->foreign('agent_id')
+                ->references('id')
+                ->on('agents')
+                ->cascadeOnDelete();
         });
     }
 

--- a/www/database/migrations/2026_04_10_000001_add_expose_as_tool_to_agents.php
+++ b/www/database/migrations/2026_04_10_000001_add_expose_as_tool_to_agents.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            // Opt-in: expose this agent as a dedicated native tool call
+            $table->boolean('expose_as_tool')->default(false)->after('enabled');
+
+            // Caller-side: can this agent call other agents as sub-agents?
+            $table->boolean('can_call_subagents')->default(true)->after('expose_as_tool');
+
+            // Caller-side allowlist: if set, only these agent UUIDs are injected as tools
+            // null = all opted-in agents; [] = (not used — toggle off can_call_subagents instead)
+            $table->jsonb('allowed_subagents')->nullable()->after('can_call_subagents');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropColumn(['expose_as_tool', 'can_call_subagents', 'allowed_subagents']);
+        });
+    }
+};

--- a/www/resources/views/config/agents/form.blade.php
+++ b/www/resources/views/config/agents/form.blade.php
@@ -233,6 +233,80 @@
                         </span>
                     </label>
                 </div>
+
+                <!-- Sub-agent Settings -->
+                <div
+                    x-data="{
+                        exposeAsTool: {{ old('expose_as_tool', ($agent->expose_as_tool ?? ($sourceAgent->expose_as_tool ?? false)) ? 'true' : 'false') }},
+                        canCallSubagents: {{ old('can_call_subagents', ($agent->can_call_subagents ?? ($sourceAgent->can_call_subagents ?? true)) ? 'true' : 'false') }},
+                        allowedSubagents: @js(old('allowed_subagents', $agent->allowed_subagents ?? [])),
+                    }"
+                    class="space-y-4 pt-2 border-t border-gray-700/50"
+                >
+                    <h4 class="text-sm font-semibold text-gray-300">Sub-agent Settings</h4>
+
+                    <!-- Expose as tool -->
+                    <label class="flex items-start gap-3 cursor-pointer group">
+                        <input
+                            type="checkbox"
+                            name="expose_as_tool"
+                            value="1"
+                            :checked="exposeAsTool"
+                            @change="exposeAsTool = $event.target.checked"
+                            class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                        >
+                        <div>
+                            <span class="text-sm text-white group-hover:text-blue-300">Expose as native tool</span>
+                            <p class="text-xs text-gray-400 mt-0.5">
+                                Adds this agent as a dedicated tool call (e.g. <code class="text-blue-400">agent_{{ Illuminate\Support\Str::slug($agent->name ?? 'my-agent') }}</code>) for other agents. Only enable for agents designed to be called as sub-agents.
+                            </p>
+                        </div>
+                    </label>
+
+                    <!-- Can call subagents -->
+                    <label class="flex items-start gap-3 cursor-pointer group">
+                        <input type="hidden" name="can_call_subagents" value="0">
+                        <input
+                            type="checkbox"
+                            name="can_call_subagents"
+                            value="1"
+                            :checked="canCallSubagents"
+                            @change="canCallSubagents = $event.target.checked"
+                            class="mt-0.5 w-4 h-4 rounded border-gray-700 bg-gray-800 text-blue-500 focus:ring-blue-500"
+                        >
+                        <div>
+                            <span class="text-sm text-white group-hover:text-blue-300">Can call other agents</span>
+                            <p class="text-xs text-gray-400 mt-0.5">
+                                Allow this agent to spawn sub-agents via SubAgent tool or native agent tool calls. Disable to prevent any outbound sub-agent calls.
+                            </p>
+                        </div>
+                    </label>
+
+                    <!-- Allowed subagents allowlist -->
+                    @php $exposedAgents = $exposedAgents ?? collect(); @endphp
+                    <div x-show="canCallSubagents && {{ $exposedAgents->isNotEmpty() ? 'true' : 'false' }}" x-cloak class="ml-7">
+                        <label class="block text-xs font-medium text-gray-400 mb-2">
+                            Limit to specific agents
+                            <span class="text-gray-500 font-normal">(leave empty to allow all)</span>
+                        </label>
+                        <div class="flex flex-wrap gap-2">
+                            @foreach ($exposedAgents as $exposedAgent)
+                                <label class="flex items-center gap-1.5 px-2 py-1 bg-gray-800 border border-gray-700 rounded cursor-pointer hover:border-gray-600 text-xs">
+                                    <input
+                                        type="checkbox"
+                                        name="allowed_subagents[]"
+                                        value="{{ $exposedAgent->id }}"
+                                        {{ in_array($exposedAgent->id, old('allowed_subagents', $agent->allowed_subagents ?? [])) ? 'checked' : '' }}
+                                        class="w-3.5 h-3.5 rounded border-gray-600 bg-gray-700 text-blue-500 focus:ring-blue-500"
+                                    >
+                                    <span class="text-gray-300">{{ $exposedAgent->name }}</span>
+                                    <span class="text-gray-500 font-mono">{{ $exposedAgent->slug }}</span>
+                                </label>
+                            @endforeach
+                        </div>
+                        <p class="text-xs text-gray-500 mt-1">Only agents with "Expose as native tool" enabled are listed here.</p>
+                    </div>
+                </div>
             </div>
 
             <!-- Right Column: Reasoning Settings -->


### PR DESCRIPTION
## Summary

This PR rebuilds the native subagent + agents-as-tools work as a **clean branch directly on `main`**.

It combines:
- native cross-provider subagents
- `agent_<slug>` native tool calls via `expose_as_tool`
- caller-side access control via `can_call_subagents` and `allowed_subagents`
- resumable subagent conversations
- background dispatch end-turn + cancel support
- follow-up fixes for the review issues raised on the earlier stacked PR

## Branch / dependency status

This PR is based directly on `main`.

Historical context:
- `#248` proposed the native subagent groundwork, but it was closed unmerged.
- `#291` was stacked on top of the `#248` branch, which made it unsuitable for merge as-is.
- This PR replaces that stacked structure with a clean `main`-based branch.
- The Codex auth work from `#293` is intentionally **not included** here.

Functional dependency note:
- Core subagent behavior in this PR has been validated for `codex` and `sonnet`.
- `cursor` subagent behavior depends on `#331` (`feat: add Cursor Agent as CLI provider`). In local dogfood testing, Cursor subagent output worked correctly once `#331` was merged into this branch.

## Replaces / supersedes

- Supersedes `#291`
- Re-incorporates the required unmerged groundwork that previously lived in `#248`

## What changed

### Native subagents
- Adds `SubAgent`, `SubAgentOutput`, and `SubAgentCancel`
- Adds `pd subagent:run`, `pd subagent:output`, and `pd subagent:cancel`
- Adds `subagent_tasks` persistence and live status/output collection
- Supports foreground and background subagent execution

### Agents as native tool calls
- Adds `expose_as_tool`, `can_call_subagents`, and `allowed_subagents` to agents
- Exposes opted-in agents as dedicated `agent_<slug>` tool calls
- Adds `AgentTool` and `SubAgentRunner`
- Filters injected agent tools by caller workspace and allowlist

### CLI provider orchestration
- Injects explicit orchestration guidance for Claude Code / Codex system prompts
- Lists exposed agents with the exact `pd subagent:run` command to use
- Preserves the strict prohibition on falling back to native Task/subagent mechanisms

### Review fixes included
- Fixes the `ToolRegistry::getAgentTools()` docblock mismatch
- Fixes `can_call_subagents` default handling in the config form/controller
- Tightens `allowed_subagents` validation to same-workspace, enabled, exposed agents
- Guards against invalid or overlong `agent_<slug>` tool names
- Fixes `SubAgentRunner::resume()` background end-turn inconsistency
- Fixes the resume race by marking conversations processing before dispatch
- Fixes early end-turn behavior so mixed tool batches still recurse unless all tools request end-turn
- Fixes task output ownership checks and agent/conversation binding on resume
- Fixes standalone CLI output/cancel flows after the ownership hardening

## Review status

- All actionable CodeRabbit review comments on this PR have been addressed.
- The remaining known follow-up is the functional Cursor dependency on `#331`, described above.

## Validation

- `php -l` passed on all touched PHP files
- `git diff --check` passed
- Laravel booted successfully from the clean worktree
- Local dogfood validation passed for `codex` and `sonnet` subagents
- Local dogfood validation showed `cursor` subagents working after merging `#331` into the same branch

## Notes

This PR is intentionally scoped to the subagent / agents-as-tools feature set.
It does **not** include the separate Codex authentication / device-auth work.
